### PR TITLE
feat: plain MCP server at /mcp, fix Rightmove scraping

### DIFF
--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -1,0 +1,26 @@
+"""Shared ASGI middleware for property-shared HTTP apps."""
+from __future__ import annotations
+
+
+class _AcceptNormalizer:
+    """Stamp Accept to the MCP-spec value on /mcp only, so json_response=True never 406s.
+
+    Anthropic sends mixed Accept headers per request type (application/json for
+    initialize, text/event-stream for tools/list). Only stamp the MCP endpoint —
+    leave /health and other routes with their original Accept headers.
+    """
+
+    def __init__(self, app, mcp_path: bytes = b"/mcp"):
+        self.app = app
+        self._mcp_path = mcp_path.rstrip(b"/")
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") == "http" and scope.get("path", "").rstrip("/").encode() == self._mcp_path:
+            headers = [
+                (b"accept", b"application/json, text/event-stream")
+                if name.lower() == b"accept"
+                else (name, value)
+                for name, value in scope.get("headers", [])
+            ]
+            scope = {**scope, "headers": headers}
+        await self.app(scope, receive, send)

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
+from importlib.metadata import version as _pkg_version
 from typing import Any
 
-import httpx
 from fastapi import FastAPI
 from starlette.types import ASGIApp, Receive, Scope, Send
 import uvicorn
@@ -10,58 +10,18 @@ from app.api.routes import api_router
 from app.core.config import get_settings
 from app.core.logging import configure_logging
 from app.web.routes import router as demo_router
+from app.core.middleware import _AcceptNormalizer
+from app.mcp.server import build_asgi_app
 
 
-# ---------------------------------------------------------------------------
-# MCP proxy — forward /mcp to the canonical MCP server at propertydata.fly.dev
-#
 # Can't use app.mount("/mcp") — Starlette always 307-redirects /mcp → /mcp/
 # and neither Claude.ai nor ChatGPT follow 307 for POST requests.
 # Middleware routes /mcp directly without redirect.
-# ---------------------------------------------------------------------------
-_MCP_UPSTREAM = "https://uk-property-mcp.fly.dev"
-_HOP_BY_HOP = frozenset([
-    b"host", b"transfer-encoding", b"connection", b"keep-alive",
-    b"proxy-authenticate", b"proxy-authorization", b"te", b"trailers", b"upgrade",
-])
-
-
-async def _mcp_proxy(scope: Scope, receive: Receive, send: Send) -> None:
-    """Proxy /mcp requests to the canonical MCP server at propertydata.fly.dev."""
-    path = scope["path"]
-    query = scope.get("query_string", b"").decode()
-    url = _MCP_UPSTREAM + path
-    if query:
-        url += f"?{query}"
-
-    body = b""
-    while True:
-        message = await receive()
-        body += message.get("body", b"")
-        if not message.get("more_body", False):
-            break
-
-    headers = {k: v for k, v in scope.get("headers", []) if k.lower() not in _HOP_BY_HOP}
-
-    async with httpx.AsyncClient() as client:
-        async with client.stream(
-            scope["method"], url, content=body, headers=headers, timeout=60.0
-        ) as response:
-            await send({
-                "type": "http.response.start",
-                "status": response.status_code,
-                "headers": [
-                    (k, v) for k, v in response.headers.raw
-                    if k.lower() not in {b"transfer-encoding"}
-                ],
-            })
-            async for chunk in response.aiter_bytes():
-                await send({"type": "http.response.body", "body": chunk, "more_body": True})
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
+_local_mcp_app = _AcceptNormalizer(build_asgi_app())
 
 
 class MCPMiddleware:
-    """Route /mcp requests to the MCP proxy without Starlette mount redirect."""
+    """Route /mcp requests to the local FastMCP app without Starlette mount redirect."""
 
     def __init__(self, app: ASGIApp, mcp_handler: Any) -> None:
         self.app = app
@@ -91,11 +51,15 @@ def create_app() -> FastAPI:
     settings = get_settings()
     app = FastAPI(
         title=settings.app_name,
-        version="1.4.0",
+        version=_pkg_version("property-shared"),
         lifespan=app_lifespan,
     )
     app.include_router(api_router)
     app.include_router(demo_router)
+
+    @app.get("/health", include_in_schema=False)
+    async def health():
+        return {"status": "ok"}
 
     @app.get("/.well-known/glama.json", include_in_schema=False)
     async def glama_connector_manifest():
@@ -104,10 +68,14 @@ def create_app() -> FastAPI:
             "maintainers": [{"email": "paul@bouch.dev"}],
         }
 
+    @app.get("/.well-known/mcp/server-card.json", include_in_schema=False)
+    async def server_card():
+        return {"serverInfo": {"name": "property-data", "version": _pkg_version("property-shared")}}
+
     from app.core.metrics import HTTPMetricsMiddleware, setup_metrics
     setup_metrics(app)
 
