### PR TITLE
Add HTTP metrics middleware and Prometheus metrics for request counts and durations

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -1,10 +1,102 @@
-"""Prometheus metrics endpoint for the FastAPI app."""
+"""Prometheus metrics for HTTP traffic and metrics endpoint."""
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+import time
+
+from fastapi import FastAPI, Request
 from fastapi.responses import Response
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+HTTP_REQUESTS_TOTAL = Counter(
+    "property_shared_http_requests_total",
+    "Total HTTP requests handled by property-shared.",
+    labelnames=("surface", "route", "method", "status", "status_class"),
+)
+
+HTTP_REQUEST_DURATION_SECONDS = Histogram(
+    "property_shared_http_request_duration_seconds",
+    "HTTP request duration in seconds for property-shared.",
+    labelnames=("surface", "route", "method", "status_class"),
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+)
+
+
+def _surface(path: str) -> str:
+    if path in {"/metrics", "/health", "/v1/health"}:
+        return "infra"
+    if path == "/mcp" or path.startswith("/mcp/"):
+        return "mcp_proxy"
+    if path.startswith("/v1/"):
+        return "api"
+    return "web"
+
+
+def _route_label(request: Request, surface: str) -> str:
+    route = request.scope.get("route")
+    route_path = getattr(route, "path", None)
+    if isinstance(route_path, str) and route_path:
+        return route_path
+
+    if surface == "mcp_proxy":
+        return "/mcp"
+    if surface == "api":
+        return "/v1/<unmatched>"
+    if surface == "infra":
+        return "/infra"
+    return "/web"
+
+
+class HTTPMetricsMiddleware:
+    """ASGI middleware that records low-cardinality HTTP metrics."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if path == "/metrics":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive=receive)
+        surface = _surface(path)
+        method = scope.get("method", "GET")
+        route = _route_label(request, surface)
+
+        start = time.perf_counter()
+        status_code = 500
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code
+            if message.get("type") == "http.response.start":
+                status_code = int(message.get("status", 500))
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            elapsed = time.perf_counter() - start
+            status = str(status_code)
+            status_class = f"{status_code // 100}xx"
+            HTTP_REQUESTS_TOTAL.labels(
+                surface=surface,
+                route=route,
+                method=method,
+                status=status,
+                status_class=status_class,
+            ).inc()
+            HTTP_REQUEST_DURATION_SECONDS.labels(
+                surface=surface,
+                route=route,
+                method=method,
+                status_class=status_class,
+            ).observe(elapsed)
 
 
 def setup_metrics(app: FastAPI) -> None:

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -64,10 +64,8 @@ class HTTPMetricsMiddleware:
             await self.app(scope, receive, send)
             return
 
-        request = Request(scope, receive=receive)
         surface = _surface(path)
         method = scope.get("method", "GET")
-        route = _route_label(request, surface)
 
         start = time.perf_counter()
         status_code = 500
@@ -84,6 +82,10 @@ class HTTPMetricsMiddleware:
             elapsed = time.perf_counter() - start
             status = str(status_code)
             status_class = f"{status_code // 100}xx"
+
+            request = Request(scope)
+            route = _route_label(request, surface)
+
             HTTP_REQUESTS_TOTAL.labels(
                 surface=surface,
                 route=route,

--- a/app/main.py
+++ b/app/main.py
@@ -104,10 +104,11 @@ def create_app() -> FastAPI:
             "maintainers": [{"email": "paul@bouch.dev"}],
         }
 
-    from app.core.metrics import setup_metrics
+    from app.core.metrics import HTTPMetricsMiddleware, setup_metrics
     setup_metrics(app)
 
     app.add_middleware(MCPMiddleware, mcp_handler=_mcp_proxy)
+    app.add_middleware(HTTPMetricsMiddleware)
 
     return app
 

--- a/tests/test_http_metrics.py
+++ b/tests/test_http_metrics.py
@@ -82,3 +82,23 @@ def test_metrics_scrapes_are_not_counted_as_app_traffic():
     metrics_text = client.get("/metrics").text
 
     assert 'route="/metrics"' not in metrics_text
+
+
+def test_metrics_use_fastapi_route_template_for_real_request():
+    app = FastAPI()
+
+    @app.get("/v1/report/{postcode}")
+    async def report(postcode: str):
+        return {"postcode": postcode}
+
+    setup_metrics(app)
+    app.add_middleware(HTTPMetricsMiddleware)
+
+    client = TestClient(app)
+    client.get("/v1/report/SW1A-1AA?secret=not-a-label")
+
+    metrics_text = client.get("/metrics").text
+
+    assert 'route="/v1/report/{postcode}"' in metrics_text
+    assert "SW1A-1AA" not in metrics_text
+    assert "secret=not-a-label" not in metrics_text

--- a/tests/test_http_metrics.py
+++ b/tests/test_http_metrics.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from app.core.metrics import HTTPMetricsMiddleware, _route_label, _surface, setup_metrics
+
+
+def _make_request(path: str, query_string: bytes = b"", route_path: str | None = None) -> Request:
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "query_string": query_string,
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+    if route_path is not None:
+        class _Route:
+            path = route_path
+
+        scope["route"] = _Route()
+    return Request(scope)
+
+
+def test_surface_classification():
+    assert _surface("/v1/health") == "infra"
+    assert _surface("/v1/report") == "api"
+    assert _surface("/mcp") == "mcp_proxy"
+    assert _surface("/mcp/messages") == "mcp_proxy"
+    assert _surface("/metrics") == "infra"
+    assert _surface("/") == "web"
+
+
+def test_route_label_uses_template_and_not_querystring():
+    request = _make_request("/v1/report/AB12", query_string=b"postcode=SW1A+1AA", route_path="/v1/report/{uprn}")
+    assert _route_label(request, "api") == "/v1/report/{uprn}"
+
+
+def test_route_label_fallbacks_are_low_cardinality():
+    assert _route_label(_make_request("/v1/report/AB12"), "api") == "/v1/<unmatched>"
+    assert _route_label(_make_request("/mcp/session/abc123"), "mcp_proxy") == "/mcp"
+    assert _route_label(_make_request("/metrics"), "infra") == "/infra"
+    assert _route_label(_make_request("/demo/random/xyz"), "web") == "/web"
+
+
+def test_metrics_endpoint_returns_prometheus_text_and_metric_families():
+    app = FastAPI()
+
+    @app.get("/v1/health")
+    async def health():
+        return {"ok": True}
+
+    setup_metrics(app)
+    app.add_middleware(HTTPMetricsMiddleware)
+    client = TestClient(app)
+
+    client.get("/v1/health")
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    assert "text/plain" in response.headers["content-type"]
+    assert "property_shared_http_requests_total" in response.text
+    assert "property_shared_http_request_duration_seconds_bucket" in response.text
+
+
+def test_metrics_scrapes_are_not_counted_as_app_traffic():
+    app = FastAPI()
+
+    @app.get("/")
+    async def home():
+        return {"ok": True}
+
+    setup_metrics(app)
+    app.add_middleware(HTTPMetricsMiddleware)
+    client = TestClient(app)
+
+    client.get("/")
+    metrics_text = client.get("/metrics").text
+
+    assert 'route="/metrics"' not in metrics_text


### PR DESCRIPTION
### Motivation
- Provide low-cardinality Prometheus metrics for HTTP traffic including request counts and latencies.
- Avoid counting scraper traffic and reduce cardinality by classifying surfaces and normalizing route labels.

### Description
- Add `HTTPMetricsMiddleware` that records request totals and duration histograms using `Counter` and `Histogram` in `app/core/metrics.py`.
- Implement `_surface` and `_route_label` helpers to classify requests into `infra`, `api`, `mcp_proxy`, and `web` surfaces and to select low-cardinality route labels.
- Expose `/metrics` via `setup_metrics` which returns `generate_latest()` with `CONTENT_TYPE_LATEST` and skip metric collection for `/metrics` requests.
- Register the middleware in `create_app()` in `app/main.py` by importing and adding `HTTPMetricsMiddleware` alongside existing setup.
- Add unit tests in `tests/test_http_metrics.py` that verify surface classification, route-label behavior, middleware metrics emission, and that `/metrics` scrapes are not counted.

### Testing
- Ran the new unit tests with `pytest tests/test_http_metrics.py` and they passed.
- Verified the `/metrics` endpoint returns Prometheus text and contains the new metric families `property_shared_http_requests_total` and `property_shared_http_request_duration_seconds`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa911f81608326ac478c94989cdb51)