### PR TITLE
feat: multimodal image support for rightmove_listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 UK property data in one package. Pulls Land Registry sales, EPC certificates, Rightmove listings, rental yields, stamp duty calculations, planning portal links, and Companies House records.
 
-Use it as a **Python library**, **CLI**, or **HTTP API**.
-
-> **MCP server moved:** The MCP server is now [`uk-property-mcp`](https://github.com/paulieb89/uk-property-mcp) — install with `pip install uk-property-mcp`. `https://property-shared.fly.dev/mcp` remains available as a permanent proxy to `uk-property-mcp`.
+Use it as a **Python library**, **CLI**, **HTTP API**, or **MCP server**.
 
 ## What You Get
 
@@ -26,6 +24,27 @@ Use it as a **Python library**, **CLI**, or **HTTP API**.
 ## Skills
 
 Want structured property reports instead of raw data? Claude skills that chain these tools into investment summaries are available at [bouch.dev/products](https://bouch.dev/products).
+
+## Use as MCP Server
+
+No install required — paste the URL into your MCP client config and go.
+
+**Claude Code, Cursor, any MCP client:**
+
+```json
+{
+  "mcpServers": {
+    "property-shared": {
+      "type": "http",
+      "url": "https://property-shared.fly.dev/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop, ChatGPT and clients with visual dashboards** — use `https://propertydata.fly.dev/mcp` instead. This server adds interactive UI dashboards (wip). Not supported in all MCP clients.
+
+Both servers expose the same core tools. `property-shared.fly.dev` is the plain tools-only server that works everywhere.
 
 ## Install
 

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -7,8 +7,14 @@ from __future__ import annotations
 
 from importlib.metadata import version as _pkg_version
 
+import asyncio
+
+import httpx
 from fastmcp import FastMCP
 from fastmcp.server.http import create_streamable_http_app
+from fastmcp.tools import ToolResult
+from fastmcp.utilities.types import Image
+from mcp.types import TextContent
 
 mcp = FastMCP(
     "property-data",
@@ -24,6 +30,17 @@ mcp = FastMCP(
         "a company by name."
     ),
 )
+
+
+async def _fetch_rightmove_image(url: str) -> bytes | None:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(f"https://propertydata.fly.dev/img?url={url}")
+            if resp.status_code != 200:
+                return None
+            return resp.content
+    except Exception:
+        return None
 
 
 @mcp.tool()
@@ -160,20 +177,48 @@ async def rightmove_search(
 
 
 @mcp.tool()
-def rightmove_listing(
+async def rightmove_listing(
     property_url_or_id: str,
     include_images: bool = False,
-) -> dict:
+    max_images: int = 3,
+) -> dict | ToolResult:
     """Full detail for a single Rightmove listing (URL or numeric ID).
 
-    include_images returns photo and floorplan URLs — useful for eval fixtures
-    but adds significant payload size.
+    include_images fetches and embeds photos and floorplans as MCP image content.
+    max_images caps the number of property photos (default 3); floorplans always included.
     """
+    import anyio
     from property_core import fetch_listing
-    result = fetch_listing(property_url_or_id)
-    if include_images:
-        return result.model_dump()
-    return result.model_dump(exclude={"images", "floorplans"})
+
+    result = await anyio.to_thread.run_sync(lambda: fetch_listing(property_url_or_id))
+
+    if not include_images:
+        return result.model_dump(exclude={"images", "floorplans"})
+
+    photo_urls = (result.images or [])[:max_images]
+    floorplan_urls = result.floorplans or []
+    all_urls = photo_urls + floorplan_urls
+
+    raw_results = await asyncio.gather(
+        *[_fetch_rightmove_image(u) for u in all_urls],
+        return_exceptions=True,
+    )
+
+    price_str = f"£{result.price:,}" if result.price else "price unknown"
+    beds = result.bedrooms if result.bedrooms is not None else "?"
+    prop_type = result.property_type or "property"
+    address = result.address or "unknown address"
+    summary = f"{address} — {price_str} — {beds} bed {prop_type}"
+
+    content: list = [TextContent(type="text", text=summary)]
+    for img_bytes in raw_results:
+        if isinstance(img_bytes, bytes) and img_bytes:
+            content.append(Image(data=img_bytes, format="jpeg"))
+
+    return ToolResult(
+        content=content,
+        structured_content=result.model_dump(exclude={"images", "floorplans"}),
+    )
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

- `_fetch_rightmove_image`: async helper that fetches Rightmove photos via the `propertydata.fly.dev/img` proxy, returns `bytes | None` (silent failure on any error)
- `rightmove_listing` now async; `include_images=True` returns a `ToolResult` with up to `max_images` property photos + all floorplans embedded as MCP image content, plus a one-line text summary and `structured_content` dict (image URLs excluded)
- `include_images=False` (default) behaviour unchanged — plain dict return
- README: removed stale `uk-property-mcp` callout, added clear MCP Server section explaining `property-shared.fly.dev` vs `propertydata.fly.dev`

## Test plan

- [x] 97/97 tests passing (`uv run --extra dev pytest tests/ -v`)
- [ ] Deploy to Fly and verify `include_images=true` returns embedded images in MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)