### PR TITLE
fix: default auto_escalate=true on /v1/ppd/comps REST endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+- REST API `/v1/ppd/comps` now defaults `auto_escalate=true`. Previously the REST API was the odd one out —  All three interfaces now behave identically: thin markets auto-widen from postcode→sector→district, with the `escalated_from`/`escalated_to` fields in the response indicating any widening that occurred. Pass `auto_escalate=false` to opt out.
+
 ## v1.4.0 (2026-03-28)
 
 ### New Features

--- a/app/api/v1/ppd.py
+++ b/app/api/v1/ppd.py
@@ -138,7 +138,7 @@ async def comps(
     search_level: Literal["postcode", "sector", "district"] = "sector",
     address: Optional[str] = Query(None, description="Subject property address for context"),
     enrich_epc: bool = Query(False, description="Enrich comps with EPC floor area and price/sqft"),
-    auto_escalate: bool = Query(False, description="Auto-widen search area if fewer than 5 results"),
+    auto_escalate: bool = Query(True, description="Auto-widen search area if fewer than 5 results (default true)"),
 ) -> PPDCompsResponse:
     """Get comparable sales summary for a postcode (sector/district supported).
 


### PR DESCRIPTION
Aligns the REST API with both MCP servers (property-shared and propertydata), which already defaulted to true. Thin postcode-level markets now auto-widen to sector→district consistently across all three interfaces, with escalated_from/escalated_to fields making the behaviour transparent. Callers can opt out with auto_escalate=false.