-    app.add_middleware(MCPMiddleware, mcp_handler=_mcp_proxy)
+    app.add_middleware(MCPMiddleware, mcp_handler=_local_mcp_app)
     app.add_middleware(HTTPMetricsMiddleware)
 
     return app

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -1,0 +1,189 @@
+"""Plain FastMCP server — property tools, no Prefab UI.
+
+Exposes property_core functions as MCP tools. Suitable for any MCP client
+regardless of ext-apps / Prefab UI support.
+"""
+from __future__ import annotations
+
+from fastmcp import FastMCP
+from fastmcp.server.http import create_streamable_http_app
+
+mcp = FastMCP(
+    "property-data",
+    instructions=(
+        "UK property data tools. Use property_report for a full data pull when you "
+        "have a street address + postcode. For postcode-only queries use property_comps "
+        "and property_yield separately. ppd_transactions for specific property history, "
+        "rightmove_search to browse listings, rightmove_listing for full detail on one "
+        "listing, property_epc for energy certificates, rental_analysis for rental market "
+        "figures, stamp_duty for SDLT, property_blocks for block-buy analysis, "
+        "planning_search for council planning portals, company_search to find a company "
+        "by name."
+    ),
+)
+
+
+@mcp.tool()
+def property_comps(
+    postcode: str,
+    months: int = 24,
+    property_type: str | None = None,
+    search_level: str = "sector",
+    address: str | None = None,
+) -> dict:
+    """Comparable sales from Land Registry Price Paid Data."""
+    from property_core import PPDService
+    return PPDService().comps(
+        postcode=postcode,
+        months=months,
+        property_type=property_type,
+        search_level=search_level,
+        address=address,
+    ).model_dump()
+
+
+@mcp.tool()
+async def property_yield(
+    postcode: str,
+    months: int = 24,
+    search_level: str = "sector",
+    property_type: str | None = None,
+) -> dict:
+    """Rental yield analysis for a postcode."""
+    from property_core import calculate_yield
+    return (await calculate_yield(
+        postcode=postcode,
+        months=months,
+        search_level=search_level,
+        property_type=property_type,
+    )).model_dump()
+
+
+@mcp.tool()
+async def rental_analysis(
+    postcode: str,
+    radius: float = 0.5,
+    purchase_price: int | None = None,
+) -> dict:
+    """Rental market analysis and achievable rent estimate."""
+    from property_core import analyze_rentals
+    return (await analyze_rentals(
+        postcode=postcode,
+        radius=radius,
+        purchase_price=purchase_price,
+    )).model_dump()
+
+
+@mcp.tool()
+async def property_epc(postcode: str, address: str | None = None) -> dict | None:
+    """EPC energy certificate lookup by postcode (+ optional address filter)."""
+    from property_core import EPCClient
+    result = await EPCClient().search_by_postcode(postcode=postcode, address=address)
+    return result.model_dump() if result else None
+
+
+@mcp.tool()
+def stamp_duty(
+    price: int,
+    additional_property: bool = False,
+    first_time_buyer: bool = False,
+    non_resident: bool = False,
+) -> dict:
+    """UK Stamp Duty Land Tax (SDLT) calculation with full breakdown."""
+    from property_core import calculate_stamp_duty
+    return calculate_stamp_duty(
+        price=price,
+        additional_property=additional_property,
+        first_time_buyer=first_time_buyer,
+        non_resident=non_resident,
+    ).model_dump()
+
+
+@mcp.tool()
+async def rightmove_search(url: str, max_pages: int = 3) -> list[dict]:
+    """Fetch Rightmove listings from a search URL."""
+    from property_core import fetch_listings
+    listings = await fetch_listings(url=url, max_pages=max_pages)
+    return [l.model_dump() for l in listings]
+
+
+@mcp.tool()
+def rightmove_listing(property_url_or_id: str) -> dict:
+    """Full detail for a single Rightmove listing (URL or numeric ID)."""
+    from property_core import fetch_listing
+    return fetch_listing(property_url_or_id).model_dump()
+
+
+@mcp.tool()
+async def property_blocks(
+    postcode: str,
+    search_level: str = "sector",
+    months: int = 24,
+) -> dict:
+    """Block-buy analysis — identify buildings with multiple flat sales."""
+    from property_core import analyze_blocks
+    return (await analyze_blocks(
+        postcode=postcode,
+        search_level=search_level,
+        months=months,
+    )).model_dump()
+
+
+@mcp.tool()
+def company_search(name: str) -> dict:
+    """Search Companies House for a company by name."""
+    from property_core import CompaniesHouseClient
+    result = CompaniesHouseClient().search(name)
+    return result.model_dump() if result else {"items": []}
+
+
+@mcp.tool()
+async def property_report(
+    address: str,
+    postcode: str,
+    months: int = 24,
+) -> dict:
+    """Full property data pull — comps + EPC + yield + market in one call.
+
+    Requires both a street address and postcode, e.g. address='10 Downing Street',
+    postcode='SW1A 2AA'.
+    """
+    from property_core.report_service import PropertyReportService
+    result = await PropertyReportService().generate_report(
+        address_query=f"{address}, {postcode}",
+        ppd_months=months,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def planning_search(postcode: str) -> dict:
+    """Find the council planning portal URL for a postcode."""
+    from property_core import PlanningService
+    return PlanningService().search(postcode)
+
+
+@mcp.tool()
+def ppd_transactions(
+    postcode: str,
+    limit: int = 10,
+    property_type: str | None = None,
+) -> dict:
+    """Raw Land Registry Price Paid transactions for a postcode."""
+    from property_core import PPDService
+    return PPDService().search_transactions(
+        postcode=postcode,
+        postcode_prefix=None,
+        limit=limit,
+        property_type=property_type,
+    )
+
+
+def build_asgi_app():
+    """Streamable-HTTP ASGI app for MCPMiddleware in app/main.py."""
+    return create_streamable_http_app(
+        mcp,
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+    )

--- a/property_core/rightmove_scraper.py
+++ b/property_core/rightmove_scraper.py
@@ -195,7 +195,7 @@ def _get_with_retries(
 
 # --- Listing detail helpers ---
 
-_PAGE_MODEL_RE = re.compile(r"window\.PAGE_MODEL\s*=\s*(\{.+?\})\s*\n", re.DOTALL)
+_PAGE_MODEL_RE = re.compile(r"window\.__PAGE_MODEL\s*=\s*(.+);")
 
 
 def _normalize_property_url(url_or_id: str) -> str:
@@ -206,16 +206,35 @@ def _normalize_property_url(url_or_id: str) -> str:
     return f"https://www.rightmove.co.uk/properties/{url_or_id}"
 
 
+def _decode_graph(nodes: list, idx: int, seen: frozenset = frozenset()) -> Any:
+    """Recursively dereference Rightmove's pointer-graph encoding.
+
+    Each node is either a primitive (returned as-is) or a dict/list whose
+    values are integer indices into the same nodes array.
+    """
+    if idx in seen:
+        return None
+    val = nodes[idx]
+    seen = seen | {idx}
+    if isinstance(val, dict):
+        return {k: _decode_graph(nodes, v, seen) for k, v in val.items()}
+    if isinstance(val, list):
+        return [_decode_graph(nodes, i, seen) for i in val]
+    return val
+
+
 def _extract_page_model(html: str) -> Dict[str, Any]:
     """Extract PAGE_MODEL JSON from a Rightmove property detail page."""
     match = _PAGE_MODEL_RE.search(html)
     if not match:
         raise RightmoveError("Could not locate PAGE_MODEL data on the property page")
     try:
-        parsed = json.loads(match.group(1))
-    except json.JSONDecodeError as exc:
+        outer = json.loads(match.group(1))
+        nodes = json.loads(outer["data"])
+    except (json.JSONDecodeError, KeyError) as exc:
         raise RightmoveError(f"PAGE_MODEL contained invalid JSON: {exc}") from exc
-    property_data = parsed.get("propertyData")
+    root = _decode_graph(nodes, 0)
+    property_data = root.get("propertyData")
     if not property_data:
         raise RightmoveError("propertyData not found in PAGE_MODEL")
     return property_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.7.5"
+version = "1.8.0"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates, rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"
@@ -58,6 +58,7 @@ api = [
   "fastapi>=0.128.0",
   "uvicorn>=0.40.0",
   "prometheus-client==0.24.1",
+  "fastmcp>=3.2.4",
 ]
 cli = [
   "typer>=0.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1175,7 +1175,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.7.5"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1190,6 +1190,7 @@ dependencies = [
 [package.optional-dependencies]
 api = [
     { name = "fastapi" },
+    { name = "fastmcp" },
     { name = "prometheus-client" },
     { name = "uvicorn" },
 ]
@@ -1218,6 +1219,7 @@ planning = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.14.3" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.128.0" },
+    { name = "fastmcp", marker = "extra == 'api'", specifier = ">=3.2.4" },
     { name = "fastmcp", extras = ["apps"], marker = "extra == 'apps'", specifier = "==3.2.4" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },


### PR DESCRIPTION
## Summary

- Replaces the httpx proxy (`/mcp` → `uk-property-mcp.fly.dev`) with a local FastMCP server in `app/mcp/server.py` — eliminates the circular release dependency (property_core fixes previously required two releases)
- Adds `_AcceptNormalizer` wrapping so Claude.ai mixed-Accept headers no longer cause 406/connection-closed failures (`propshard` was showing Failed in Claude.ai MCP panel)
- Extracts `_AcceptNormalizer` to `app/core/middleware.py`; shared by both `app/main.py` and `property_app/server.py`
- Fixes Rightmove listing scraper: `window.PAGE_MODEL` renamed to `window.__PAGE_MODEL`; adds `_decode_graph()` for the new pointer-graph encoding
- Adds `fastmcp>=3.2.4` to `api` extra; bumps version `1.7.5` → `1.8.0`

## Test plan

- [ ] Merge and pull locally
- [ ] `curl -fsS https://property-shared.fly.dev/health`
- [ ] `curl -fsS https://property-shared.fly.dev/.well-known/mcp/server-card.json` → should return `1.8.0`
- [ ] Check `propshard` shows Connected in Claude.ai MCP panel
- [ ] Test `rightmove_listing` tool — should return full detail without PAGE_MODEL error
- [ ] Verify `propertydata-app` (propertydata.fly.dev) still connects in Claude.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)