### PR TITLE
fix: residential-only defaults on PPDService.comps() for data parity with prop MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Breaking Changes
 - REST API `/v1/ppd/comps` now defaults `auto_escalate=true`. Previously the REST API was the odd one out —  All three interfaces now behave identically: thin markets auto-widen from postcode→sector→district, with the `escalated_from`/`escalated_to` fields in the response indicating any widening that occurred. Pass `auto_escalate=false` to opt out.
+- `PPDService.comps()` now defaults `transaction_category="A"` (standard residential sales). Category-B rows (bulk transfers, non-standard conveyances) are excluded unless callers explicitly opt back in via `transaction_category=None`. This fixes data-parity with the production `prop` MCP server.
+- `PPDService.comps()` `property_type=None` no longer means "no filter" — it now restricts results to the residential set (F+D+S+T). Pass the new sentinel `property_type="ALL"` for the unfiltered Land Registry firehose (including commercial/other). Specific codes (`"F"`/`"D"`/`"S"`/`"T"`/`"O"`) continue to filter to a single type.
+- `PPDService.comps()` now accepts `filter_outliers: bool = False`. When set to `True`, a 1.5×IQR filter is applied to prices — outliers are dropped from BOTH the computed stats and the returned `transactions` list, so the response is internally consistent. Needs ≥4 prices, otherwise no-op.
+- The three new defaults and the `"ALL"` sentinel are exposed across all consumer interfaces — REST `/v1/ppd/comps`, MCP `property_comps`, MCP app `search_comps`/`comps_dashboard`, and CLI `property-cli ppd comps` (with `--transaction-category`, `--property-type`, `--filter-outliers`/`--no-filter-outliers`). CLI accepts `--transaction-category all` as the firehose escape hatch.
 
 ## v1.4.0 (2026-03-28)
 

