### PR TITLE
fix: property_epc area-mode + rental-radius escalation in calculate_yield

### DIFF
--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -168,10 +168,49 @@ async def rental_analysis(
 
 @mcp.tool(annotations={"readOnlyHint": True})
 async def property_epc(postcode: str, address: str | None = None) -> dict | None:
-    """EPC energy certificate lookup by postcode (+ optional address filter)."""
+    """Energy Performance Certificate data for a UK property or postcode area.
+
+    With address: returns the matched EPC certificate for that specific property.
+    Without address: returns an aggregated summary of every certificate at the
+    postcode — count, rating distribution, property-type breakdown, floor-area
+    range — plus a hint to call again with an address for single-property detail.
+
+    Returns None if no certificates exist for the postcode at all.
+    """
+    from collections import Counter
+
     from property_core import EPCClient
-    result = await EPCClient().search_by_postcode(postcode=postcode, address=address)
-    return result.model_dump() if result else None
+
+    client = EPCClient()
+
+    if address:
+        result = await client.search_by_postcode(postcode, address=address)
+        if result is None:
+            return None
+        return _slim(result.model_dump(mode="json", exclude_none=True))
+
+    # Area mode — aggregate all certs at this postcode rather than returning
+    # an arbitrary first row.
+    certs = await client.search_all_by_postcode(postcode)
+    if not certs:
+        return None
+
+    ratings = Counter(c.rating for c in certs if c.rating)
+    types = Counter(c.property_type for c in certs if c.property_type)
+    areas = [c.floor_area for c in certs if c.floor_area]
+
+    return _slim({
+        "postcode": postcode,
+        "summary": {
+            "count": len(certs),
+            "rating_distribution": dict(sorted(ratings.items())),
+            "property_type_breakdown": dict(sorted(types.items())),
+            "floor_area_min": min(areas) if areas else None,
+            "floor_area_max": max(areas) if areas else None,
+            "floor_area_avg": round(sum(areas) / len(areas), 1) if areas else None,
+        },
+        "note": "Call property_epc again with a specific address for individual property details.",
+    })
 
 
 @mcp.tool(annotations={"readOnlyHint": True})

--- a/property_core/models/report.py
+++ b/property_core/models/report.py
@@ -87,6 +87,7 @@ class YieldAnalysis(BaseModel):
     sale_count: int = 0
     median_monthly_rent: Optional[int] = None
     rental_count: int = 0
+    rental_search_radius_miles: Optional[float] = None
     gross_yield_pct: Optional[float] = None
     yield_assessment: Optional[str] = None  # "strong", "average", "weak"
     data_quality: Optional[str] = None

--- a/property_core/yield_service.py
+++ b/property_core/yield_service.py
@@ -72,33 +72,41 @@ async def calculate_yield(
             thin_market=comps.thin_market,
         )
 
-    # Fetch rental listings (sync → thread)
+    # Fetch rental listings (sync → thread). On empty result, escalate the
+    # radius up to 2.0mi before giving up — rural postcodes often have no
+    # rentals at the default 0.5mi but plenty within a wider catchment.
     location_api = RightmoveLocationAPI(rate_limit_delay=delay)
-    try:
-        url = await asyncio.to_thread(
-            location_api.build_search_url,
-            postcode,
-            property_type="rent",
-            building_type=property_type,
-            radius=radius,
-        )
-        listings = await asyncio.to_thread(
-            fetch_listings,
-            url,
-            max_pages=1,
-            rate_limit_seconds=delay,
-        )
-    except Exception:
-        return YieldAnalysis(
-            postcode=postcode,
-            median_sale_price=comps.median,
-            sale_count=comps.count,
-            thin_market=comps.thin_market,
-        )
+    radii_to_try = [radius] + [r for r in (1.0, 1.5, 2.0) if r > radius]
 
-    # Keep all listings with valid prices - LET_AGREED are confirmed
-    # deals and arguably better data than aspirational asking rents
-    active = [l for l in listings if l.price and l.price > 0]
+    active: list = []
+    final_radius = radius
+    for try_radius in radii_to_try:
+        try:
+            url = await asyncio.to_thread(
+                location_api.build_search_url,
+                postcode,
+                property_type="rent",
+                building_type=property_type,
+                radius=try_radius,
+            )
+            listings = await asyncio.to_thread(
+                fetch_listings,
+                url,
+                max_pages=1,
+                rate_limit_seconds=delay,
+            )
+        except Exception:
+            return YieldAnalysis(
+                postcode=postcode,
+                median_sale_price=comps.median,
+                sale_count=comps.count,
+                thin_market=comps.thin_market,
+            )
+
+        active = [l for l in listings if l.price and l.price > 0]
+        final_radius = try_radius
+        if active:
+            break
 
     if not active:
         return YieldAnalysis(
@@ -122,6 +130,7 @@ async def calculate_yield(
         sale_count=comps.count,
         median_monthly_rent=median_rent,
         rental_count=len(active),
+        rental_search_radius_miles=final_radius,
         gross_yield_pct=gross_yield,
         thin_market=comps.thin_market,
     )


### PR DESCRIPTION
## Summary

Two user-facing data-quality fixes surfaced in MCP Inspector testing against postcodes like DE12 6LL. Both were identified in earlier diagnosis passes but missed during PR #12's scope pivot.

### Fix 1 — \`property_epc\` area mode

\`property_epc(postcode='DE12 6LL')\` without an address was returning an arbitrary first row (5 Alexandra Road) and the LLM was treating that as THE property at the postcode. The MCP App's \`epc_lookup\` tool already had the correct dual-mode pattern — this PR ports it to plain MCP.

**Before:**
\`\`\`json
{ \"rating\": \"D\", \"address\": \"5 Alexandra Road, Overseal\", ... }
\`\`\`

**After:**
\`\`\`json
{
  \"postcode\": \"DE12 6LL\",
  \"summary\": {
    \"count\": 16,
    \"rating_distribution\": {\"D\": 9, \"E\": 6, \"F\": 1},
    \"property_type_breakdown\": {\"Bungalow\": 4, \"House\": 12},
    \"floor_area_min\": 69.0, \"floor_area_max\": 163.0, \"floor_area_avg\": 100.7
  },
  \"note\": \"Call property_epc again with a specific address for individual property details.\"
}
\`\`\`

With an address, returns the matched cert as before (behaviour preserved). Also applied \`_slim\` + \`exclude_none\` to kill \`floor_level: null\` and other cosmetic nulls.

### Fix 2 — Rental-radius escalation in \`calculate_yield\`

\`property_yield\` for rural postcodes (DE12 6LL is rural Derbyshire, ~2,500 population) was returning \`rental_count: 0\` with no yield because Rightmove has no rental listings within the default 0.5mi. The yield tool's existing \`auto_escalate\` param only widens the **PPD sale** search (postcode→sector→district), not the rental radius.

This PR adds rental-radius escalation: when no listings are found at the requested radius, retry at 1.0mi, 1.5mi, 2.0mi before giving up. New \`rental_search_radius_miles\` field on \`YieldAnalysis\` surfaces which radius produced the data so callers can sanity-check.

**Before:**
\`\`\`json
{ \"median_sale_price\": 230000, \"sale_count\": 50, \"rental_count\": 0, \"thin_market\": false }
\`\`\`

**After:**
\`\`\`json
{ \"median_sale_price\": 230000, \"sale_count\": 50, \"median_monthly_rent\": 850, \"rental_count\": 6,
  \"rental_search_radius_miles\": 1.5, \"gross_yield_pct\": 4.43, \"thin_market\": false }
\`\`\`

## Files changed

- \`app/mcp/server.py\` — \`property_epc\` rewritten with dual-mode + \`_slim\`/\`exclude_none\`
- \`property_core/yield_service.py\` — rental-radius escalation loop
- \`property_core/models/report.py\` — added \`rental_search_radius_miles\` field

## Test plan

- [x] \`pytest -q\` — 128 passed (same count, no regressions)
- [x] Live test: \`property_epc(postcode='DE12 6LL')\` returns 16-cert summary, not one row
- [x] Live test: \`property_epc(postcode='DE12 6LL', address='5 Alexandra Road')\` still returns the single cert
- [x] Live test: \`property_yield(postcode='DE12 6LL')\` returns yield 4.43% computed against rentals found at 1.5mi
- [ ] Manual smoke after deploy: confirm same results via MCP Inspector

## Out of scope

- \`RentalAnalysis\` vs \`YieldAnalysis\` field-name drift (\`median_rent_monthly\` vs \`median_monthly_rent\`) — known issue, separate cleanup
- \`PropertyReportService\` still uses \`last_sale.price\` for yield in the REST/CLI surface (the v1.10.x yield bug) — the MCP composition tool is gone (replaced by prompt), so this only affects \`POST /v1/property/report\` consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)