### PR TITLE
fix: apply _slim + exclude_none to remaining plain MCP tools

### DIFF
--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -158,12 +158,13 @@ async def rental_analysis(
     fields when escalation occurs.
     """
     from property_core import analyze_rentals
-    return (await analyze_rentals(
+    result = await analyze_rentals(
         postcode=postcode,
         radius=radius,
         purchase_price=purchase_price,
         auto_escalate=auto_escalate,
-    )).model_dump()
+    )
+    return _slim(result.model_dump(mode="json", exclude_none=True))
 
 
 @mcp.tool(annotations={"readOnlyHint": True})
@@ -222,12 +223,13 @@ def stamp_duty(
 ) -> dict:
     """UK Stamp Duty Land Tax (SDLT) calculation with full breakdown."""
     from property_core import calculate_stamp_duty
-    return calculate_stamp_duty(
+    result = calculate_stamp_duty(
         price=price,
         additional_property=additional_property,
         first_time_buyer=first_time_buyer,
         non_resident=non_resident,
-    ).model_dump()
+    )
+    return _slim(result.model_dump(mode="json", exclude_none=True))
 
 
 @mcp.tool(annotations={"readOnlyHint": True})
@@ -327,7 +329,7 @@ async def property_blocks(
             months=months,
         )
     )
-    return result.model_dump()
+    return _slim(result.model_dump(mode="json", exclude_none=True))
 
 
 @mcp.tool(annotations={"readOnlyHint": True})
@@ -335,7 +337,9 @@ def company_search(name: str) -> dict:
     """Search Companies House for a company by name."""
     from property_core import CompaniesHouseClient
     result = CompaniesHouseClient().search(name)
-    return result.model_dump() if result else {"items": []}
+    if not result:
+        return {"items": []}
+    return _slim(result.model_dump(mode="json", exclude_none=True))
 
 
 @mcp.tool(annotations={"readOnlyHint": True})
@@ -359,10 +363,10 @@ def ppd_transactions(
         limit=limit,
         property_type=property_type,
     )
-    return {
+    return _slim({
         **{k: v for k, v in result.items() if k != "results"},
-        "results": [t.model_dump() for t in result["results"]],
-    }
+        "results": [t.model_dump(mode="json", exclude_none=True) for t in result["results"]],
+    })
 
 
 @mcp.resource("councils://list")


### PR DESCRIPTION
## Summary

Finishes the slim sweep that started in PR #11. PR #11 applied \`_slim()\` + \`exclude_none=True\` to \`property_comps\` only — the other plain MCP tools that return Pydantic models with optional fields kept emitting null bloat.

Surfaced today via MCP Inspector: \`ppd_transactions\` for DE12 6LL was returning 10 EPC null fields per transaction (\`epc_match\`, \`epc_match_score\`, \`epc_floor_area_sqm\`, etc.) + top-level \`raw: null\`. ~190 wasted tokens per transaction.

## Tools fixed

| Tool | Was | Now |
|---|---|---|
| \`ppd_transactions\` | bare per-txn \`model_dump()\` + raw=null at top | \`_slim(\{... \"results\": [t.model_dump(mode=\"json\", exclude_none=True) for t in ...]\})\` |
| \`property_blocks\` | bare \`model_dump()\` | \`_slim(result.model_dump(mode=\"json\", exclude_none=True))\` |
| \`rental_analysis\` | bare \`model_dump()\` | same |
| \`stamp_duty\` | bare \`model_dump()\` | same |
| \`company_search\` | bare \`model_dump()\` | same |

Tools already cleaned in earlier PRs (\`property_comps\`, \`property_yield\`, \`property_epc\`) unchanged.

## Live verification

DE12 6LL \`ppd_transactions(limit=2)\`:
- **Before**: ~2k+ bytes for 2 txns, 25 keys per txn, top-level \`raw: null\`
- **After**: 782 bytes for 2 txns, 14 keys per txn, no top-level \`raw\`

## Test plan

- [x] \`pytest -q\` — 128 passed (same count, no regressions)
- [x] Live test on each fixed tool — no nulls visible
- [ ] Manual smoke via MCP Inspector after deploy

## Out of scope (separate concerns)

Downstream MCP servers (\`uk-property-mcp\`, \`property-descriptions-mcp\`) have the same pattern in many of their tools — they call \`property_core.PPDService\` etc. and emit the same nulls because their local \`_slim\` helpers strip specific keys but don't drop null fields. Background audit identified 9 of 14 bloated tools in uk-property-mcp and 1 of 3 in property-descriptions-mcp. Worth fixing in those repos in a follow-up PR if you want consistent slim across the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)