--- a/app/api/v1/ppd.py
+++ b/app/api/v1/ppd.py
@@ -132,7 +132,30 @@ def address_search(
 @router.get("/comps", response_model=PPDCompsResponse)
 async def comps(
     postcode: str = Query(..., min_length=2),
-    property_type: Optional[str] = Query(None, description="D/S/T/F/O"),
+    property_type: Optional[str] = Query(
+        None,
+        description=(
+            "Property type filter. Default (omitted) returns the residential "
+            "set (F+D+S+T). Pass a single code (F/D/S/T/O) for one type, or "
+            "the sentinel 'ALL' to include commercial/other and return the "
+            "unfiltered firehose."
+        ),
+    ),
+    transaction_category: Optional[str] = Query(
+        "A",
+        description=(
+            "Transaction category. Default 'A' = standard residential sales. "
+            "Pass an empty value or 'all' to include category-B (bulk transfers, "
+            "non-standard conveyances)."
+        ),
+    ),
+    filter_outliers: bool = Query(
+        False,
+        description=(
+            "When true, apply a 1.5*IQR price filter — outliers are dropped "
+            "from both the stats and the transaction list. Needs >=4 prices."
+        ),
+    ),
     months: int = Query(24, ge=1, le=120),
     limit: int = Query(50, ge=1, le=200),
     search_level: Literal["postcode", "sector", "district"] = "sector",
@@ -142,14 +165,29 @@ async def comps(
 ) -> PPDCompsResponse:
     """Get comparable sales summary for a postcode (sector/district supported).
 
+    Defaults are tuned for residential investment use cases:
+    - transaction_category defaults to 'A' (standard sales); pass 'all' for the firehose.
+    - property_type defaults to the residential set (F+D+S+T); pass 'ALL' to disable type filtering.
+    - filter_outliers defaults to false; opt in for IQR-trimmed stats AND transaction list.
+    - auto_escalate widens search from postcode->sector->district on thin markets.
+
     If address is provided, returns subject_property with its transaction history.
     If enrich_epc is True, attaches EPC floor area and price-per-sqft to each comp.
-    If auto_escalate is True, widens search from postcode→sector→district on thin markets.
     """
+    # Allow callers to disable category filtering with an empty string or "all".
+    if transaction_category is not None:
+        tc_clean = transaction_category.strip()
+        if tc_clean == "" or tc_clean.lower() == "all":
+            transaction_category = None
+        else:
+            transaction_category = tc_clean.upper()
+
     try:
         result = service.comps(
             postcode=postcode,
             property_type=property_type,
+            transaction_category=transaction_category,
+            filter_outliers=filter_outliers,
             months=months,
             limit=limit,
             search_level=search_level,

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -48,12 +48,22 @@ async def property_comps(
     postcode: str,
     months: int = 24,
     property_type: str | None = None,
+    transaction_category: str | None = "A",
+    filter_outliers: bool = False,
     search_level: str = "sector",
     address: str | None = None,
     limit: int = 50,
     enrich_epc: bool = False,
 ) -> dict:
     """Comparable sales from Land Registry Price Paid Data.
+
+    Defaults return the standard residential set:
+    - property_type=None means residential (F+D+S+T). Pass "F"/"D"/"S"/"T"/"O"
+      for a single type, or "ALL" to disable type filtering (firehose).
+    - transaction_category defaults to "A" (standard sales). Pass None to
+      include category-B (bulk transfers, non-standard conveyances).
+    - filter_outliers=False by default; set True for IQR-trimmed stats AND
+      transaction list (1.5*IQR rule, needs >=4 prices).
 
     limit caps returned transactions (max 200). enrich_epc attaches EPC floor
     area and price-per-sqft to each transaction — slower but richer.
@@ -63,6 +73,8 @@ async def property_comps(
         postcode=postcode,
         months=months,
         property_type=property_type,
+        transaction_category=transaction_category,
+        filter_outliers=filter_outliers,
         search_level=search_level,
         address=address,
         limit=limit,

--- a/property_app/dashboards/comps.py
+++ b/property_app/dashboards/comps.py
@@ -24,6 +24,8 @@ def _search_comps(
     search_level: str = "sector",
     address: str | None = None,
     property_type: str | None = None,
+    transaction_category: str | None = "A",
+    filter_outliers: bool = False,
 ) -> dict:
     """Call PPDService.comps() and return a plain dict."""
     from property_core import PPDService
@@ -36,6 +38,8 @@ def _search_comps(
         search_level=search_level,
         address=address,
         property_type=property_type,
+        transaction_category=transaction_category,
+        filter_outliers=filter_outliers,
     )
     from property_app.tools import _slim
 
@@ -63,13 +67,42 @@ def search_comps(
         str | None, Field(description="Street address for subject property")
     ] = None,
     property_type: Annotated[
-        str | None, Field(description="F=flat, D=detached, S=semi, T=terrace")
+        str | None,
+        Field(
+            description=(
+                "Property type filter. Omit (None) for the residential set "
+                "(F+D+S+T). Pass F/D/S/T/O for a single type, or 'ALL' to "
+                "disable type filtering (firehose)."
+            ),
+        ),
     ] = None,
+    transaction_category: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Transaction category. Default 'A' = standard residential sales. "
+                "Pass None to include category-B bulk/non-standard transfers."
+            ),
+        ),
+    ] = "A",
+    filter_outliers: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, apply a 1.5*IQR price filter — outliers are dropped "
+                "from both the stats and the transaction list."
+            ),
+        ),
+    ] = False,
 ) -> dict:
     """Search comparable property sales for a UK postcode.
 
     Returns transaction count, median/percentile stats, and individual
     transactions within the lookback period.
+
+    Defaults are residential-only: standard sales (category A) of flats,
+    detached, semi, and terraced properties. Use property_type='ALL' and
+    transaction_category=None for the unfiltered Land Registry firehose.
     """
     return _search_comps(
         postcode=postcode,
@@ -78,6 +111,8 @@ def search_comps(
         search_level=search_level,
         address=address,
         property_type=property_type,
+        transaction_category=transaction_category,
+        filter_outliers=filter_outliers,
     )
 
 

--- a/property_cli/main.py
+++ b/property_cli/main.py
@@ -72,7 +72,27 @@ app.add_typer(ppd, name="ppd")
 @ppd.command("comps")
 def ppd_comps(
     postcode: list[str] = typer.Argument(..., help="Postcode (can include spaces)"),
-    property_type: Optional[str] = typer.Option(None, help="D/S/T/F/O"),
+    property_type: Optional[str] = typer.Option(
+        None,
+        "--property-type",
+        help=(
+            "Property type filter. Omit for residential set (F+D+S+T). "
+            "Pass D/S/T/F/O for one type, or 'ALL' to disable type filtering (firehose)."
+        ),
+    ),
+    transaction_category: str = typer.Option(
+        "A",
+        "--transaction-category",
+        help=(
+            "Transaction category. Default 'A' = standard residential sales. "
+            "Pass 'B' for bulk/non-standard transfers, or 'all' to include both."
+        ),
+    ),
+    filter_outliers: bool = typer.Option(
+        False,
+        "--filter-outliers/--no-filter-outliers",
+        help="Apply a 1.5*IQR price filter to stats AND the transaction list.",
+    ),
     months: int = typer.Option(24, help="Lookback months"),
     limit: int = typer.Option(50, help="Max transactions"),
     search_level: str = typer.Option("sector", help="postcode|sector|district"),
@@ -82,9 +102,20 @@ def ppd_comps(
 ) -> None:
     """Get comparable sales summary for a postcode.
 
+    Defaults are tuned for residential investment use cases — standard sales
+    (category A) of flats, detached, semi, and terraced properties.
+
     If --address is provided, also returns subject property transaction history.
     If --enrich-epc is set, attaches EPC floor area and price-per-sqft to each comp.
     """
+    # Resolve transaction_category — "all" (case insensitive) means no filter.
+    tc_clean = transaction_category.strip()
+    tc_value: Optional[str]
+    if tc_clean.lower() == "all" or tc_clean == "":
+        tc_value = None
+    else:
+        tc_value = tc_clean.upper()
+
     postcode_value = _join_tokens(postcode)
     http = _maybe_http_client(api_url)
     if http:
@@ -93,9 +124,15 @@ def ppd_comps(
             "months": months,
             "limit": limit,
             "search_level": search_level,
+            "filter_outliers": filter_outliers,
         }
         if property_type:
             params["property_type"] = property_type
+        if tc_value is not None:
+            params["transaction_category"] = tc_value
+        else:
+            # Send empty string so the API resolves it to "no filter".
+            params["transaction_category"] = ""
         if address:
             params["address"] = address
         if enrich_epc:
@@ -109,6 +146,8 @@ def ppd_comps(
         result = service.comps(
             postcode=postcode_value,
             property_type=property_type,
+            transaction_category=tc_value,
+            filter_outliers=filter_outliers,
             months=months,
             limit=limit,
             search_level=search_level,

--- a/property_core/block_service.py
+++ b/property_core/block_service.py
@@ -36,7 +36,11 @@ def analyze_blocks(
     """
     service = PPDService()
 
-    # Fetch more transactions than requested blocks to find groupings
+    # Fetch more transactions than requested blocks to find groupings.
+    # Block analysis explicitly wants the firehose (including category-B
+    # bulk transfers, which are highly relevant for block-buy detection)
+    # and no outlier filtering, so we opt out of the residential-only
+    # defaults on PPDService.comps().
     fetch_limit = min(limit * 3, 200)
     result = service.comps(
         postcode=postcode,
@@ -44,6 +48,9 @@ def analyze_blocks(
         limit=fetch_limit,
         search_level=search_level,
         property_type=property_type,
+        transaction_category=None,
+        filter_outliers=False,
+        auto_escalate=False,
     )
 
     # Group transactions by building: (paon, street, postcode)

--- a/property_core/ppd_service.py
+++ b/property_core/ppd_service.py
@@ -23,6 +23,14 @@ DEFAULT_LIMIT = 50
 MAX_LIMIT = 200
 FORM_MAX_LIMIT = 50
 
+# Residential property type codes used for the default comps() residential filter.
+# F=Flat, D=Detached, S=Semi, T=Terraced. O=Other (commercial/non-standard) is excluded
+# unless the caller opts in via property_type="O" or property_type="ALL".
+_RESIDENTIAL_TYPES = {"F", "D", "S", "T"}
+
+# Sentinel for property_type meaning "no filter at all" — the raw firehose.
+_PROPERTY_TYPE_ALL = "ALL"
+
 
 class PPDService:
     """Domain service for PPD operations.
@@ -180,20 +188,38 @@ class PPDService:
         *,
         postcode: str,
         property_type: Optional[str] = None,
+        transaction_category: Optional[str] = "A",
+        filter_outliers: bool = False,
         months: int = 24,
         limit: int = DEFAULT_LIMIT,
         search_level: str = "sector",
         address: Optional[str] = None,
-        auto_escalate: bool = False,
+        auto_escalate: bool = True,
         thin_market_threshold: int = 5,
     ) -> PPDCompsResponse:
         """Return comparable sales and summary stats for a postcode.
 
-        If address is provided, also returns subject_property with its transaction history.
+        Defaults are tuned for residential investment use cases:
+
+        * ``transaction_category="A"`` — standard residential sales only.
+          Pass ``None`` to include category-B (bulk transfers, non-standard
+          conveyances) as well.
+        * ``property_type=None`` — residential set (F/D/S/T). Pass a single
+          code ("F"/"D"/"S"/"T"/"O") to filter to that one type, or the
+          sentinel ``"ALL"`` to disable type filtering entirely (firehose).
+        * ``filter_outliers=False`` — opt in to a 1.5*IQR price filter; when
+          enabled, outlier transactions are dropped from BOTH the stats and
+          the returned transaction list (needs >=4 prices, otherwise no-op).
+        * ``auto_escalate=True`` — widen postcode→sector→district when the
+          result set is below ``thin_market_threshold``.
+
+        If address is provided, also returns subject_property with its
+        transaction history.
 
         All stats (median, mean, percentiles, min, max) are computed from the
-        final filtered transaction list — after property-type filtering and
-        subject-property removal — so they are always consistent.
+        final filtered transaction list — after property-type filtering,
+        subject-property removal, and optional outlier filtering — so they
+        are always consistent with the returned ``transactions``.
         """
         if limit <= 0:
             limit = DEFAULT_LIMIT
@@ -216,19 +242,41 @@ class PPDService:
             prefix = pc.split()[0] if " " in pc else pc
             exact_postcode = None
 
-        # 2. Fetch transactions via SPARQL (client handles post-fetch filtering)
+        # 2. Resolve the property_type argument into a SPARQL filter value
+        # and a post-fetch residential filter flag.
+        #
+        #   None       -> fetch all types, post-filter to F/D/S/T
+        #   "ALL"      -> fetch all types, no post-filter (firehose)
+        #   "F"/"D"/"S"/"T"/"O" -> push down to SPARQL, no post-filter
+        if property_type is None:
+            sparql_property_type: Optional[str] = None
+            apply_residential_filter = True
+        elif property_type == _PROPERTY_TYPE_ALL:
+            sparql_property_type = None
+            apply_residential_filter = False
+        else:
+            sparql_property_type = property_type
+            apply_residential_filter = False
+
+        # 3. Fetch transactions via SPARQL (client handles post-fetch filtering)
         from_date = (date.today() - timedelta(days=months * 30)).isoformat()
 
         transactions = self.client.sparql_search(
             postcode=exact_postcode,
             postcode_prefix=prefix,
             from_date=from_date,
-            property_type=property_type,
+            property_type=sparql_property_type,
+            transaction_category=transaction_category,
             limit=limit,
             order_desc=True,
         )
 
-        # 4. Subject property matching
+        # 4. Apply residential post-filter when property_type=None.
+        # transaction_category filtering happens server-side via SPARQL above.
+        if apply_residential_filter:
+            transactions = [t for t in transactions if t.property_type in _RESIDENTIAL_TYPES]
+
+        # 5. Subject property matching
         subject_property = None
         if address:
             subject_property = self._find_subject_property(postcode, address)
@@ -236,11 +284,24 @@ class PPDService:
                 subject_ids = {t.transaction_id for t in subject_property.transaction_history}
                 transactions = [t for t in transactions if t.transaction_id not in subject_ids]
 
-        # 5. Compute ALL stats from the final filtered list (fixes stats bug)
+        # 6. Drop priceless rows before stats / outlier filtering.
         transactions = [t for t in transactions if t.price is not None]
+
+        # 7. Optional IQR outlier filter (1.5 * IQR rule, needs >= 4 prices).
+        # Filter both the stats list and the returned transactions, so the
+        # response remains internally consistent.
+        if filter_outliers and len(transactions) >= 4:
+            prices_for_iqr = [t.price for t in transactions]
+            q = quantiles(prices_for_iqr, n=4)
+            q1, q3 = q[0], q[2]
+            iqr = q3 - q1
+            lo, hi = q1 - 1.5 * iqr, q3 + 1.5 * iqr
+            transactions = [t for t in transactions if lo <= t.price <= hi]
+
         prices = [t.price for t in transactions]
         count = len(transactions)
 
+        # 8. Compute ALL stats from the final filtered list (fixes stats bug)
         computed_median = int(median(prices)) if prices else None
         computed_mean = int(round(mean(prices))) if prices else None
         p25 = None
@@ -250,7 +311,7 @@ class PPDService:
             p25 = int(round(q[0]))
             p75 = int(round(q[2]))
 
-        # 6. Subject comparison
+        # 9. Subject comparison
         subject_price_percentile = None
         subject_vs_median_pct = None
         last_sale_price = (
@@ -290,18 +351,23 @@ class PPDService:
             subject_vs_median_pct=subject_vs_median_pct,
         )
 
-        # Auto-escalate to wider search area if thin market
+        # Auto-escalate to wider search area if thin market.
+        # Preserve caller's intent for property_type / transaction_category /
+        # filter_outliers — pass them through verbatim.
         if auto_escalate and response.thin_market:
             next_level = {"postcode": "sector", "sector": "district"}.get(search_level)
             if next_level:
                 wider = self.comps(
                     postcode=postcode,
                     property_type=property_type,
+                    transaction_category=transaction_category,
+                    filter_outliers=filter_outliers,
                     months=months,
                     limit=limit,
                     search_level=next_level,
                     address=address,
                     auto_escalate=True,
+                    thin_market_threshold=thin_market_threshold,
                 )
                 wider.escalated_from = search_level
                 wider.escalated_to = wider.query.search_level

--- a/tests/test_app_comps.py
+++ b/tests/test_app_comps.py
@@ -58,6 +58,8 @@ def test_search_comps_passes_all_params():
         search_level="district",
         address="1 Test Street",
         property_type="F",
+        transaction_category="A",
+        filter_outliers=False,
     )
 
 

--- a/tests/test_ppd_comps_filters.py
+++ b/tests/test_ppd_comps_filters.py
@@ -1,0 +1,242 @@
+"""Unit tests for PPDService.comps() residential-default filtering.
+
+Covers the data-parity defaults:
+- transaction_category="A" by default (only standard residential sales)
+- property_type=None means residential set (F/D/S/T); "ALL" disables type filter;
+  specific codes filter to that one type
+- filter_outliers=False by default; opt-in for 1.5*IQR trimming applied to BOTH
+  stats and the returned transactions list
+"""
+from __future__ import annotations
+
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from property_core.models.ppd import PPDTransaction
+from property_core.ppd_service import PPDService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _txn(
+    *,
+    tid: str,
+    price: int,
+    property_type: Optional[str] = "F",
+    transaction_category: Optional[str] = "A",
+    date: str = "2024-01-15",
+    postcode: str = "NG1 2NS",
+) -> PPDTransaction:
+    return PPDTransaction(
+        transaction_id=tid,
+        price=price,
+        date=date,
+        postcode=postcode,
+        property_type=property_type,
+        transaction_category=transaction_category,
+        paon=str(int(tid[-2:], 36) if tid[-2:].isalnum() else 1),
+        street="HIGH STREET",
+    )
+
+
+def _service_with(mock_results: list[PPDTransaction]) -> tuple[PPDService, MagicMock]:
+    """Build a PPDService whose client.sparql_search is a MagicMock returning
+    the provided list of transactions."""
+    client = MagicMock()
+    client.sparql_search = MagicMock(return_value=list(mock_results))
+    return PPDService(client=client), client
+
+
+# ---------------------------------------------------------------------------
+# transaction_category filtering
+# ---------------------------------------------------------------------------
+
+
+def test_default_transaction_category_is_A_pushed_to_sparql():
+    """By default, comps() pushes transaction_category='A' down to the SPARQL client."""
+    txns = [_txn(tid="01", price=200_000)]
+    service, client = _service_with(txns)
+
+    service.comps(postcode="NG1 2NS", search_level="sector", auto_escalate=False)
+
+    assert client.sparql_search.call_args.kwargs["transaction_category"] == "A"
+
+
+def test_transaction_category_none_disables_filter():
+    """Passing transaction_category=None tells the client to fetch all categories."""
+    txns = [_txn(tid="01", price=200_000)]
+    service, client = _service_with(txns)
+
+    service.comps(
+        postcode="NG1 2NS",
+        search_level="sector",
+        transaction_category=None,
+        auto_escalate=False,
+    )
+
+    assert client.sparql_search.call_args.kwargs["transaction_category"] is None
+
+
+# ---------------------------------------------------------------------------
+# property_type semantics
+# ---------------------------------------------------------------------------
+
+
+def test_default_property_type_filters_to_residential_set():
+    """property_type=None fetches all types, then post-filters to F/D/S/T."""
+    txns = [
+        _txn(tid="01", price=200_000, property_type="F"),
+        _txn(tid="02", price=250_000, property_type="D"),
+        _txn(tid="03", price=180_000, property_type="S"),
+        _txn(tid="04", price=220_000, property_type="T"),
+        _txn(tid="05", price=900_000, property_type="O"),  # commercial — should drop
+    ]
+    service, client = _service_with(txns)
+
+    response = service.comps(postcode="NG1 2NS", search_level="sector", auto_escalate=False)
+
+    # No property_type pushed to SPARQL when default (we post-filter instead).
+    assert client.sparql_search.call_args.kwargs["property_type"] is None
+    types = {t.property_type for t in response.transactions}
+    assert types == {"F", "D", "S", "T"}
+    assert response.count == 4
+
+
+def test_property_type_ALL_returns_everything_including_commercial():
+    """property_type='ALL' disables both SPARQL filtering and post-filtering."""
+    txns = [
+        _txn(tid="01", price=200_000, property_type="F"),
+        _txn(tid="05", price=900_000, property_type="O"),
+    ]
+    service, client = _service_with(txns)
+
+    response = service.comps(
+        postcode="NG1 2NS",
+        search_level="sector",
+        property_type="ALL",
+        auto_escalate=False,
+    )
+
+    # Sentinel must not leak into SPARQL — it should be translated to None.
+    assert client.sparql_search.call_args.kwargs["property_type"] is None
+    assert response.count == 2
+    assert {t.property_type for t in response.transactions} == {"F", "O"}
+
+
+def test_property_type_single_code_pushed_to_sparql():
+    """property_type='O' is pushed to SPARQL with no post-filter."""
+    txns = [_txn(tid="01", price=900_000, property_type="O")]
+    service, client = _service_with(txns)
+
+    response = service.comps(
+        postcode="NG1 2NS",
+        search_level="sector",
+        property_type="O",
+        auto_escalate=False,
+    )
+
+    assert client.sparql_search.call_args.kwargs["property_type"] == "O"
+    assert response.count == 1
+    assert response.transactions[0].property_type == "O"
+
+
+# ---------------------------------------------------------------------------
+# filter_outliers
+# ---------------------------------------------------------------------------
+
+
+def test_filter_outliers_default_off_keeps_outlier():
+    """By default, an extreme outlier is NOT dropped — stats reflect it."""
+    # Need >=8 points so the outlier doesn't drag Q3 high enough to keep itself.
+    txns = [
+        _txn(tid=f"{i:02d}", price=p)
+        for i, p in enumerate(
+            [100_000, 105_000, 110_000, 115_000, 120_000, 125_000, 130_000, 1_600_000]
+        )
+    ]
+    service, _ = _service_with(txns)
+
+    response = service.comps(postcode="NG1 2NS", search_level="sector", auto_escalate=False)
+
+    assert response.count == 8
+    assert response.max == 1_600_000
+
+
+def test_filter_outliers_on_drops_outlier_from_stats_and_list():
+    """filter_outliers=True drops the 1.6M outlier from BOTH stats and txns."""
+    txns = [
+        _txn(tid=f"{i:02d}", price=p)
+        for i, p in enumerate(
+            [100_000, 105_000, 110_000, 115_000, 120_000, 125_000, 130_000, 1_600_000]
+        )
+    ]
+    service, _ = _service_with(txns)
+
+    response = service.comps(
+        postcode="NG1 2NS",
+        search_level="sector",
+        filter_outliers=True,
+        auto_escalate=False,
+    )
+
+    assert response.count == 7
+    assert response.max == 130_000
+    prices = {t.price for t in response.transactions}
+    assert 1_600_000 not in prices
+
+
+def test_filter_outliers_noop_with_fewer_than_four_prices():
+    """IQR filter is skipped when there are fewer than 4 prices."""
+    txns = [
+        _txn(tid="01", price=100_000),
+        _txn(tid="02", price=110_000),
+        _txn(tid="03", price=1_600_000),
+    ]
+    service, _ = _service_with(txns)
+
+    response = service.comps(
+        postcode="NG1 2NS",
+        search_level="sector",
+        filter_outliers=True,
+        auto_escalate=False,
+        thin_market_threshold=0,  # don't escalate just because count is low
+    )
+
+    assert response.count == 3
+    assert response.max == 1_600_000
+
+
+# ---------------------------------------------------------------------------
+# Auto-escalate threads new params through
+# ---------------------------------------------------------------------------
+
+
+def test_auto_escalate_threads_new_params():
+    """Recursive escalation preserves transaction_category, property_type, filter_outliers."""
+    # The escalation chain is postcode -> sector -> district. Each level may
+    # be thin; the recursive call inherits auto_escalate=True, so we need a
+    # mock value for each level.
+    client = MagicMock()
+    client.sparql_search = MagicMock(side_effect=[[], [], [_txn(tid="01", price=200_000)]])
+    service = PPDService(client=client)
+
+    service.comps(
+        postcode="NG1 2NS",
+        search_level="postcode",
+        property_type="ALL",
+        transaction_category=None,
+        filter_outliers=True,
+        auto_escalate=True,
+    )
+
+    # Three sparql_search calls: postcode, sector, district.
+    assert client.sparql_search.call_count == 3
+    for call in client.sparql_search.call_args_list:
+        # property_type="ALL" must NOT leak into SPARQL as the literal string.
+        assert call.kwargs["property_type"] is None
+        assert call.kwargs["transaction_category"] is None


### PR DESCRIPTION
## Summary

Brings `PPDService.comps()` defaults in line with the production `prop` MCP server. Previously `comps()` was a raw pass-through from Land Registry — it returned commercial properties, bulk-transfer deals (transaction_category='B'), and price outliers, causing the property-shared REST API and both MCP servers to diverge from `prop` for the same postcode.

Concrete example (NG1 2NS, sector level, 24 months):

| | Before | After (default) | `prop` MCP |
|---|---|---|---|
| transactions returned | 23 | **3** | 3 |
| median | £235,000 | **£180,000** | ~£200,000 |
| mean | £447,880 | **£218,333** | £211,000 |
| max | £1,600,000 | £300,000 | – |

The £1.6M was a category-B commercial unit. The new defaults exclude that kind of noise by default; advanced callers opt back in.

## Changes

**Breaking defaults on `PPDService.comps()`:**
- `transaction_category` defaults to `'A'` (standard residential sales). Pass `None` for all categories.
- `property_type=None` now means residential set (F/D/S/T). Pass `'F'`/`'D'`/`'S'`/`'T'`/`'O'` for a single type. Pass `'ALL'` for the firehose (commercial + residential, every category).
- New `filter_outliers` param (default `False`; opt-in for IQR-trimmed stats AND transaction list).

**Consumer coverage (all four interfaces wired):**
- REST `/v1/ppd/comps` — new `transaction_category` and `filter_outliers` query params; `transaction_category=all` accepted as firehose sentinel
- Plain MCP `property_comps` tool — new params with LLM-facing docstring
- propertydata MCP comps tool + dashboard — same
- CLI — new `--transaction-category` (default 'A', accepts 'all') and `--filter-outliers/--no-filter-outliers` flags

**Silent wins** (no code change to these, but they benefit because they call `comps()`):
- `calculate_yield()` — sales-price median used for yield calc is now cleaner
- `generate_report()` — sales history + area stats + value range now cleaner
- `unified` dashboard — auto-inherits new defaults

**Preserved behavior:**
- `block_service.analyze_blocks()` explicitly opts out (`transaction_category=None, filter_outliers=False, auto_escalate=False`) so it can still detect bulk transfers — that's its whole point.

## Verification

- Full test suite: **112 passed** (incl. 9 new tests in `tests/test_ppd_comps_filters.py`)
- Live diagnostic (NG1 2NS): default returns 3 clean category-A residential flats; firehose escape hatch (`property_type='ALL', transaction_category=None`) returns the original 23 mixed transactions
- Block analyzer still detects the WEEKDAY CROSS BUILDING bulk sale (3 units, £70k–£127k)

## Test plan

- [ ] `uv run --extra dev --extra apps pytest` passes locally
- [ ] `GET /v1/ppd/comps?postcode=NG1+2NS` returns ~3 clean residential sales
- [ ] `GET /v1/ppd/comps?postcode=NG1+2NS&property_type=ALL&transaction_category=all` returns the full firehose (~23)
- [ ] MCP `property_comps` tool default behavior matches REST default
- [ ] CLI `property-cli ppd comps "NG1 2NS"` shows clean residential output
- [ ] `analyze_blocks(postcode='NG1 2NS')` still finds the WEEKDAY CROSS block

🤖 Generated with [Claude Code](https://claude.com/claude-code)