### PR TITLE
fix(security): close Rightmove SSRF, correct EPC/MEES text, fix record_status crash (v1.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v1.13.0 (2026-08-24) — security hotfix
+
+### Security
+- **Server-Side Request Forgery (SSRF) in the Rightmove fetch paths — fixed.** `fetch_listing()` passed any string beginning with `http` straight to the HTTP client with no host or scheme validation, and `fetch_listings()` accepted an arbitrary search URL. Both were reachable from unauthenticated surfaces (the `rightmove_listing` MCP tool, `GET /v1/rightmove/listings`, and `GET /v1/rightmove/listing/{id}`), giving an unauthenticated caller a server-side fetch primitive against internal addresses (verified against cloud-metadata, localhost, and userinfo-trick targets). URLs are now validated against an exact host allowlist (`property_core/url_safety.py`): https only, no userinfo, default port only, no suffix or substring host matching. Redirects are resolved and re-validated per hop instead of being followed automatically, and responses are size-capped.
+- **`/img` proxy host check bypass (MCP app) — fixed.** The proxy validated with `url.startswith("https://media.rightmove.co.uk")`, which lookalike hosts (`…co.uk.evil.example`) and userinfo tricks (`…co.uk@evil.example`) both defeat. It now validates with httpx's own URL parser — the same parser that issues the request, so the two cannot disagree about the host — and follows redirects manually with per-hop re-validation. The response is streamed with a running byte cap (a buffered `get()` materialises the whole body before any size check, so the cap would not have protected the 512MB VM), non-image `Content-Type`s are refused rather than echoed back on our own origin, and `X-Content-Type-Options: nosniff` is set.
+
+### Breaking Changes
+- **REST** — `GET /v1/rightmove/listings` no longer accepts `search_url`. It now takes the same structured filters as `/v1/rightmove/search-url` (`postcode`, `property_type`, `building_type`, `min_price`, `max_price`, `min_bedrooms`, `max_bedrooms`, `radius`, `sort_by`) and builds the Rightmove URL server-side. `postcode` is required.
+- **REST** — `GET /v1/rightmove/listing/{property_id}` now constrains `property_id` to 1–12 digits at the routing layer; non-numeric values return 422 instead of being fetched.
+- **MCP** — the `rightmove_listing` tool parameter is renamed `property_url_or_id` → `property_id` and accepts the numeric Rightmove ID only.
+- **CLI** — `property-cli rightmove listings` now takes a postcode plus filters instead of a raw search URL (e.g. `property-cli rightmove listings "SW1A 1AA" --property-type sale --radius 0.25`). `property-cli rightmove listing` takes the numeric ID only.
+- **Library (source-compatible)** — `fetch_listing()` still accepts both a numeric ID **and** a canonical Rightmove listing URL (`https://www.rightmove.co.uk/properties/<id>`), and keeps its original parameter name `property_url_or_id`, so both positional and keyword callers (`fetch_listing(property_url_or_id=...)`) are unaffected. The difference is that a URL is now used *only* to extract the numeric ID: it is host/scheme-validated, the ID is parsed out, and the fetched URL is rebuilt internally — the caller's URL is never requested. Anything else (another host, a userinfo or lookalike-host trick, a non-listing path such as `/redirect?to=…`, a non-https scheme or non-default port) raises `ValueError`/`UnsafeURLError` before any request. New helper `extract_property_id()` is exported for callers that want to normalise a reference themselves.
+- **Library** — `fetch_listings(search_url)` still takes a URL but validates it against the Rightmove host allowlist, raising `UnsafeURLError`. Build search URLs with `RightmoveLocationAPI.build_search_url()`.
+
+**Upgrade note for downstream servers** (`property-descriptions-mcp`, `uk-property-mcp`): no code change is required to keep working on this release — a Rightmove listing URL passed to `fetch_listing()` is still accepted. Only non-Rightmove or non-listing URLs, which previously would have been fetched server-side, now raise.
+
+### Fixed
+- `property-cli rightmove listing` passed `include_raw=` to `fetch_listing()`, which has never accepted that parameter — the core-mode branch raised `TypeError` on every invocation. `--include-raw` now works as documented.
+- `tests/test_mcp_server_epc.py` still imported `get_epc_certificate`, renamed to `epc_certificate` in v1.12.0 — two tests had been failing since that rename.
+- **Incorrect EPC/MEES regulatory guidance.** Both MCP servers stated, in the `epc-ratings://reference` resource *and* in the `investment_analysis` prompt, that EPC band C has been required for new tenancies since April 2025 and that existing tenancies must comply by 2028. Verified against gov.uk: the current legal minimum for privately rented domestic property in England and Wales is band **E** (since 1 April 2020, subject to exemptions), and the proposed band C standard has a single compliance date of **1 October 2030** for all tenancies — an earlier date for new tenancies was explicitly ruled out, and the standard is not yet in force. Because this text reached users through a resource and a prompt, it could distort an analysis with no tool call involved.
+- `PPDService.search_transactions(record_status=...)` / `PricePaidDataClient.sparql_search(record_status=...)` raised `AttributeError` on the first returned row. SPARQL search returns `PPDTransaction`, which has no `record_status` field — that field belongs to `PPDTransactionRecord`, built only by the Linked Data `get_transaction_record()` lookup. The parameter now raises `UnsupportedRecordStatusFilterError` (a `ValueError`) immediately, before any query is issued, pointing callers at `transaction_record()`. `GET /v1/ppd/transactions?record_status=...` returns 422 instead of a misleading 502. Real SPARQL-level record-status filtering is deliberately deferred until the triple shape is verified against the live Land Registry ontology.
+
+### Developer Experience
+- `pyproject.toml` now sets `testpaths = ["tests"]`, and `scripts/epc_token_test.py` is renamed to `scripts/measure_epc_tokens.py`. Pytest's default `*_test.py` glob was matching that script, so a bare `pytest` from the repo root would import and execute a live-network measurement script during collection.
+- Documented test commands in `CLAUDE.md` and `GUIDELINES.md` were missing `--extra api`, so they could not collect `test_http_metrics.py` or `test_mcp_server.py`. All four extras (`dev`, `api`, `apps`, `cli`) are now documented.
+
 ## v1.12.0 (2026-05-17)
 
 ### Added
@@ -24,7 +50,7 @@
 - `councils://list` — full UK planning portal registry (99 councils) as a queryable resource. LLMs can read this once instead of repeatedly calling `planning_search` for individual lookups.
 - `council://{code}` — single-council profile by code/slug.
 - `sdlt-bands://current` — April 2025 UK Stamp Duty Land Tax band schedule, including additional-property + non-resident surcharges and first-time buyer relief. LLMs can cite the bands directly without forcing a `stamp_duty` calculator call.
-- `epc-ratings://reference` — A–G EPC band definitions, SAP score ranges, and regulatory context (April 2025 rental minimum of band C). Grounds LLM EPC explanations in canonical data rather than training-data recall.
+- `epc-ratings://reference` — A–G EPC band definitions, SAP score ranges, and regulatory context (April 2025 rental minimum of band C). Grounds LLM EPC explanations in canonical data rather than training-data recall. **⚠️ Correction: the regulatory claim shipped in this release was wrong — the current minimum is band E, and band C is proposed for 1 October 2030. Fixed in v1.13.0 above; this line is left as-published for history.**
 
 ### Removed — dev utilities
 - `component_test` and `image_test` MCP tools removed from `propertydata.fly.dev/mcp`. These were internal dev artifacts that polluted the production tool selection surface.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,12 +38,13 @@ uv run --extra cli property-cli analysis rental "NG1 1AA"
 # CLI targeting running API (add --api-url)
 uv run --extra cli property-cli ppd comps "SW1A 1AA" --api-url http://localhost:8000
 
-# Tests
-uv run --extra dev --extra apps pytest                        # unit tests (mocked)
-RUN_LIVE_TESTS=1 uv run --extra dev --extra apps pytest       # live network tests
+# Tests — all four extras are required: `api` provides fastapi (test_http_metrics,
+# test_mcp_server), `apps` provides fastmcp[apps], `cli` provides typer.
+uv run --extra dev --extra api --extra apps --extra cli pytest                  # unit tests (mocked)
+RUN_LIVE_TESTS=1 uv run --extra dev --extra api --extra apps --extra cli pytest # live network tests
 
 # Single test
-uv run --extra dev --extra apps pytest tests/test_ppd_service_live.py -v
+uv run --extra dev --extra api --extra apps --extra cli pytest tests/test_ppd_service_live.py -v
 ```
 
 ## Fly.io Deployment — Two Apps, One Repo

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -82,13 +82,16 @@ Three-layer pattern:
 
 **Unit tests** (mocked, default):
 ```bash
-uv run --extra dev pytest -v
+uv run --extra dev --extra api --extra apps --extra cli pytest -v
 ```
 
 **Live integration tests** (real network calls):
 ```bash
-RUN_LIVE_TESTS=1 uv run --extra dev pytest -v
+RUN_LIVE_TESTS=1 uv run --extra dev --extra api --extra apps --extra cli pytest -v
 ```
+
+All four extras are required: `api` provides fastapi (needed by `test_http_metrics.py`
+and `test_mcp_server.py`), `apps` provides fastmcp[apps], `cli` provides typer.
 
 Tests skip gracefully on 503/network errors.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -68,12 +68,13 @@ property-cli rightmove search-url "SW1A 1AA" --property-type sale --radius 0.25
 # Build a search URL for rentals
 property-cli rightmove search-url "SW1A 1AA" --property-type rent --radius 0.25
 
-# Fetch listings from a search URL
-property-cli rightmove listings "<search_url>" --max-pages 1
+# Fetch listings for a postcode (the search URL is built for you)
+property-cli rightmove listings "SW1A 1AA" --property-type sale --radius 0.25 --max-pages 1
 
 # Fetch full details for a single listing (tenure, service charge, ground rent, etc.)
+# Takes the numeric property ID only — full URLs are not accepted.
 property-cli rightmove listing 161151632
-property-cli rightmove listing "https://www.rightmove.co.uk/properties/161151632" --include-raw
+property-cli rightmove listing 161151632 --include-raw
 ```
 
 **All listings** include: `listing_status` (e.g., "SOLD_STC", "UNDER_OFFER"), `tags` (all status tags as list), `latitude`/`longitude` (direct access).
@@ -208,8 +209,8 @@ Results include `locality` and `district` fields from the Land Registry address 
 ### Rightmove
 - `GET /v1/rightmove/search-url?postcode=SW1A%201AA&property_type=sale&radius=0.25` — Sales
 - `GET /v1/rightmove/search-url?postcode=SW1A%201AA&property_type=rent&radius=0.25` — Rentals
-- `GET /v1/rightmove/listings?search_url=<url>&max_pages=1`
-- `GET /v1/rightmove/listing/{property_id}` — Full listing detail (tenure, costs, floorplans)
+- `GET /v1/rightmove/listings?postcode=SW1A%201AA&property_type=sale&radius=0.25&max_pages=1` — takes the same filters as `search-url`; the Rightmove URL is built server-side
+- `GET /v1/rightmove/listing/{property_id}` — Full listing detail (tenure, costs, floorplans). `property_id` must be the numeric Rightmove ID.
 
 All listing results include `raw` with the full `__NEXT_DATA__` property object.
 Listing detail results include `raw` with the full `PAGE_MODEL.propertyData` dict.

--- a/app/api/v1/ppd.py
+++ b/app/api/v1/ppd.py
@@ -14,6 +14,7 @@ from app.schemas.ppd import (
 )
 from property_core.block_service import analyze_blocks
 from property_core.models.block import BlockAnalysisResponse
+from property_core.ppd_client import UnsupportedRecordStatusFilterError
 from property_core.ppd_service import PPDService
 
 router = APIRouter(prefix="/ppd", tags=["ppd"])
@@ -46,7 +47,13 @@ def transactions(
     property_type: Optional[str] = Query(None, description="D/S/T/F/O"),
     estate_type: Optional[str] = Query(None, description="F/L"),
     transaction_category: Optional[str] = Query(None, description="A/B"),
-    record_status: Optional[str] = Query(None, description="A/C/D"),
+    record_status: Optional[str] = Query(
+        None,
+        description=(
+            "Unsupported on this endpoint — any value returns 422. Record status is "
+            "only available per-transaction via GET /ppd/transaction/{transaction_id}."
+        ),
+    ),
     new_build: Optional[bool] = None,
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -79,6 +86,11 @@ def transactions(
             include_raw=include_raw,
         )
         return PPDSearchResponse(**result)
+    except UnsupportedRecordStatusFilterError as exc:
+        # Caller error, not an upstream failure — deliberately narrow so that
+        # other ValueErrors (internal bugs) keep surfacing as 502 rather than
+        # being misreported as bad input.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"PPD search failed: {exc}") from exc
 

--- a/app/api/v1/rightmove.py
+++ b/app/api/v1/rightmove.py
@@ -6,7 +6,7 @@ from functools import partial
 from typing import Literal, Optional
 
 import anyio
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Path, Query
 
 from app.schemas.rightmove import (
     RightmoveListingDetailResponse,
@@ -54,12 +54,39 @@ async def search_url(
 
 @router.get("/listings", response_model=RightmoveListingsResponse)
 async def listings(
-    search_url: str = Query(..., min_length=10),
+    postcode: str = Query(..., min_length=2),
+    property_type: Literal["sale", "rent"] = "sale",
+    building_type: Optional[str] = Query(None, description="F=flat, D=detached, S=semi, T=terraced"),
+    min_price: Optional[int] = Query(None, ge=0),
+    max_price: Optional[int] = Query(None, ge=0),
+    min_bedrooms: Optional[int] = Query(None, ge=0),
+    max_bedrooms: Optional[int] = Query(None, ge=0),
+    radius: Optional[float] = Query(None, ge=0),
+    sort_by: Optional[str] = Query(None, description="newest|oldest|price_low|price_high|most_reduced"),
     max_pages: Optional[int] = Query(None, ge=1, le=20),
     include_raw: bool = Query(False, description="Ignored (raw is always included in v2)"),
 ) -> RightmoveListingsResponse:
-    """Fetch listing results from a Rightmove search URL."""
+    """Fetch listing results for a postcode.
+
+    Takes the same structured filters as ``/search-url`` and builds the Rightmove
+    URL server-side. This endpoint previously accepted an arbitrary ``search_url``
+    and fetched it, which was an SSRF vector; raw URLs are no longer accepted.
+    """
     try:
+        search_url = await anyio.to_thread.run_sync(
+            partial(
+                RightmoveLocationAPI().build_search_url,
+                postcode,
+                property_type=property_type,
+                building_type=building_type,
+                min_price=min_price,
+                max_price=max_price,
+                min_bedrooms=min_bedrooms,
+                max_bedrooms=max_bedrooms,
+                radius=radius,
+                sort_by=sort_by,
+            )
+        )
         results = await anyio.to_thread.run_sync(
             partial(fetch_listings, search_url, max_pages=max_pages)
         )
@@ -70,14 +97,24 @@ async def listings(
 
 @router.get("/listing/{property_id}", response_model=RightmoveListingDetailResponse)
 async def listing_detail(
-    property_id: str,
+    property_id: str = Path(
+        ..., pattern=r"^[0-9]{1,12}$", description="Numeric Rightmove property ID"
+    ),
     include_raw: bool = Query(False, description="Ignored (raw is always included in v2)"),
 ) -> RightmoveListingDetailResponse:
-    """Fetch full details for an individual Rightmove property listing."""
+    """Fetch full details for an individual Rightmove property listing.
+
+    ``property_id`` must be the numeric Rightmove ID. Full URLs are rejected at
+    the routing layer (422) — they were previously fetched server-side.
+    """
     try:
         result = await anyio.to_thread.run_sync(
             partial(fetch_listing, property_id)
         )
         return RightmoveListingDetailResponse(result=result)
+    # No `except ValueError -> 422` here: the Path regex above is the only ID
+    # gate needed, and pydantic's ValidationError subclasses ValueError, so
+    # catching it would report an upstream page-shape change as caller error
+    # (and leak internal field names) instead of paging on a 502.
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"Rightmove listing detail failed: {exc}") from exc

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -417,19 +417,33 @@ async def rightmove_search(
 @mcp.tool(annotations={"readOnlyHint": True})
 @_timed_tool
 async def rightmove_listing(
-    property_url_or_id: str,
+    property_id: str,
     include_images: bool = False,
     max_images: int = 3,
 ) -> dict | ToolResult:
-    """Full detail for a single Rightmove listing (URL or numeric ID).
+    """Full detail for a single Rightmove listing.
 
+    property_id is the numeric Rightmove property ID (the digits at the end of a
+    rightmove.co.uk/properties/... URL), max 12 digits. Full URLs are not accepted.
     include_images fetches and embeds photos and floorplans as MCP image content.
     max_images caps the number of property photos (default 3); floorplans always included.
     """
+    import re
+
     import anyio
     from property_core import fetch_listing
 
-    result = await anyio.to_thread.run_sync(lambda: fetch_listing(property_url_or_id))
+    # This surface is numeric-ID-only by design. The library still accepts a
+    # canonical listing URL for downstream compatibility, but the public MCP
+    # tool deliberately does not widen its input.
+    pid = (property_id or "").strip()
+    if not re.fullmatch(r"[0-9]{1,12}", pid):
+        raise ValueError(
+            f"property_id must be a numeric Rightmove property ID (1-12 digits), got {property_id!r}. "
+            "Use the digits at the end of a rightmove.co.uk/properties/... URL."
+        )
+
+    result = await anyio.to_thread.run_sync(lambda: fetch_listing(pid))
 
     if not include_images:
         return result.model_dump(exclude={"images", "floorplans"})
@@ -589,14 +603,14 @@ def epc_ratings_resource() -> str:
         "ratings": [
             {"band": "A", "score_min": 92, "score_max": 100, "description": "Most efficient — very low running costs (near-zero or new-build standard)."},
             {"band": "B", "score_min": 81, "score_max": 91, "description": "Highly efficient — modern home with good insulation and heating."},
-            {"band": "C", "score_min": 69, "score_max": 80, "description": "Above average — typical for recent builds or well-improved older homes. Required minimum for new rentals from April 2025."},
+            {"band": "C", "score_min": 69, "score_max": 80, "description": "Above average — typical for recent builds or well-improved older homes. Proposed future minimum for rented homes (band C by 1 October 2030); not yet in force."},
             {"band": "D", "score_min": 55, "score_max": 68, "description": "Average — typical UK home as-built. Improvement potential usually high."},
-            {"band": "E", "score_min": 39, "score_max": 54, "description": "Below average — minimum legal standard for rental properties until April 2025."},
+            {"band": "E", "score_min": 39, "score_max": 54, "description": "Below average — the current legal minimum standard for rented homes in England and Wales (since 1 April 2020), subject to exemptions."},
             {"band": "F", "score_min": 21, "score_max": 38, "description": "Poor — running costs significantly above average, often single-glazed or uninsulated."},
             {"band": "G", "score_min": 1, "score_max": 20, "description": "Very poor — typically pre-1900 stock with no insulation upgrades."},
         ],
         "methodology": "Scores are calculated via the Standard Assessment Procedure (SAP 2012). Each property gets a current rating and a potential rating after recommended improvements.",
-        "regulation_note": "Since April 2025, new tenancies in England and Wales require EPC band C or above. Existing tenancies must comply by 2028 (proposed).",
+        "regulation_note": "The current legal minimum for privately rented domestic property in England and Wales is EPC band E (since 1 April 2020), subject to registered exemptions. The government has proposed raising this to band C, with a single compliance date of 1 October 2030 applying to all tenancies — an earlier date for new tenancies was explicitly ruled out. The band C standard is not yet in force.",
         "source": "https://www.gov.uk/government/collections/energy-performance-certificates",
     }
     return json.dumps(data, ensure_ascii=False, indent=2)
@@ -649,7 +663,7 @@ Run these tool calls in order:
 
 2. `property_yield(postcode='{postcode}', months=24)` — area gross yield from median sale and median rent.
 
-3. `property_epc(postcode='{postcode}', address='{address}')` — energy rating. Note: from April 2025, England + Wales rentals must reach EPC C. A property rated D-G needs works before letting.
+3. `property_epc(postcode='{postcode}', address='{address}')` — energy rating. Note: the current legal minimum for England + Wales rentals is EPC band E; a band C minimum is proposed for 1 October 2030 but is not yet in force. A property rated F-G cannot be let today without a registered exemption.
 
 4. `stamp_duty(price={purchase_price}, additional_property={additional_property}, first_time_buyer={first_time_buyer}, non_resident={non_resident})` — calculate SDLT on this purchase including any surcharges.
 
@@ -658,7 +672,7 @@ Then produce an investment summary (5–7 short paragraphs):
 - **Recent sale history**: years and prices, capital growth implied (if multiple sales exist).
 - **Gross yield estimate**: median monthly rent × 12 / {price_fmt} × 100 for a property-specific yield against THIS purchase price. Classify it (strong ≥6%, average 4–6%, weak <4%).
 - **Net yield rough estimate**: subtract a conservative 25-30% from gross for management fees, maintenance, voids, insurance. Acknowledge this is a rule-of-thumb, not tax-adjusted.
-- **EPC compliance**: rating, regulatory note (April 2025 minimum is C), and rough cost of upgrades if needed.
+- **EPC compliance**: rating, regulatory note (current minimum is band E; band C proposed for 1 October 2030, not yet in force), and rough cost of upgrades if needed.
 - **Tax cost**: SDLT total and effective rate from the stamp_duty call.
 - **Key risks**: 2–3 — thin local market (if sale_count is low), historical price decline, EPC works needed, etc.
 

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -81,10 +81,19 @@
       <button type="submit">Get search URL</button>
       <pre></pre>
     </form>
-    <p>Step 2: fetch listings for a search URL.</p>
+    <p>Step 2: fetch listings for a postcode (the search URL is built server-side).</p>
     <form onsubmit="event.preventDefault(); callApi(this, '/v1/rightmove/listings')">
-      <label>Search URL
-        <input name="search_url" placeholder="paste search URL from step 1" required>
+      <label>Postcode
+        <input name="postcode" placeholder="e.g. SW1A 1AA" required>
+      </label>
+      <label>Type
+        <select name="property_type">
+          <option value="sale">sale</option>
+          <option value="rent">rent</option>
+        </select>
+      </label>
+      <label>Radius (miles)
+        <input name="radius" type="number" step="0.25" value="0.25">
       </label>
       <label>Max pages
         <input name="max_pages" type="number" value="1">

--- a/docs/examples.py
+++ b/docs/examples.py
@@ -599,7 +599,7 @@ def example_api():
         curl "http://localhost:8000/api/v1/rightmove/search-url?postcode=NG1+1GF&property_type=sale&radius=0.5"
 
     Rightmove Listings:
-        curl "http://localhost:8000/api/v1/rightmove/listings?search_url=https://www.rightmove.co.uk/property-for-sale/find.html?locationIdentifier=POSTCODE%255E1694339&radius=0.5"
+        curl "http://localhost:8000/api/v1/rightmove/listings?postcode=NG1+1GF&property_type=sale&radius=0.5&max_pages=1"
 
     EPC Search:
         curl "http://localhost:8000/api/v1/epc/search?q=10+Downing+Street,+SW1A+2AA"

--- a/property_app/server.py
+++ b/property_app/server.py
@@ -93,14 +93,14 @@ def epc_ratings_resource() -> str:
         "ratings": [
             {"band": "A", "score_min": 92, "score_max": 100, "description": "Most efficient — very low running costs (near-zero or new-build standard)."},
             {"band": "B", "score_min": 81, "score_max": 91, "description": "Highly efficient — modern home with good insulation and heating."},
-            {"band": "C", "score_min": 69, "score_max": 80, "description": "Above average — typical for recent builds or well-improved older homes. Required minimum for new rentals from April 2025."},
+            {"band": "C", "score_min": 69, "score_max": 80, "description": "Above average — typical for recent builds or well-improved older homes. Proposed future minimum for rented homes (band C by 1 October 2030); not yet in force."},
             {"band": "D", "score_min": 55, "score_max": 68, "description": "Average — typical UK home as-built. Improvement potential usually high."},
-            {"band": "E", "score_min": 39, "score_max": 54, "description": "Below average — minimum legal standard for rental properties until April 2025."},
+            {"band": "E", "score_min": 39, "score_max": 54, "description": "Below average — the current legal minimum standard for rented homes in England and Wales (since 1 April 2020), subject to exemptions."},
             {"band": "F", "score_min": 21, "score_max": 38, "description": "Poor — running costs significantly above average, often single-glazed or uninsulated."},
             {"band": "G", "score_min": 1, "score_max": 20, "description": "Very poor — typically pre-1900 stock with no insulation upgrades."},
         ],
         "methodology": "Scores are calculated via the Standard Assessment Procedure (SAP 2012). Each property gets a current rating and a potential rating after recommended improvements.",
-        "regulation_note": "Since April 2025, new tenancies in England and Wales require EPC band C or above. Existing tenancies must comply by 2028 (proposed).",
+        "regulation_note": "The current legal minimum for privately rented domestic property in England and Wales is EPC band E (since 1 April 2020), subject to registered exemptions. The government has proposed raising this to band C, with a single compliance date of 1 October 2030 applying to all tenancies — an earlier date for new tenancies was explicitly ruled out. The band C standard is not yet in force.",
         "source": "https://www.gov.uk/government/collections/energy-performance-certificates",
     }
     return json.dumps(data, ensure_ascii=False, indent=2)
@@ -147,7 +147,7 @@ Run these tool calls in order:
 
 2. `get_yield(postcode='{postcode}', months=24)` — area gross yield.
 
-3. `epc_lookup(postcode='{postcode}', address='{address}')` — energy rating. From April 2025, England + Wales rentals must reach EPC C.
+3. `epc_lookup(postcode='{postcode}', address='{address}')` — energy rating. The current legal minimum for England + Wales rentals is EPC band E; a band C minimum is proposed for 1 October 2030 but is not yet in force.
 
 4. `stamp_duty(price={purchase_price}, additional_property={additional_property}, first_time_buyer={first_time_buyer}, non_resident={non_resident})` — calculate SDLT.
 
@@ -260,24 +260,117 @@ async def smithery_server_card(request):
     return JSONResponse({"serverInfo": {"name": "property-app", "version": _pkg_version("property-shared")}})
 
 
+_IMG_ALLOWED_HOSTS = frozenset({"media.rightmove.co.uk"})
+_IMG_MAX_BYTES = 10 * 1024 * 1024
+_IMG_MAX_REDIRECTS = 5
+_IMG_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+# NB: a raw space is NOT disallowed here. Starlette decodes "+" in a query
+# string to " ", and Rightmove media paths legitimately contain "+", so
+# rejecting spaces would silently break image fetching. Host confusion is
+# already prevented by parsing with httpx below; backslashes and control
+# characters remain rejected.
+_IMG_DISALLOWED_CHARS = frozenset("\\\t\n\r\x00\x7f")
+_IMG_ALLOWED_CONTENT_TYPES = ("image/",)
+
+
+def _validated_img_url(raw: str):
+    """Validate an image URL using httpx's own parser and return an httpx.URL.
+
+    Deliberately does NOT use urllib.parse: this request is issued by httpx, so
+    validating with a different parser could let the two disagree about the host
+    (the exact bypass class this check exists to prevent). Returns None if unsafe.
+    """
+    import httpx
+
+    if not raw or _IMG_DISALLOWED_CHARS & set(raw):
+        return None
+    try:
+        url = httpx.URL(raw)
+    except httpx.InvalidURL:
+        return None
+    if url.scheme != "https":
+        return None
+    if url.userinfo:
+        return None
+    if url.port not in (None, 443):
+        return None
+    if (url.host or "").lower() not in _IMG_ALLOWED_HOSTS:
+        return None
+    return url
+
+
 @mcp.custom_route("/img", methods=["GET"])
 async def proxy_image(request):
-    """Proxy external images through our domain to avoid CSP blocks."""
+    """Proxy Rightmove images through our domain to avoid CSP blocks.
+
+    Only allowlisted hosts are fetched, and redirects are followed manually so
+    each hop is re-validated — an allowlisted host must not be able to bounce
+    this server to an arbitrary internal address.
+    """
     import httpx
     from starlette.responses import Response
 
-    url = request.query_params.get("url", "")
-    if not url or not url.startswith("https://media.rightmove.co.uk"):
+    url = _validated_img_url(request.query_params.get("url", ""))
+    if url is None:
         return Response(status_code=400, content=b"Invalid URL")
 
     async with httpx.AsyncClient() as client:
-        resp = await client.get(url, follow_redirects=True, timeout=10.0)
+        for _ in range(_IMG_MAX_REDIRECTS + 1):
+            # Stream rather than buffer: a non-streaming get() materialises the
+            # whole body in memory before any size check, so the cap would only
+            # stop us forwarding it — not stop a 2GB body OOMing a 512MB VM.
+            async with client.stream(
+                "GET", url, follow_redirects=False, timeout=10.0
+            ) as resp:
+                if resp.status_code in _IMG_REDIRECT_STATUSES:
+                    location = resp.headers.get("Location")
+                    if not location:
+                        return Response(status_code=502, content=b"Bad redirect")
+                    try:
+                        # httpx.URL.join — the same parser that issues the next
+                        # request. join() itself can raise on hostile values
+                        # (e.g. "////evil.example"), so it is inside the try.
+                        joined = str(url.join(location))
+                    except httpx.InvalidURL:
+                        return Response(status_code=400, content=b"Invalid redirect target")
+                    nxt = _validated_img_url(joined)
+                    if nxt is None:
+                        return Response(status_code=400, content=b"Invalid redirect target")
+                    url = nxt
+                    continue
 
-    return Response(
-        content=resp.content,
-        media_type=resp.headers.get("content-type", "image/jpeg"),
-        headers={"Cache-Control": "public, max-age=86400"},
-    )
+                if resp.status_code >= 400:
+                    return Response(status_code=502, content=b"Upstream error")
+
+                content_type = resp.headers.get("content-type", "image/jpeg")
+                # Only ever re-serve images. media.rightmove.co.uk carries
+                # third-party-supplied files; echoing an arbitrary Content-Type
+                # would let one be served as HTML on this app's own origin.
+                if not content_type.lower().startswith(_IMG_ALLOWED_CONTENT_TYPES):
+                    return Response(status_code=502, content=b"Unsupported content type")
+
+                declared = resp.headers.get("Content-Length")
+                if declared and declared.isdigit() and int(declared) > _IMG_MAX_BYTES:
+                    return Response(status_code=502, content=b"Image too large")
+
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in resp.aiter_bytes():
+                    total += len(chunk)
+                    if total > _IMG_MAX_BYTES:
+                        return Response(status_code=502, content=b"Image too large")
+                    chunks.append(chunk)
+
+                return Response(
+                    content=b"".join(chunks),
+                    media_type=content_type,
+                    headers={
+                        "Cache-Control": "public, max-age=86400",
+                        "X-Content-Type-Options": "nosniff",
+                    },
+                )
+
+    return Response(status_code=502, content=b"Too many redirects")
 
 
 class _AcceptNormalizer:

--- a/property_cli/main.py
+++ b/property_cli/main.py
@@ -542,17 +542,42 @@ def rightmove_search_url(
 
 @rightmove.command("listings")
 def rightmove_listings(
-    search_url: str = typer.Argument(...),
+    postcode: list[str] = typer.Argument(..., help="Postcode or outcode, e.g. 'NG1 1AA'"),
+    property_type: str = typer.Option("sale", help="sale or rent"),
+    building_type: Optional[str] = typer.Option(None, help="F=flat, D=detached, S=semi, T=terraced"),
+    min_price: Optional[int] = typer.Option(None, help="Minimum price"),
+    max_price: Optional[int] = typer.Option(None, help="Maximum price"),
+    min_bedrooms: Optional[int] = typer.Option(None, help="Minimum bedrooms"),
+    max_bedrooms: Optional[int] = typer.Option(None, help="Maximum bedrooms"),
+    radius: Optional[float] = typer.Option(None, help="Search radius in miles"),
+    sort_by: Optional[str] = typer.Option(
+        None, help="newest|oldest|price_low|price_high|most_reduced"
+    ),
     max_pages: Optional[int] = typer.Option(1),
     rate_limit_seconds: float = typer.Option(0.6, help="Delay between pages"),
     api_url: Optional[str] = typer.Option(None, help="Call API instead of core"),
 ) -> None:
+    """Fetch Rightmove listings for a postcode.
+
+    The search URL is built from these filters. Raw search URLs are no longer
+    accepted (they were fetched server-side, an SSRF vector).
+    """
+    postcode_value = _join_tokens(postcode)
+    filters = {
+        "property_type": property_type,
+        "building_type": building_type,
+        "min_price": min_price,
+        "max_price": max_price,
+        "min_bedrooms": min_bedrooms,
+        "max_bedrooms": max_bedrooms,
+        "radius": radius,
+        "sort_by": sort_by,
+    }
     http = _maybe_http_client(api_url)
     if http:
-        data = http.get(
-            "/v1/rightmove/listings",
-            params={"search_url": search_url, "max_pages": max_pages},
-        )
+        params = {"postcode": postcode_value, "max_pages": max_pages}
+        params.update({k: v for k, v in filters.items() if v is not None})
+        data = http.get("/v1/rightmove/listings", params=params)
         listings = [
             typer.SimpleNamespace(
                 price=item.get("price"),
@@ -562,6 +587,10 @@ def rightmove_listings(
             for item in data.get("results", [])
         ]
     else:
+        search_url = RightmoveLocationAPI().build_search_url(
+            postcode_value,
+            **{k: v for k, v in filters.items() if v is not None},
+        )
         listings = fetch_listings(
             search_url,
             max_pages=max_pages,
@@ -584,26 +613,41 @@ def rightmove_listings(
 
 @rightmove.command("listing")
 def rightmove_listing(
-    url_or_id: str = typer.Argument(..., help="Rightmove property URL or numeric ID"),
+    property_id: str = typer.Argument(..., help="Numeric Rightmove property ID (max 12 digits)"),
     include_raw: bool = typer.Option(False, "--include-raw", help="Include raw PAGE_MODEL data"),
     api_url: Optional[str] = typer.Option(None, help="Call API instead of core"),
 ) -> None:
-    """Fetch full details for an individual Rightmove listing."""
+    """Fetch full details for an individual Rightmove listing.
+
+    Takes the numeric property ID only — full URLs are not accepted.
+    """
     http = _maybe_http_client(api_url)
     if http:
-        # Extract property ID from URL if needed
-        prop_id = url_or_id.strip().rstrip("/").split("/")[-1] if "/" in url_or_id else url_or_id
         data = http.get(
-            f"/v1/rightmove/listing/{prop_id}",
+            f"/v1/rightmove/listing/{property_id}",
             params={"include_raw": include_raw},
         )
         detail = data.get("result", {})
     else:
-        result = fetch_listing(url_or_id, include_raw=include_raw)
+        # CLI surface is numeric-ID-only, matching the REST and MCP contracts.
+        import re as _re
+
+        if not _re.fullmatch(r"[0-9]{1,12}", property_id.strip()):
+            typer.echo(
+                f"property_id must be a numeric Rightmove property ID (1-12 digits), got {property_id!r}"
+            )
+            raise typer.Exit(code=1)
+        try:
+            result = fetch_listing(property_id.strip())
+        except ValueError as exc:
+            typer.echo(str(exc))
+            raise typer.Exit(code=1) from exc
         detail = result.model_dump()
+        if not include_raw:
+            detail.pop("raw", None)
 
     # Display structured output
-    table = Table(title=f"Listing: {detail.get('address', url_or_id)}")
+    table = Table(title=f"Listing: {detail.get('address', property_id)}")
     table.add_column("Field", style="bold")
     table.add_column("Value")
 

--- a/property_core/__init__.py
+++ b/property_core/__init__.py
@@ -32,9 +32,20 @@ from property_core.report_service import PropertyReportService
 from property_core.stamp_duty import StampDutyResult, calculate_stamp_duty
 from property_core.yield_service import calculate_yield
 from property_core.rightmove_location import RightmoveLocationAPI
-from property_core.rightmove_scraper import fetch_listing, fetch_listings
+from property_core.rightmove_scraper import (
+    extract_property_id,
+    fetch_listing,
+    fetch_listings,
+)
+from property_core.ppd_client import UnsupportedRecordStatusFilterError
+from property_core.url_safety import UnsafeURLError, validate_allowed_url
 
 __all__ = [
+    # URL safety
+    "UnsafeURLError",
+    "validate_allowed_url",
+    # Errors
+    "UnsupportedRecordStatusFilterError",
     # Services
     "CompaniesHouseClient",
     "EPCClient",
@@ -55,6 +66,7 @@ __all__ = [
     "compute_enriched_stats",
     "enrich_comps_with_epc",
     "estimate_value_range",
+    "extract_property_id",
     "fetch_listing",
     "fetch_listings",
     "generate_insights",

--- a/property_core/ppd_client.py
+++ b/property_core/ppd_client.py
@@ -67,6 +67,21 @@ RECORD_STATUS_URIS: Dict[str, str] = {
     "D": "http://landregistry.data.gov.uk/def/ppi/delete",
 }
 
+
+class UnsupportedRecordStatusFilterError(ValueError):
+    """Raised when record_status filtering is requested on the SPARQL search path.
+
+    SPARQL search returns PPDTransaction rows, which have no record_status field
+    (it lives on PPDTransactionRecord, from the Linked Data endpoint). Filtering
+    previously dereferenced the missing attribute and crashed with AttributeError
+    on the first returned row.
+
+    Implementing this properly needs the record-status triple shape verified
+    against the live Land Registry ontology first — the URIs in
+    RECORD_STATUS_URIS look like rdf:type nodes rather than a literal predicate,
+    so it is deliberately rejected rather than guessed at.
+    """
+
 # The Land Registry site currently splits some recent years into two files.
 YEARS_WITH_PARTS = {2018, 2019, 2020, 2021, 2022, 2023}
 
@@ -149,7 +164,7 @@ class PricePaidDataClient:
         property_type: Optional[str] = None,
         estate_type: Optional[str] = None,
         transaction_category: Optional[str] = None,
-        record_status: Optional[str] = None,
+        record_status: Optional[str] = None,  # deprecated: raises if not None
         new_build: Optional[bool] = None,
         limit: int = 20,
         offset: int = 0,
@@ -162,7 +177,26 @@ class PricePaidDataClient:
         matching (CONTAINS/LCASE), and URI-based filters (applied client-side
         to avoid 503 timeouts). Core transaction fields use required bindings
         (semicolon chain) — OPTIONAL bindings cause full table scans.
+
+        Args:
+            record_status: **Not supported here.** Passing a value raises
+                UnsupportedRecordStatusFilterError. This search returns
+                PPDTransaction rows, which carry no record status — that field
+                exists only on PPDTransactionRecord, from the Linked Data
+                endpoint. The parameter is kept so callers get this explanation
+                rather than an opaque TypeError.
+
+        Raises:
+            UnsupportedRecordStatusFilterError: If record_status is not None.
         """
+        if record_status is not None:
+            raise UnsupportedRecordStatusFilterError(
+                "record_status filtering is not supported on SPARQL search: results are "
+                "PPDTransaction rows, which do not carry a record status. Use "
+                "PricePaidDataClient.get_transaction_record(transaction_id) / "
+                "PPDService.transaction_record() to read record_status for a known transaction."
+            )
+
         values_clauses = []
         filters = []
 
@@ -211,7 +245,7 @@ class PricePaidDataClient:
         # --- Client-side filters (URI-based — cause 503 in SPARQL) ---
         has_client_filters = any([
             property_type, estate_type, transaction_category,
-            record_status, new_build is not None,
+            new_build is not None,
         ])
         fetch_limit = limit * 3 if has_client_filters else limit
 
@@ -275,9 +309,9 @@ class PricePaidDataClient:
         if transaction_category:
             tc = transaction_category.upper()
             results = [t for t in results if t.transaction_category == tc]
-        if record_status:
-            rs = record_status.upper()
-            results = [t for t in results if t.record_status == rs]
+        # record_status is rejected up front (see the guard at the top of this
+        # method) — PPDTransaction has no such field, so there is nothing to
+        # filter on here.
         if new_build is not None:
             results = [t for t in results if t.new_build == new_build]
 

--- a/property_core/rightmove_scraper.py
+++ b/property_core/rightmove_scraper.py
@@ -16,15 +16,35 @@ from __future__ import annotations
 import json
 import re
 import time
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
-from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlsplit, urlunparse
 
 import requests
 from bs4 import BeautifulSoup
-from requests import Response, Session
+from requests import Session
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from property_core.models.rightmove import RightmoveListing, RightmoveListingDetail
+from property_core.url_safety import validate_allowed_url
+
+# Only these hosts may be fetched server-side. Exact matches only — see
+# property_core/url_safety.py for why suffix matching is not accepted.
+_RIGHTMOVE_HOSTS = frozenset({"www.rightmove.co.uk"})
+
+# Rightmove property IDs are numeric and far shorter than this; the bound just
+# keeps pathological input out of the URL builder.
+# [0-9] rather than \d: Python's \d also matches non-ASCII digits (e.g.
+# Arabic-Indic), which would be interpolated straight into the fetch URL.
+_PROPERTY_ID_RE = re.compile(r"^[0-9]{1,12}$")
+
+# The only URL path shape a listing ID may be recovered from.
+_PROPERTY_PATH_RE = re.compile(r"^/properties/([0-9]{1,12})/?$")
+
+# Guards against a malicious or misbehaving upstream streaming an unbounded body.
+_MAX_RESPONSE_BYTES = 10 * 1024 * 1024
+_MAX_REDIRECTS = 5
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 
 
 DEFAULT_HEADERS = {
@@ -44,6 +64,57 @@ class RightmoveError(Exception):
     """Raised when Rightmove data cannot be fetched or parsed."""
 
 
+@dataclass(frozen=True)
+class _Page:
+    """A fetched page: size-capped body text plus the final (post-redirect) URL.
+
+    Callers only ever used ``response.text``, so exposing ``.text`` keeps the
+    downstream parsers unchanged while letting the fetch layer enforce a byte cap.
+    """
+
+    text: str
+    url: str
+
+
+def extract_property_id(property_id_or_url: str) -> str:
+    """Resolve a Rightmove listing reference to its numeric property ID.
+
+    Accepts either a bare numeric ID, or a canonical Rightmove listing URL of
+    the exact form ``https://www.rightmove.co.uk/properties/<digits>``.
+
+    A URL is only ever used as a *source of digits*. It is validated against the
+    Rightmove host allowlist and then discarded — the caller's URL is never
+    fetched, so this cannot be used to reach an arbitrary host. Any other path
+    on the allowlisted host (``/search``, ``/redirect?to=...``) is rejected too.
+
+    Raises:
+        ValueError: If the value is neither a numeric ID nor a canonical
+            Rightmove listing URL. UnsafeURLError (a ValueError) is raised for a
+            URL that fails host/scheme validation.
+    """
+    value = (property_id_or_url or "").strip()
+
+    if _PROPERTY_ID_RE.match(value):
+        return value
+
+    if "//" in value or value.lower().startswith(("http:", "https:")):
+        # Raises UnsafeURLError for a non-Rightmove host, userinfo trick,
+        # lookalike host, non-https scheme, or non-default port.
+        canonical = validate_allowed_url(value, allowed_hosts=_RIGHTMOVE_HOSTS)
+        match = _PROPERTY_PATH_RE.match(urlsplit(canonical).path)
+        if match:
+            return match.group(1)
+        raise ValueError(
+            f"Not a Rightmove listing URL: {property_id_or_url!r}. Expected "
+            "https://www.rightmove.co.uk/properties/<numeric id>."
+        )
+
+    raise ValueError(
+        f"Expected a numeric Rightmove property ID (1-12 digits) or a "
+        f"https://www.rightmove.co.uk/properties/<id> URL, got {property_id_or_url!r}."
+    )
+
+
 def fetch_listing(
     property_url_or_id: str,
     *,
@@ -54,25 +125,41 @@ def fetch_listing(
     """Fetch full property details from an individual Rightmove listing page.
 
     Args:
-        property_url_or_id: Full Rightmove URL or just the numeric property ID.
+        property_url_or_id: Numeric Rightmove property ID, or a canonical
+            Rightmove listing URL (``https://www.rightmove.co.uk/properties/<id>``).
+            A URL is used only to extract the numeric ID — the fetched URL is
+            always rebuilt internally, so a caller-supplied URL is never
+            requested. This previously fetched any string starting with "http",
+            which was an SSRF vector reachable from unauthenticated surfaces.
+
+            The parameter name is retained from earlier releases so that
+            existing keyword callers (``fetch_listing(property_url_or_id=...)``)
+            keep working; the name has no bearing on validation.
         timeout: HTTP request timeout in seconds.
         retry_attempts: Number of retries on transient errors.
         retry_backoff: Exponential backoff multiplier.
 
     Returns:
         RightmoveListingDetail with all available fields from the detail page.
+
+    Raises:
+        ValueError: If the reference is neither a numeric ID nor a canonical
+            Rightmove listing URL (UnsafeURLError, a ValueError, for a URL that
+            fails host/scheme validation).
     """
-    url = _normalize_property_url(property_url_or_id)
-    session = Session()
-    response = _get_with_retries(
-        session=session,
-        url=url,
-        timeout=timeout,
-        retry_attempts=retry_attempts,
-        retry_backoff=retry_backoff,
-    )
-    property_data = _extract_page_model(response.text)
-    return RightmoveListingDetail.from_page_model(property_data, url=url)
+    pid = extract_property_id(property_url_or_id)
+    url = f"https://www.rightmove.co.uk/properties/{pid}"
+
+    with Session() as session:
+        page = _get_with_retries(
+            session=session,
+            url=url,
+            timeout=timeout,
+            retry_attempts=retry_attempts,
+            retry_backoff=retry_backoff,
+        )
+    property_data = _extract_page_model(page.text)
+    return RightmoveListingDetail.from_page_model(property_data, url=page.url)
 
 
 def fetch_listings(
@@ -84,39 +171,57 @@ def fetch_listings(
     retry_attempts: int = 3,
     retry_backoff: float = 1.5,
 ) -> list[RightmoveListing]:
-    """Fetch listings from a Rightmove search URL across pages."""
+    """Fetch listings from a Rightmove search URL across pages.
+
+    ``search_url`` is validated against the Rightmove host allowlist and
+    canonicalised before any request is made; the canonical value is what gets
+    fetched. Callers should build this URL with
+    :meth:`property_core.rightmove_location.RightmoveLocationAPI.build_search_url`
+    rather than accepting one from an end user.
+
+    Raises:
+        UnsafeURLError: If search_url is not an allowlisted https Rightmove URL.
+    """
+    # Rebind to the canonical form — everything below fetches this, never the
+    # raw input, so the validated and requested URLs cannot diverge.
+    search_url = validate_allowed_url(search_url, allowed_hosts=_RIGHTMOVE_HOSTS)
+
     listings: list[RightmoveListing] = []
     next_url = search_url
     page_counter = 0
     seen_indices: set[str] = set()
-    session = Session()
 
-    while next_url:
-        if rate_limit_seconds and page_counter > 0:
-            time.sleep(rate_limit_seconds)
-        page_counter += 1
+    with Session() as session:
+        while next_url:
+            if rate_limit_seconds and page_counter > 0:
+                time.sleep(rate_limit_seconds)
+            page_counter += 1
 
-        search_results = _get_search_results(
-            session=session,
-            url=next_url,
-            timeout=timeout,
-            retry_attempts=retry_attempts,
-            retry_backoff=retry_backoff,
-        )
-        properties = search_results.get("properties") or []
-        listings.extend(RightmoveListing.from_next_data(prop) for prop in properties)
+            search_results = _get_search_results(
+                session=session,
+                url=next_url,
+                timeout=timeout,
+                retry_attempts=retry_attempts,
+                retry_backoff=retry_backoff,
+            )
+            properties = search_results.get("properties") or []
+            listings.extend(RightmoveListing.from_next_data(prop) for prop in properties)
 
-        pagination = search_results.get("pagination") or {}
-        next_index = pagination.get("next")
+            pagination = search_results.get("pagination") or {}
+            next_index = pagination.get("next")
 
-        if max_pages is not None and page_counter >= max_pages:
-            break
+            if max_pages is not None and page_counter >= max_pages:
+                break
 
-        if not next_index or str(next_index) in seen_indices:
-            break
+            if not next_index or str(next_index) in seen_indices:
+                break
 
-        seen_indices.add(str(next_index))
-        next_url = _url_with_index(search_url, next_index)
+            seen_indices.add(str(next_index))
+            # Rewrites only the `index` query param on the already-validated
+            # canonical URL, so the host cannot change; re-validated anyway.
+            next_url = validate_allowed_url(
+                _url_with_index(search_url, next_index), allowed_hosts=_RIGHTMOVE_HOSTS
+            )
 
     return listings
 
@@ -157,17 +262,94 @@ def _url_with_index(url: str, index: str | int) -> str:
     return urlunparse(parsed._replace(query=new_query))
 
 
-def _make_request(session: Session, url: str, timeout: float) -> Response:
-    try:
-        response = session.get(url, headers=DEFAULT_HEADERS, timeout=timeout)
-    except requests.RequestException as exc:
-        raise RetryableError(f"Network error: {exc}") from exc
+def _read_capped(response: Any) -> bytes:
+    """Read a response body, refusing anything over _MAX_RESPONSE_BYTES.
 
-    if response.status_code == 429 or response.status_code >= 500:
-        raise RetryableError(f"Server responded with {response.status_code}")
-    if response.status_code >= 400:
-        raise RightmoveError(f"Request failed with status code {response.status_code}")
-    return response
+    Two layers: an up-front Content-Length check (cheap, avoids reading at all)
+    and a running cap while streaming (covers a missing, chunked, or spoofed
+    Content-Length).
+    """
+    declared = (response.headers or {}).get("Content-Length")
+    if declared:
+        try:
+            declared_bytes: Optional[int] = int(declared)
+        except (TypeError, ValueError):
+            declared_bytes = None
+        if declared_bytes is not None and declared_bytes > _MAX_RESPONSE_BYTES:
+            raise RightmoveError(
+                f"Response declares {declared_bytes} bytes, over the "
+                f"{_MAX_RESPONSE_BYTES} byte limit"
+            )
+
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=65536):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > _MAX_RESPONSE_BYTES:
+            raise RightmoveError(
+                f"Response exceeded the {_MAX_RESPONSE_BYTES} byte limit while streaming"
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _make_request(
+    session: Session,
+    url: str,
+    timeout: float,
+    *,
+    allowed_hosts: frozenset[str] = _RIGHTMOVE_HOSTS,
+) -> _Page:
+    """Fetch ``url``, following only redirects that stay inside ``allowed_hosts``.
+
+    Redirects are resolved and re-validated manually rather than delegated to
+    the HTTP client: automatic following would let an allowlisted host bounce us
+    to an arbitrary internal address, which would reopen the SSRF hole that
+    validating the initial URL closes.
+    """
+    current = url
+    for _ in range(_MAX_REDIRECTS + 1):
+        try:
+            response = session.get(
+                current,
+                headers=DEFAULT_HEADERS,
+                timeout=timeout,
+                allow_redirects=False,
+                stream=True,
+            )
+        except requests.RequestException as exc:
+            raise RetryableError(f"Network error: {exc}") from exc
+
+        try:
+            status = response.status_code
+
+            if status in _REDIRECT_STATUSES:
+                location = (response.headers or {}).get("Location")
+                if not location:
+                    raise RightmoveError(f"Redirect {status} with no Location header")
+                # Resolve relative/protocol-relative targets against the current
+                # URL, then re-validate: '//evil.example/x' resolves to a
+                # different host and is rejected here.
+                current = validate_allowed_url(
+                    urljoin(current, location), allowed_hosts=allowed_hosts
+                )
+                continue
+
+            if status == 429 or status >= 500:
+                raise RetryableError(f"Server responded with {status}")
+            if status >= 400:
+                raise RightmoveError(f"Request failed with status code {status}")
+
+            body = _read_capped(response)
+            encoding = getattr(response, "encoding", None) or "utf-8"
+        finally:
+            response.close()
+
+        return _Page(text=body.decode(encoding, errors="replace"), url=current)
+
+    raise RightmoveError(f"Exceeded {_MAX_REDIRECTS} redirects starting from {url}")
 
 
 def _get_with_retries(
@@ -177,14 +359,14 @@ def _get_with_retries(
     timeout: float,
     retry_attempts: int = 3,
     retry_backoff: float = 1.5,
-) -> Response:
+) -> _Page:
     @retry(
         stop=stop_after_attempt(retry_attempts),
         wait=wait_exponential(multiplier=retry_backoff, min=1, max=30),
         retry=retry_if_exception_type(RetryableError),
         reraise=True,
     )
-    def _fetch() -> Response:
+    def _fetch() -> _Page:
         return _make_request(session, url, timeout)
 
     try:
@@ -196,14 +378,6 @@ def _get_with_retries(
 # --- Listing detail helpers ---
 
 _PAGE_MODEL_RE = re.compile(r"window\.__PAGE_MODEL\s*=\s*(.+);")
-
-
-def _normalize_property_url(url_or_id: str) -> str:
-    """Accept a full Rightmove URL or numeric ID, return a canonical detail URL."""
-    url_or_id = url_or_id.strip()
-    if url_or_id.startswith("http"):
-        return url_or_id
-    return f"https://www.rightmove.co.uk/properties/{url_or_id}"
 
 
 def _decode_graph(nodes: list, idx: int, seen: frozenset = frozenset()) -> Any:

--- a/property_core/url_safety.py
+++ b/property_core/url_safety.py
@@ -1,0 +1,90 @@
+"""URL allowlist validation for outbound server-side fetches.
+
+Any code path that fetches a URL influenced by caller input must run it through
+:func:`validate_allowed_url` first, and must then fetch the *returned* value.
+
+Fetching the returned value rather than the original string is what closes the
+parser-differential gap: this module validates with :mod:`urllib.parse`, while
+the HTTP client does its own independent parsing. Reconstructing the URL from
+components that have already been validated removes any opportunity for the two
+parsers to disagree about which host is really being contacted.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit, urlunsplit
+
+# Backslashes and raw whitespace/control characters are the classic way two URL
+# parsers end up disagreeing about where the authority ends (some treat "\" as
+# "/", some strip control characters, some do neither). Rejecting them outright
+# is cheaper and safer than trying to model every parser's normalisation rules.
+_DISALLOWED_CHARS = frozenset(
+    "\\ \t\n\r\x0b\x0c\x00\x01\x02\x03\x04\x05\x06\x07\x08"
+    "\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f"
+)
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a URL fails scheme/host/port validation or cannot be parsed.
+
+    Subclasses ``ValueError`` to match the repo convention that invalid input
+    raises ``ValueError`` (see .claude/rules/property-core.md).
+    """
+
+
+def validate_allowed_url(url: str, *, allowed_hosts: frozenset[str]) -> str:
+    """Validate ``url`` against ``allowed_hosts`` and return a canonical form.
+
+    Enforces: https only, no userinfo, default port only, and an exact
+    (case-insensitive) hostname match against ``allowed_hosts``. Suffix and
+    substring matches are deliberately not accepted, so neither
+    ``https://www.rightmove.co.uk.evil.example/`` nor
+    ``https://evil.example/www.rightmove.co.uk`` can pass.
+
+    Args:
+        url: The candidate URL.
+        allowed_hosts: Exact hostnames permitted for this call site.
+
+    Returns:
+        A canonical URL rebuilt from the validated components. **Callers must
+        fetch this value, not the original input.**
+
+    Raises:
+        UnsafeURLError: If the URL is malformed or fails any check.
+    """
+    if not isinstance(url, str) or not url:
+        raise UnsafeURLError("URL must be a non-empty string")
+
+    bad = _DISALLOWED_CHARS & set(url)
+    if bad:
+        raise UnsafeURLError(
+            f"URL contains disallowed characters: {sorted(repr(c) for c in bad)}"
+        )
+
+    try:
+        # urlsplit, not urlparse: urlparse peels off a ";params" segment, which
+        # urlunparse would then silently drop from the canonical URL.
+        parsed = urlsplit(url)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise UnsafeURLError(f"URL could not be parsed: {exc}") from exc
+
+    if parsed.scheme != "https":
+        raise UnsafeURLError(f"URL scheme must be https, got {parsed.scheme!r}")
+
+    if parsed.username is not None or parsed.password is not None:
+        raise UnsafeURLError("URL must not contain userinfo (user:pass@host)")
+
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise UnsafeURLError(f"URL port could not be parsed: {exc}") from exc
+    if port not in (None, 443):
+        raise UnsafeURLError(f"URL port must be the https default, got {port!r}")
+
+    hostname = parsed.hostname
+    if not hostname or hostname.lower() not in allowed_hosts:
+        raise UnsafeURLError(f"Host {hostname!r} is not allowlisted")
+
+    # Rebuild from validated parts only. The fragment is dropped (it is never
+    # transmitted to the server) and the port is left implicit.
+    return urlunsplit(("https", hostname.lower(), parsed.path or "/", parsed.query, ""))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.12.0"
+version = "1.13.0"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates, rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"
@@ -90,6 +90,7 @@ exclude = [".uv-cache", ".venv", "*.pyc", "__pycache__", ".pytest_cache", ".git"
 
 [tool.pytest.ini_options]
 addopts = "-ra"
+testpaths = ["tests"]
 
 [dependency-groups]
 dev = [

--- a/scripts/measure_epc_tokens.py
+++ b/scripts/measure_epc_tokens.py
@@ -7,7 +7,7 @@ Tests four candidate response shapes against a real postcode:
   4. slim_list_capped  — slim_list capped at N certs
 
 Run:
-    uv run --env-file .env --extra dev python scripts/epc_token_test.py
+    uv run --env-file .env --extra dev python scripts/measure_epc_tokens.py
 """
 
 from __future__ import annotations

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.7.3",
+  "version": "1.13.0",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.7.3",
+      "version": "1.13.0",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/tests/test_epc_compliance_text.py
+++ b/tests/test_epc_compliance_text.py
@@ -1,0 +1,123 @@
+"""EPC/MEES regulatory text must not misstate the law.
+
+Both MCP servers previously claimed, in the `epc-ratings://reference` resource
+*and* in the `investment_analysis` prompt, that EPC band C has been required for
+new tenancies since April 2025 and that existing tenancies must comply by 2028.
+
+Verified against gov.uk:
+  * The current legal minimum for privately rented domestic property in England
+    and Wales is band **E** (since 1 April 2020).
+  * The proposed future standard is band **C** with a single compliance date of
+    **1 October 2030** for all tenancies — the government explicitly rejected an
+    earlier date for new tenancies. It is not yet in force.
+
+These assertions cover resources and prompts on *both* servers, because the two
+server modules carry independent copies of the same text and a resource-only
+test cannot see the prompt copy.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+# "2028" and any claim that 2025 is when band C became required are the two
+# specific false statements being removed.
+_FALSE_2028 = re.compile(r"\b2028\b")
+_FALSE_2025_C = re.compile(
+    r"(April 2025[^.]*\bband C\b)|(\bband C\b[^.]*April 2025)"
+    r"|(from April 2025[^.]*EPC C)|(Since April 2025)",
+    re.IGNORECASE,
+)
+
+
+async def _epc_resource_text(mcp) -> str:
+    result = await mcp.read_resource("epc-ratings://reference")
+    return result.contents[0].content
+
+
+async def _investment_prompt_text(mcp) -> str:
+    result = await mcp.render_prompt(
+        "investment_analysis",
+        {
+            "address": "10 Downing Street",
+            "postcode": "SW1A 2AA",
+            "purchase_price": "500000",
+        },
+    )
+    return "\n".join(str(m) for m in result.messages)
+
+
+def _assert_corrected(text: str, where: str) -> None:
+    assert not _FALSE_2028.search(text), f"{where}: stale 2028 compliance date still present"
+    assert not _FALSE_2025_C.search(text), f"{where}: still claims band C required from April 2025"
+    assert "2030" in text, f"{where}: missing the real 1 October 2030 compliance date"
+
+
+class TestPlainMcpServer:
+    @pytest.mark.anyio
+    async def test_resource_states_current_minimum_is_e(self):
+        from app.mcp.server import mcp
+
+        text = await _epc_resource_text(mcp)
+        _assert_corrected(text, "plain MCP epc-ratings resource")
+
+        data = json.loads(text)
+        note = data["regulation_note"]
+        assert "E" in note, "regulation_note must state band E is the current minimum"
+        assert "2030" in note
+
+    @pytest.mark.anyio
+    async def test_band_descriptions_are_accurate(self):
+        from app.mcp.server import mcp
+
+        data = json.loads(await _epc_resource_text(mcp))
+        bands = {b["band"]: b["description"] for b in data["ratings"]}
+
+        # Band C must be described as future/proposed, never as a current rule.
+        assert not _FALSE_2025_C.search(bands["C"])
+        assert "2030" in bands["C"] or "proposed" in bands["C"].lower()
+
+        # Band E must be described as the current legal minimum.
+        assert "minimum" in bands["E"].lower()
+        assert not _FALSE_2028.search(bands["E"])
+
+    @pytest.mark.anyio
+    async def test_investment_analysis_prompt_is_accurate(self):
+        """The prompt carries its own copy — the resource test cannot catch it."""
+        from app.mcp.server import mcp
+
+        _assert_corrected(await _investment_prompt_text(mcp), "plain MCP investment_analysis prompt")
+
+
+class TestMcpAppServer:
+    @pytest.mark.anyio
+    async def test_resource_states_current_minimum_is_e(self):
+        import property_app.tools  # noqa: F401
+        from property_app.server import mcp
+
+        text = await _epc_resource_text(mcp)
+        _assert_corrected(text, "MCP app epc-ratings resource")
+
+        data = json.loads(text)
+        assert "E" in data["regulation_note"]
+
+    @pytest.mark.anyio
+    async def test_band_descriptions_are_accurate(self):
+        import property_app.tools  # noqa: F401
+        from property_app.server import mcp
+
+        data = json.loads(await _epc_resource_text(mcp))
+        bands = {b["band"]: b["description"] for b in data["ratings"]}
+        assert not _FALSE_2025_C.search(bands["C"])
+        assert "2030" in bands["C"] or "proposed" in bands["C"].lower()
+        assert "minimum" in bands["E"].lower()
+
+    @pytest.mark.anyio
+    async def test_investment_analysis_prompt_is_accurate(self):
+        import property_app.tools  # noqa: F401
+        from property_app.server import mcp
+
+        _assert_corrected(await _investment_prompt_text(mcp), "MCP app investment_analysis prompt")

--- a/tests/test_img_proxy.py
+++ b/tests/test_img_proxy.py
@@ -1,0 +1,198 @@
+"""SSRF tests for the /img proxy in property_app/server.py.
+
+The proxy previously accepted any URL passing a bare
+``url.startswith("https://media.rightmove.co.uk")`` prefix check, which lookalike
+hosts and userinfo tricks both defeat, and it followed redirects automatically
+with no size cap.
+
+Validation here goes through httpx's own URL parser (never urllib.parse), because
+httpx is what actually issues the request — validating with a different parser
+would reinstate the very host-confusion bug being fixed.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from property_app.server import _IMG_MAX_BYTES, _validated_img_url, proxy_image
+
+
+class TestRejects:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "",
+            "https://evil.example/x.jpg",
+            # Defeats a bare startswith() prefix check:
+            "https://media.rightmove.co.uk.evil.example/x.jpg",
+            # Real host here is evil.example — the userinfo trick:
+            "https://media.rightmove.co.uk@evil.example/x.jpg",
+            "https://user:pass@evil.example/x.jpg",
+            "https://user:pass@media.rightmove.co.uk/x.jpg",
+            "http://media.rightmove.co.uk/x.jpg",
+            "https://media.rightmove.co.uk:8080/x.jpg",
+            "https://127.0.0.1/x.jpg",
+            "https://169.254.169.254/latest/meta-data/",
+            "file:///etc/passwd",
+            "not a url",
+            # Parser-differential characters.
+            "https://media.rightmove.co.uk\\@evil.example/x.jpg",
+            "https://media.rightmove.co.uk/x.jpg\nHost: evil.example",
+            "https://media.rightmove.co.uk\t/x.jpg",
+        ],
+    )
+    def test_unsafe_urls_rejected(self, url):
+        assert _validated_img_url(url) is None
+
+
+class TestAccepts:
+    def test_allowlisted_image_url(self):
+        url = _validated_img_url("https://media.rightmove.co.uk/dir/IMG_01.jpeg")
+        assert url is not None
+        assert url.host == "media.rightmove.co.uk"
+        assert url.scheme == "https"
+
+    def test_query_string_preserved(self):
+        url = _validated_img_url("https://media.rightmove.co.uk/x.jpeg?w=100")
+        assert url is not None
+        assert b"w=100" in url.query
+
+
+class _Req:
+    """Minimal stand-in for a Starlette request."""
+
+    def __init__(self, url):
+        self.query_params = {"url": url}
+
+
+def _mock_transport(monkeypatch, handler):
+    """Route proxy_image's httpx calls to `handler`, recording each request."""
+    seen: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return handler(request)
+
+    real_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(_handler)
+        return real_client(*args, **kwargs)
+
+    # proxy_image does `import httpx` at call time, so patching the module
+    # attribute here is what it will resolve.
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+    return seen
+
+
+class TestProxyImageBehaviour:
+    """Covers proxy_image itself, not just the URL validator."""
+
+    @pytest.mark.anyio
+    async def test_rejects_unsafe_url_without_any_request(self, monkeypatch):
+        seen = _mock_transport(
+            monkeypatch, lambda req: httpx.Response(200, content=b"x", headers={})
+        )
+        resp = await proxy_image(_Req("https://media.rightmove.co.uk@evil.example/x.jpg"))
+        assert resp.status_code == 400
+        assert seen == []
+
+    @pytest.mark.anyio
+    async def test_does_not_delegate_redirects_to_httpx(self, monkeypatch):
+        """If follow_redirects were True, httpx would chase the 302 itself."""
+        seen = _mock_transport(
+            monkeypatch,
+            lambda req: httpx.Response(
+                302, headers={"Location": "https://evil.example/x.jpg"}
+            ),
+        )
+        resp = await proxy_image(_Req("https://media.rightmove.co.uk/a.jpg"))
+        assert resp.status_code == 400, "cross-host redirect must be refused"
+        assert [str(r.url) for r in seen] == ["https://media.rightmove.co.uk/a.jpg"]
+        assert not any("evil.example" in str(r.url) for r in seen)
+
+    @pytest.mark.anyio
+    async def test_same_host_redirect_is_followed(self, monkeypatch):
+        def handler(req):
+            if req.url.path == "/a.jpg":
+                return httpx.Response(302, headers={"Location": "/b.jpg"})
+            return httpx.Response(
+                200, content=b"IMG", headers={"content-type": "image/jpeg"}
+            )
+
+        seen = _mock_transport(monkeypatch, handler)
+        resp = await proxy_image(_Req("https://media.rightmove.co.uk/a.jpg"))
+        assert resp.status_code == 200
+        assert [r.url.path for r in seen] == ["/a.jpg", "/b.jpg"]
+
+    @pytest.mark.anyio
+    async def test_non_image_content_type_is_refused(self, monkeypatch):
+        """media.rightmove.co.uk carries third-party files; never echo text/html."""
+        _mock_transport(
+            monkeypatch,
+            lambda req: httpx.Response(
+                200, content=b"<script>alert(1)</script>", headers={"content-type": "text/html"}
+            ),
+        )
+        resp = await proxy_image(_Req("https://media.rightmove.co.uk/evil.html"))
+        assert resp.status_code == 502
+
+    @pytest.mark.anyio
+    async def test_successful_image_sets_nosniff(self, monkeypatch):
+        _mock_transport(
+            monkeypatch,
+            lambda req: httpx.Response(
+                200, content=b"IMG", headers={"content-type": "image/jpeg"}
+            ),
+        )
+        resp = await proxy_image(_Req("https://media.rightmove.co.uk/a.jpg"))
+        assert resp.status_code == 200
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+
+    @pytest.mark.anyio
+    async def test_oversized_body_is_capped(self, monkeypatch):
+        _mock_transport(
+            monkeypatch,
+            lambda req: httpx.Response(
+                200,
+                content=b"x" * (_IMG_MAX_BYTES + 1024),
+                headers={"content-type": "image/jpeg"},
+            ),
+        )
+        resp = await proxy_image(_Req("https://media.rightmove.co.uk/big.jpg"))
+        assert resp.status_code == 502
+
+    @pytest.mark.anyio
+    async def test_plus_in_image_url_is_not_rejected(self, monkeypatch):
+        """Starlette decodes '+' to ' '; rejecting spaces silently broke images."""
+        _mock_transport(
+            monkeypatch,
+            lambda req: httpx.Response(
+                200, content=b"IMG", headers={"content-type": "image/jpeg"}
+            ),
+        )
+        resp = await proxy_image(_Req("https://media.rightmove.co.uk/dir/IMG 01+02.jpeg"))
+        assert resp.status_code == 200
+
+
+class TestRedirectResolution:
+    """A redirect target must be re-validated with the same parser."""
+
+    def test_cross_host_redirect_target_rejected(self):
+        base = _validated_img_url("https://media.rightmove.co.uk/a/b.jpeg")
+        assert base is not None
+        assert _validated_img_url(str(base.join("https://evil.example/x"))) is None
+
+    def test_protocol_relative_redirect_target_rejected(self):
+        base = _validated_img_url("https://media.rightmove.co.uk/a/b.jpeg")
+        assert base is not None
+        assert _validated_img_url(str(base.join("//evil.example/x"))) is None
+
+    def test_same_host_relative_redirect_target_allowed(self):
+        base = _validated_img_url("https://media.rightmove.co.uk/a/b.jpeg")
+        assert base is not None
+        nxt = _validated_img_url(str(base.join("/c/d.jpeg")))
+        assert nxt is not None
+        assert nxt.host == "media.rightmove.co.uk"
+        assert nxt.path == "/c/d.jpeg"

--- a/tests/test_mcp_server_epc.py
+++ b/tests/test_mcp_server_epc.py
@@ -98,24 +98,24 @@ def test_property_epc_search_filters_to_keep_fields_only():
 
 
 # ---------------------------------------------------------------------------
-# get_epc_certificate
+# epc_certificate
 # ---------------------------------------------------------------------------
 
 
-def test_get_epc_certificate_returns_none_when_not_found():
-    """get_epc_certificate returns None when the lmk_key is not recognised."""
-    from app.mcp.server import get_epc_certificate
+def test_epc_certificate_returns_none_when_not_found():
+    """epc_certificate returns None when the lmk_key is not recognised."""
+    from app.mcp.server import epc_certificate
 
     with patch("property_core.EPCClient") as mock_cls:
         mock_cls.return_value.get_certificate = AsyncMock(return_value=None)
-        result = asyncio.run(get_epc_certificate("nonexistent-key"))
+        result = asyncio.run(epc_certificate("nonexistent-key"))
         assert result is None
         mock_cls.return_value.get_certificate.assert_awaited_once_with("nonexistent-key")
 
 
-def test_get_epc_certificate_returns_full_slim_cert():
-    """get_epc_certificate returns a slimmed full cert dict with raw stripped."""
-    from app.mcp.server import get_epc_certificate
+def test_epc_certificate_returns_full_slim_cert():
+    """epc_certificate returns a slimmed full cert dict with raw stripped."""
+    from app.mcp.server import epc_certificate
 
     mock_epc = MagicMock()
     mock_epc.model_dump.return_value = {
@@ -129,7 +129,7 @@ def test_get_epc_certificate_returns_full_slim_cert():
 
     with patch("property_core.EPCClient") as mock_cls:
         mock_cls.return_value.get_certificate = AsyncMock(return_value=mock_epc)
-        result = asyncio.run(get_epc_certificate("abc123"))
+        result = asyncio.run(epc_certificate("abc123"))
 
     assert isinstance(result, dict)
     assert result["lmk_key"] == "abc123"

--- a/tests/test_ppd_record_status.py
+++ b/tests/test_ppd_record_status.py
@@ -1,0 +1,129 @@
+"""record_status filtering on SPARQL search was a guaranteed crash.
+
+PricePaidDataClient.sparql_search() builds PPDTransaction objects, then filtered
+them with `t.record_status`. PPDTransaction has no such field — it belongs to
+PPDTransactionRecord, the Linked Data detail model built by
+get_transaction_record(). So any caller passing record_status hit AttributeError
+as soon as the query returned a single row.
+
+It now fails fast with a specific, actionable error instead.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1 import ppd as ppd_router
+from property_core.ppd_client import (
+    PricePaidDataClient,
+    UnsupportedRecordStatusFilterError,
+)
+from property_core.ppd_service import PPDService
+
+# One realistic SPARQL binding — enough for the old code to reach the filter.
+_BINDINGS = {
+    "results": {
+        "bindings": [
+            {
+                "transactionId": {"value": "abc-123"},
+                "pricePaid": {"value": "450000"},
+                "transactionDate": {"value": "2024-03-01"},
+                "postcode": {"value": "SW1A 1AA"},
+                "propertyType": {
+                    "value": "http://landregistry.data.gov.uk/def/common/flat-maisonette"
+                },
+                "estateType": {"value": "http://landregistry.data.gov.uk/def/common/leasehold"},
+                "transactionCategory": {
+                    "value": "http://landregistry.data.gov.uk/def/ppi/standardPricePaidTransaction"
+                },
+                "newBuild": {"value": "false"},
+                "paon": {"value": "10"},
+                "street": {"value": "DOWNING STREET"},
+            }
+        ]
+    }
+}
+
+
+class TestClientLevel:
+    def test_record_status_raises_specific_error_not_attributeerror(self):
+        client = PricePaidDataClient()
+        with patch.object(client, "_fetch_sparql", return_value=_BINDINGS) as mock_fetch:
+            with pytest.raises(UnsupportedRecordStatusFilterError) as excinfo:
+                client.sparql_search(postcode="SW1A 1AA", record_status="A")
+        # Fails before building or issuing the query at all.
+        mock_fetch.assert_not_called()
+        assert "get_transaction_record" in str(excinfo.value)
+
+    def test_error_is_a_valueerror_for_callers_catching_invalid_input(self):
+        assert issubclass(UnsupportedRecordStatusFilterError, ValueError)
+
+    def test_search_without_record_status_still_works(self):
+        client = PricePaidDataClient()
+        with patch.object(client, "_fetch_sparql", return_value=_BINDINGS):
+            results = client.sparql_search(postcode="SW1A 1AA")
+        assert len(results) == 1
+        assert results[0].price == 450000
+
+    def test_other_client_side_filters_are_unaffected(self):
+        client = PricePaidDataClient()
+        with patch.object(client, "_fetch_sparql", return_value=_BINDINGS):
+            flats = client.sparql_search(postcode="SW1A 1AA", property_type="F")
+            houses = client.sparql_search(postcode="SW1A 1AA", property_type="D")
+        assert len(flats) == 1
+        assert houses == []
+
+
+class TestServiceLevel:
+    def test_service_propagates_the_specific_error(self):
+        service = PPDService()
+        with patch.object(service.client, "_fetch_sparql", return_value=_BINDINGS):
+            with pytest.raises(UnsupportedRecordStatusFilterError):
+                service.search_transactions(postcode="SW1A 1AA", postcode_prefix=None, record_status="A")
+
+
+class TestApiLayer:
+    @pytest.fixture()
+    def client(self):
+        app = FastAPI()
+        app.include_router(ppd_router.router, prefix="/v1")
+        return TestClient(app)
+
+    def test_record_status_returns_422_not_502(self, client):
+        """Invalid input is a caller error, not 'upstream unavailable'."""
+        with patch.object(ppd_router.service.client, "_fetch_sparql", return_value=_BINDINGS):
+            resp = client.get(
+                "/v1/ppd/transactions", params={"postcode": "SW1A 1AA", "record_status": "A"}
+            )
+        assert resp.status_code == 422, resp.text
+        assert "get_transaction_record" in resp.json()["detail"]
+
+    def test_unrelated_failures_still_map_to_502(self, client):
+        """Narrowing the except clause must not reclassify genuine upstream errors."""
+        with patch.object(
+            ppd_router.service, "search_transactions", side_effect=RuntimeError("upstream down")
+        ):
+            resp = client.get("/v1/ppd/transactions", params={"postcode": "SW1A 1AA"})
+        assert resp.status_code == 502, resp.text
+
+    def test_unrelated_valueerror_is_not_swallowed_as_422(self, client):
+        """Only the record_status error maps to 422 — not every ValueError.
+
+        A ValueError from elsewhere usually signals an internal bug, and
+        reporting it as a caller error would hide it.
+        """
+        with patch.object(
+            ppd_router.service, "search_transactions", side_effect=ValueError("internal parse bug")
+        ):
+            resp = client.get("/v1/ppd/transactions", params={"postcode": "SW1A 1AA"})
+        assert resp.status_code == 502, resp.text
+
+    def test_search_without_record_status_still_succeeds(self, client):
+        with patch.object(ppd_router.service.client, "_fetch_sparql", return_value=_BINDINGS):
+            resp = client.get("/v1/ppd/transactions", params={"postcode": "SW1A 1AA"})
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 1

--- a/tests/test_rightmove_router.py
+++ b/tests/test_rightmove_router.py
@@ -1,0 +1,110 @@
+"""Endpoint-level tests for app/api/v1/rightmove.py.
+
+This router previously had no test coverage at all, while exposing two of the
+three confirmed SSRF entry points:
+  * GET /rightmove/listings?search_url=<anything>  -> fetched server-side
+  * GET /rightmove/listing/{property_id}           -> URLs passed straight through
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1 import rightmove as rightmove_router
+
+
+@pytest.fixture()
+def client():
+    app = FastAPI()
+    app.include_router(rightmove_router.router, prefix="/v1")
+    return TestClient(app)
+
+
+class TestListingDetailPathValidation:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "https:%2F%2Fevil.example%2Fx",
+            "..%2F..%2Fetc%2Fpasswd",
+            "abc123",
+            "12a",
+            "9" * 13,
+            "-1",
+        ],
+    )
+    def test_non_numeric_ids_rejected_at_routing_layer(self, client, raw):
+        with patch.object(rightmove_router, "fetch_listing") as mock_fetch:
+            resp = client.get(f"/v1/rightmove/listing/{raw}")
+        assert resp.status_code in (404, 422), resp.status_code
+        mock_fetch.assert_not_called()
+
+    def test_listing_url_is_rejected_by_the_public_rest_surface(self, client):
+        """The library accepts a canonical URL; this public surface does not."""
+        with patch.object(rightmove_router, "fetch_listing") as mock_fetch:
+            resp = client.get(
+                "/v1/rightmove/listing/https%3A%2F%2Fwww.rightmove.co.uk%2Fproperties%2F123456"
+            )
+        assert resp.status_code in (404, 422)
+        mock_fetch.assert_not_called()
+
+    def test_numeric_id_reaches_the_service(self, client):
+        with patch.object(rightmove_router, "fetch_listing") as mock_fetch:
+            mock_fetch.return_value = _stub_detail()
+            resp = client.get("/v1/rightmove/listing/123456")
+        assert resp.status_code == 200
+        mock_fetch.assert_called_once_with("123456")
+
+
+class TestListingsStructuredFilters:
+    def test_raw_search_url_is_no_longer_accepted(self, client):
+        """The old contract must be gone: search_url alone can't drive a fetch."""
+        with patch.object(rightmove_router, "fetch_listings") as mock_fetch:
+            resp = client.get(
+                "/v1/rightmove/listings",
+                params={"search_url": "https://evil.example/x"},
+            )
+        assert resp.status_code == 422, "postcode is now required"
+        mock_fetch.assert_not_called()
+
+    def test_postcode_builds_url_server_side(self, client):
+        built = "https://www.rightmove.co.uk/property-for-sale/find.html?locationIdentifier=X"
+        with patch.object(rightmove_router, "RightmoveLocationAPI") as mock_api, patch.object(
+            rightmove_router, "fetch_listings"
+        ) as mock_fetch:
+            mock_api.return_value.build_search_url.return_value = built
+            mock_fetch.return_value = []
+            resp = client.get("/v1/rightmove/listings", params={"postcode": "NG1 1AA"})
+
+        assert resp.status_code == 200
+        # The URL handed to the scraper came from the builder, not from the caller.
+        assert mock_fetch.call_args.args[0] == built
+        assert mock_api.return_value.build_search_url.call_args.args[0] == "NG1 1AA"
+
+    def test_caller_cannot_smuggle_a_host_through_filters(self, client):
+        """Even with an injected search_url param, the fetched URL is the built one."""
+        built = "https://www.rightmove.co.uk/property-for-sale/find.html?locationIdentifier=X"
+        with patch.object(rightmove_router, "RightmoveLocationAPI") as mock_api, patch.object(
+            rightmove_router, "fetch_listings"
+        ) as mock_fetch:
+            mock_api.return_value.build_search_url.return_value = built
+            mock_fetch.return_value = []
+            resp = client.get(
+                "/v1/rightmove/listings",
+                params={"postcode": "NG1 1AA", "search_url": "https://evil.example/x"},
+            )
+
+        assert resp.status_code == 200
+        assert mock_fetch.call_args.args[0] == built
+        assert "evil.example" not in str(mock_fetch.call_args)
+
+
+def _stub_detail():
+    from property_core.models.rightmove import RightmoveListingDetail
+
+    return RightmoveListingDetail(
+        id=123456, url="https://www.rightmove.co.uk/properties/123456"
+    )

--- a/tests/test_rightmove_scraper.py
+++ b/tests/test_rightmove_scraper.py
@@ -1,0 +1,479 @@
+"""SSRF remediation tests for property_core/rightmove_scraper.py.
+
+Confirmed vulnerability being closed here: fetch_listing() passed any string
+beginning with "http" straight through to session.get() with no host or scheme
+validation, and fetch_listings() accepted an arbitrary search URL. Both were
+reachable from unauthenticated surfaces (the `rightmove_listing` MCP tool and
+the /v1/rightmove/listings + /v1/rightmove/listing/{id} REST endpoints), giving
+an unauthenticated caller a server-side fetch primitive against internal hosts.
+
+The assertions below deliberately check that *no outbound request is attempted*
+for unsafe input, rather than only checking that an exception is raised — an
+exception raised after the request has already gone out would not close the hole.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from property_core import rightmove_scraper
+from property_core.rightmove_scraper import (
+    RightmoveError,
+    extract_property_id,
+    fetch_listing,
+    fetch_listings,
+)
+from property_core.url_safety import UnsafeURLError
+
+# --------------------------------------------------------------------------
+# Test doubles
+# --------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, *, url, status_code=200, headers=None, body=b"", encoding="utf-8"):
+        self.url = url
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._body = body
+        self.encoding = encoding
+        self.closed = False
+
+    @property
+    def text(self) -> str:
+        return self._body.decode(self.encoding, errors="replace")
+
+    @property
+    def content(self) -> bytes:
+        return self._body
+
+    def iter_content(self, chunk_size=8192):
+        for i in range(0, len(self._body), chunk_size):
+            yield self._body[i : i + chunk_size]
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+class _FakeSession:
+    """Records every URL actually requested."""
+
+    def __init__(self, responder):
+        self.requested: list[str] = []
+        self.requested_kwargs: list[dict] = []
+        self.responses: list[_FakeResponse] = []
+        self._responder = responder
+        self.closed = False
+
+    def get(self, url, **kwargs):
+        self.requested.append(url)
+        self.requested_kwargs.append(kwargs)
+        resp = self._responder(url, **kwargs)
+        self.responses.append(resp)
+        return resp
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+class _ExplodingSession(_FakeSession):
+    """Fails loudly if any outbound request is attempted at all."""
+
+    def __init__(self):
+        super().__init__(responder=None)
+
+    def get(self, url, **kwargs):  # noqa: ARG002
+        raise AssertionError(f"SSRF: an outbound request was attempted to {url!r}")
+
+
+def _install(monkeypatch, session):
+    monkeypatch.setattr(rightmove_scraper, "Session", lambda: session)
+    return session
+
+
+def _listing_html(property_id: int = 123456) -> bytes:
+    """Minimal but structurally real Rightmove PAGE_MODEL payload."""
+    nodes = [{"propertyData": 1}, {"id": 2}, property_id]
+    page_model = json.dumps({"data": json.dumps(nodes)})
+    return f"window.__PAGE_MODEL = {page_model};".encode()
+
+
+def _search_html(properties=None) -> bytes:
+    payload = {
+        "props": {
+            "pageProps": {
+                "searchResults": {
+                    "properties": properties or [],
+                    "pagination": {},
+                }
+            }
+        }
+    }
+    return (
+        '<html><body><script id="__NEXT_DATA__" type="application/json">'
+        f"{json.dumps(payload)}</script></body></html>"
+    ).encode()
+
+
+# --------------------------------------------------------------------------
+# fetch_listing — now ID-only
+# --------------------------------------------------------------------------
+
+
+class TestExtractPropertyId:
+    """Library compatibility: downstream servers (property-descriptions-mcp,
+    uk-property-mcp) advertise "URL or numeric ID" and pass it straight through.
+
+    A canonical listing URL is therefore still accepted — but only as a source
+    of digits. The URL itself is never fetched.
+    """
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("123456", "123456"),
+            ("  123456  ", "123456"),
+            ("https://www.rightmove.co.uk/properties/123456", "123456"),
+            ("https://www.rightmove.co.uk/properties/123456/", "123456"),
+            ("https://www.rightmove.co.uk/properties/123456?utm=x", "123456"),
+            ("https://www.rightmove.co.uk/properties/123456#photos", "123456"),
+            ("https://WWW.RIGHTMOVE.CO.UK/properties/123456", "123456"),
+            ("https://www.rightmove.co.uk:443/properties/123456", "123456"),
+        ],
+    )
+    def test_legitimate_references_resolve(self, value, expected):
+        assert extract_property_id(value) == expected
+
+    @pytest.mark.parametrize(
+        "hostile",
+        [
+            # Wrong host — the SSRF payloads.
+            "https://evil.example/properties/123456",
+            "http://169.254.169.254/properties/123456",
+            "https://127.0.0.1:8080/properties/123456",
+            # Host-confusion tricks that a naive "contains rightmove" check misses.
+            "https://www.rightmove.co.uk@evil.example/properties/123456",
+            "https://www.rightmove.co.uk.evil.example/properties/123456",
+            "https://evil.example/www.rightmove.co.uk/properties/123456",
+            # Right host, wrong scheme/port.
+            "http://www.rightmove.co.uk/properties/123456",
+            "https://www.rightmove.co.uk:8080/properties/123456",
+            # Right host, but NOT a listing path — must not become a fetch.
+            "https://www.rightmove.co.uk/",
+            "https://www.rightmove.co.uk/property-for-sale/find.html",
+            "https://www.rightmove.co.uk/redirect?to=https://evil.example",
+            "https://www.rightmove.co.uk/properties/123456/extra",
+            "https://www.rightmove.co.uk/properties/abc",
+            "https://www.rightmove.co.uk/properties/",
+            "file:///etc/passwd",
+            "",
+            "not-an-id",
+        ],
+    )
+    def test_hostile_or_malformed_references_rejected(self, hostile):
+        with pytest.raises(ValueError):  # UnsafeURLError is a ValueError
+            extract_property_id(hostile)
+
+
+class TestFetchListingInput:
+    @pytest.mark.parametrize(
+        "hostile",
+        [
+            "https://evil.example/properties/123456",
+            "http://169.254.169.254/latest/meta-data/",
+            "https://127.0.0.1:8080/admin",
+            "https://www.rightmove.co.uk@evil.example/properties/1",
+            "https://www.rightmove.co.uk.evil.example/properties/1",
+            "https://www.rightmove.co.uk/redirect?to=https://evil.example",
+            "file:///etc/passwd",
+        ],
+    )
+    def test_hostile_urls_refused_without_any_request(self, monkeypatch, hostile):
+        """The core SSRF regression: these must never reach the network layer."""
+        session = _install(monkeypatch, _ExplodingSession())
+        with pytest.raises((ValueError, UnsafeURLError)):
+            fetch_listing(hostile)
+        assert session.requested == []
+
+    def test_legacy_keyword_argument_still_works(self, monkeypatch):
+        """External callers may use fetch_listing(property_url_or_id="...").
+
+        Both known sibling servers call positionally, but this library is
+        published on PyPI, so the original parameter name is retained. The name
+        has no bearing on validation — the value still goes through
+        extract_property_id().
+        """
+        session = _install(
+            monkeypatch,
+            _FakeSession(lambda url, **kw: _FakeResponse(url=url, body=_listing_html())),
+        )
+        fetch_listing(property_url_or_id="123456")
+        assert session.requested == ["https://www.rightmove.co.uk/properties/123456"]
+
+    def test_legacy_keyword_argument_accepts_a_listing_url(self, monkeypatch):
+        session = _install(
+            monkeypatch,
+            _FakeSession(lambda url, **kw: _FakeResponse(url=url, body=_listing_html())),
+        )
+        fetch_listing(property_url_or_id="https://www.rightmove.co.uk/properties/123456")
+        assert session.requested == ["https://www.rightmove.co.uk/properties/123456"]
+
+    def test_legacy_keyword_argument_is_still_validated(self, monkeypatch):
+        """Compatibility must not open a validation bypass."""
+        session = _install(monkeypatch, _ExplodingSession())
+        with pytest.raises((ValueError, UnsafeURLError)):
+            fetch_listing(property_url_or_id="https://evil.example/properties/123456")
+        assert session.requested == []
+
+    def test_signature_exposes_the_legacy_parameter_name(self):
+        """Pin the public name so any future rename is a deliberate decision."""
+        import inspect
+
+        assert list(inspect.signature(fetch_listing).parameters)[0] == "property_url_or_id"
+
+    def test_legitimate_url_fetches_the_rebuilt_canonical_url(self, monkeypatch):
+        """A valid listing URL works, but the fetched URL is rebuilt from the ID.
+
+        Query string and fragment from the caller's URL are discarded.
+        """
+        session = _install(
+            monkeypatch,
+            _FakeSession(lambda url, **kw: _FakeResponse(url=url, body=_listing_html())),
+        )
+        fetch_listing("https://www.rightmove.co.uk/properties/123456?utm_source=evil#x")
+        assert session.requested == ["https://www.rightmove.co.uk/properties/123456"]
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        ["", "  ", "abc", "12a34", "-1", "1.5", "12 34", "1/../../x", "9" * 13],
+    )
+    def test_non_numeric_or_overlong_ids_refused(self, monkeypatch, bad_id):
+        session = _install(monkeypatch, _ExplodingSession())
+        with pytest.raises(ValueError):
+            fetch_listing(bad_id)
+        assert session.requested == []
+
+    def test_numeric_id_builds_canonical_rightmove_url(self, monkeypatch):
+        session = _install(
+            monkeypatch,
+            _FakeSession(lambda url, **kw: _FakeResponse(url=url, body=_listing_html())),
+        )
+        fetch_listing("123456")
+        assert session.requested == ["https://www.rightmove.co.uk/properties/123456"]
+
+    def test_session_is_closed_even_when_input_is_rejected(self, monkeypatch):
+        session = _install(monkeypatch, _FakeSession(lambda url, **kw: _FakeResponse(url=url)))
+        with pytest.raises(ValueError):
+            fetch_listing("not-an-id")
+        assert session.closed or session.requested == []
+
+
+# --------------------------------------------------------------------------
+# fetch_listings — allowlisted search URLs only
+# --------------------------------------------------------------------------
+
+
+class TestFetchListingsHostAllowlist:
+    @pytest.mark.parametrize(
+        "hostile",
+        [
+            "https://evil.example/search",
+            "https://www.rightmove.co.uk.evil.example/search",
+            "https://www.rightmove.co.uk@evil.example/search",
+            "http://www.rightmove.co.uk/search",
+            "https://www.rightmove.co.uk:8080/search",
+            "https://169.254.169.254/",
+        ],
+    )
+    def test_unsafe_search_urls_refused_without_any_request(self, monkeypatch, hostile):
+        session = _install(monkeypatch, _ExplodingSession())
+        with pytest.raises((ValueError, UnsafeURLError, RightmoveError)):
+            fetch_listings(hostile)
+        assert session.requested == []
+
+    def test_allowlisted_search_url_is_fetched(self, monkeypatch):
+        session = _install(
+            monkeypatch,
+            _FakeSession(lambda url, **kw: _FakeResponse(url=url, body=_search_html())),
+        )
+        url = "https://www.rightmove.co.uk/property-for-sale/find.html?locationIdentifier=X"
+        assert fetch_listings(url, max_pages=1) == []
+        assert session.requested and session.requested[0].startswith(
+            "https://www.rightmove.co.uk/"
+        )
+
+    def test_redirects_are_not_delegated_to_the_http_client(self, monkeypatch):
+        """The whole redirect defense rests on allow_redirects=False.
+
+        Without this assertion, deleting `allow_redirects=False` from
+        _make_request leaves every redirect test green — requests would follow
+        redirects itself, _make_request would never observe a 3xx, and an
+        allowlisted host could bounce us anywhere. Assert the kwarg directly.
+        """
+        session = _install(
+            monkeypatch,
+            _FakeSession(lambda url, **kw: _FakeResponse(url=url, body=_search_html())),
+        )
+        fetch_listings(
+            "https://www.rightmove.co.uk/property-for-sale/find.html?a=b", max_pages=1
+        )
+        assert session.requested_kwargs, "no request was made"
+        for kwargs in session.requested_kwargs:
+            assert kwargs.get("allow_redirects") is False, (
+                "allow_redirects must be False so each hop is re-validated"
+            )
+            assert kwargs.get("stream") is True, (
+                "stream must be True so the byte cap applies before the body is buffered"
+            )
+
+    def test_listing_detail_also_disables_client_redirects(self, monkeypatch):
+        session = _install(
+            monkeypatch,
+            _FakeSession(lambda url, **kw: _FakeResponse(url=url, body=_listing_html())),
+        )
+        fetch_listing("123456")
+        assert session.requested_kwargs
+        for kwargs in session.requested_kwargs:
+            assert kwargs.get("allow_redirects") is False
+            assert kwargs.get("stream") is True
+
+    def test_fetched_url_is_the_canonicalised_value_not_the_raw_input(self, monkeypatch):
+        """Guards against 'validate A, fetch B' parser-differential drift."""
+        session = _install(
+            monkeypatch,
+            _FakeSession(lambda url, **kw: _FakeResponse(url=url, body=_search_html())),
+        )
+        fetch_listings(
+            "https://www.rightmove.co.uk:443/property-for-sale/find.html?a=b", max_pages=1
+        )
+        assert session.requested[0] == "https://www.rightmove.co.uk/property-for-sale/find.html?a=b"
+
+
+# --------------------------------------------------------------------------
+# Redirect handling
+# --------------------------------------------------------------------------
+
+
+class TestRedirects:
+    def _redirecting(self, location, *, status=302):
+        def responder(url, **kwargs):  # noqa: ARG001
+            if "find.html" in url and "redirected" not in url:
+                headers = {} if location is None else {"Location": location}
+                return _FakeResponse(url=url, status_code=status, headers=headers)
+            return _FakeResponse(url=url, body=_search_html())
+
+        return responder
+
+    START = "https://www.rightmove.co.uk/property-for-sale/find.html?locationIdentifier=X"
+
+    def test_cross_host_redirect_is_not_followed(self, monkeypatch):
+        session = _install(monkeypatch, _FakeSession(self._redirecting("https://evil.example/x")))
+        with pytest.raises((RightmoveError, UnsafeURLError, ValueError)):
+            fetch_listings(self.START, max_pages=1)
+        assert not any("evil.example" in u for u in session.requested)
+
+    def test_protocol_relative_redirect_is_not_followed(self, monkeypatch):
+        session = _install(monkeypatch, _FakeSession(self._redirecting("//evil.example/x")))
+        with pytest.raises((RightmoveError, UnsafeURLError, ValueError)):
+            fetch_listings(self.START, max_pages=1)
+        assert not any("evil.example" in u for u in session.requested)
+
+    def test_redirect_without_location_is_rejected(self, monkeypatch):
+        _install(monkeypatch, _FakeSession(self._redirecting(None)))
+        with pytest.raises(RightmoveError):
+            fetch_listings(self.START, max_pages=1)
+
+    def test_same_host_relative_redirect_is_followed(self, monkeypatch):
+        session = _install(
+            monkeypatch, _FakeSession(self._redirecting("/property-for-sale/redirected.html"))
+        )
+        fetch_listings(self.START, max_pages=1)
+        assert session.requested[-1] == (
+            "https://www.rightmove.co.uk/property-for-sale/redirected.html"
+        )
+
+    def test_redirect_loop_is_bounded(self, monkeypatch):
+        def responder(url, **kwargs):  # noqa: ARG001
+            return _FakeResponse(
+                url=url,
+                status_code=302,
+                headers={"Location": "https://www.rightmove.co.uk/loop"},
+            )
+
+        session = _install(monkeypatch, _FakeSession(responder))
+        with pytest.raises(RightmoveError):
+            fetch_listings(self.START, max_pages=1)
+        assert len(session.requested) <= 6, "redirect chain must be capped"
+
+
+# --------------------------------------------------------------------------
+# Response size caps
+# --------------------------------------------------------------------------
+
+
+class TestResponseSizeCap:
+    START = "https://www.rightmove.co.uk/property-for-sale/find.html?locationIdentifier=X"
+
+    def test_oversized_content_length_rejected(self, monkeypatch):
+        def responder(url, **kwargs):  # noqa: ARG001
+            return _FakeResponse(
+                url=url,
+                headers={"Content-Length": str(50 * 1024 * 1024)},
+                body=b"x" * 10,
+            )
+
+        _install(monkeypatch, _FakeSession(responder))
+        with pytest.raises(RightmoveError):
+            fetch_listings(self.START, max_pages=1)
+
+    def test_oversized_stream_rejected_and_response_closed(self, monkeypatch):
+        """No Content-Length (or a spoofed one) must still be capped while streaming."""
+
+        def responder(url, **kwargs):  # noqa: ARG001
+            return _FakeResponse(url=url, headers={}, body=b"x" * (30 * 1024 * 1024))
+
+        session = _install(monkeypatch, _FakeSession(responder))
+        with pytest.raises(RightmoveError):
+            fetch_listings(self.START, max_pages=1)
+        assert session.responses and all(r.closed for r in session.responses)
+
+
+class TestPublicMcpSurfaceStaysNumericOnly:
+    """The library accepts a canonical listing URL for downstream compatibility;
+    the public MCP tool deliberately does not widen its input."""
+
+    @pytest.mark.anyio
+    async def test_mcp_tool_rejects_listing_url(self, monkeypatch):
+        from app.mcp.server import rightmove_listing
+
+        session = _install(monkeypatch, _ExplodingSession())
+        with pytest.raises(ValueError):
+            await rightmove_listing("https://www.rightmove.co.uk/properties/123456")
+        assert session.requested == []
+
+    @pytest.mark.anyio
+    async def test_mcp_tool_accepts_numeric_id(self, monkeypatch):
+        from app.mcp.server import rightmove_listing
+
+        session = _install(
+            monkeypatch,
+            _FakeSession(lambda url, **kw: _FakeResponse(url=url, body=_listing_html())),
+        )
+        await rightmove_listing("123456")
+        assert session.requested == ["https://www.rightmove.co.uk/properties/123456"]

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -1,0 +1,133 @@
+"""Unit tests for the URL allowlist helper used to close the Rightmove SSRF paths.
+
+The scraper previously accepted any string beginning with "http" and fetched it
+server-side (property_core/rightmove_scraper.py::_normalize_property_url), which
+was reachable from an unauthenticated MCP tool and two unauthenticated REST
+endpoints. These tests pin the validation contract that replaces that behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from property_core.url_safety import UnsafeURLError, validate_allowed_url
+
+RIGHTMOVE = frozenset({"www.rightmove.co.uk"})
+MEDIA = frozenset({"media.rightmove.co.uk"})
+
+
+class TestAccepts:
+    def test_allowlisted_https_host(self):
+        url = "https://www.rightmove.co.uk/properties/123456"
+        assert validate_allowed_url(url, allowed_hosts=RIGHTMOVE) == url
+
+    def test_preserves_query_string(self):
+        url = "https://www.rightmove.co.uk/property-for-sale/find.html?index=24&radius=0.25"
+        out = validate_allowed_url(url, allowed_hosts=RIGHTMOVE)
+        assert "index=24" in out and "radius=0.25" in out
+
+    def test_explicit_default_port_is_allowed(self):
+        out = validate_allowed_url(
+            "https://www.rightmove.co.uk:443/properties/1", allowed_hosts=RIGHTMOVE
+        )
+        # Canonicalised back to the implicit default port.
+        assert out == "https://www.rightmove.co.uk/properties/1"
+
+    def test_separate_allowlists_are_independent(self):
+        media = "https://media.rightmove.co.uk/photo.jpeg"
+        assert validate_allowed_url(media, allowed_hosts=MEDIA) == media
+        # ...but the media host is not valid for the search/listing allowlist.
+        with pytest.raises(UnsafeURLError):
+            validate_allowed_url(media, allowed_hosts=RIGHTMOVE)
+
+
+class TestRejects:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://evil.example/x",
+            # Lookalike hosts — the exact bypass the old startswith() check allowed.
+            "https://www.rightmove.co.uk.evil.example/x",
+            "https://wwwXrightmoveXco.uk/x",
+            "https://evil.example/www.rightmove.co.uk",
+            # Userinfo tricks: the real host here is evil.example.
+            "https://www.rightmove.co.uk@evil.example/x",
+            "https://user:pass@evil.example/x",
+            # Credentials even on an allowlisted host.
+            "https://user:pass@www.rightmove.co.uk/x",
+            # Non-https schemes.
+            "http://www.rightmove.co.uk/properties/1",
+            "file:///etc/passwd",
+            "gopher://www.rightmove.co.uk/x",
+            # Non-default ports.
+            "https://www.rightmove.co.uk:8080/x",
+            "https://www.rightmove.co.uk:22/x",
+            # Internal / cloud-metadata targets — the classic SSRF payloads.
+            "https://127.0.0.1/x",
+            "https://localhost/x",
+            "https://169.254.169.254/latest/meta-data/",
+            "https://[::1]/x",
+        ],
+    )
+    def test_unsafe_urls_raise(self, url):
+        with pytest.raises(UnsafeURLError):
+            validate_allowed_url(url, allowed_hosts=RIGHTMOVE)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://www.rightmove.co.uk\\@evil.example/x",
+            "https:\\\\evil.example/x",
+            "https://www.rightmove.co.uk/x\nHost: evil.example",
+            "https://www.rightmove.co.uk/x\r\nX: y",
+            "https://www.rightmove.co.uk\t/x",
+            "https://www.rightmove.co.uk/x\x00",
+        ],
+    )
+    def test_control_chars_and_backslashes_raise(self, url):
+        """Parser-differential guards.
+
+        Backslashes and control characters are the classic way two URL parsers
+        disagree about where the host ends. Rejecting them outright means we
+        never validate one interpretation while the HTTP client fetches another.
+        """
+        with pytest.raises(UnsafeURLError):
+            validate_allowed_url(url, allowed_hosts=RIGHTMOVE)
+
+    def test_malformed_url_raises_unsafe_not_raw_valueerror(self):
+        """A parse failure must surface as UnsafeURLError, never a raw ValueError.
+
+        Callers map UnsafeURLError to a clean 4xx/RightmoveError; a leaked
+        ValueError would become an unhandled 500.
+        """
+        with pytest.raises(UnsafeURLError):
+            validate_allowed_url("https://www.rightmove.co.uk:notaport/x", allowed_hosts=RIGHTMOVE)
+
+    def test_empty_and_relative_urls_raise(self):
+        for url in ("", "/properties/123", "www.rightmove.co.uk/x"):
+            with pytest.raises(UnsafeURLError):
+                validate_allowed_url(url, allowed_hosts=RIGHTMOVE)
+
+
+class TestCanonicalisation:
+    """The returned value — not the input — is what callers must fetch."""
+
+    def test_returns_canonical_form_built_from_validated_parts(self):
+        out = validate_allowed_url(
+            "https://www.rightmove.co.uk:443/properties/1?a=b#fragment",
+            allowed_hosts=RIGHTMOVE,
+        )
+        assert out.startswith("https://www.rightmove.co.uk/")
+        assert "#" not in out, "fragment must be dropped"
+        assert "a=b" in out
+
+    def test_empty_path_is_canonicalised_to_root(self):
+        out = validate_allowed_url("https://www.rightmove.co.uk", allowed_hosts=RIGHTMOVE)
+        assert out == "https://www.rightmove.co.uk/"
+
+    def test_output_revalidates_cleanly(self):
+        """Canonical output must itself pass validation (idempotence)."""
+        once = validate_allowed_url(
+            "https://www.rightmove.co.uk:443/properties/1?a=b", allowed_hosts=RIGHTMOVE
+        )
+        assert validate_allowed_url(once, allowed_hosts=RIGHTMOVE) == once

--- a/uv.lock
+++ b/uv.lock
@@ -1175,7 +1175,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Security hotfix for three independently verified defects. Branched from `57deef9`, the commit actually deployed as Fly release v122 — deliberately **not** from the local working tree, which carries an unrelated, unverified `_HttpGuard` claude.ai compatibility experiment that must not ride along with a security release.

## 1. SSRF in the Rightmove fetch paths (release blocker)

`fetch_listing()` passed any string starting with `http` straight to `session.get()` with no host or scheme validation; `fetch_listings()` accepted an arbitrary search URL. Both were reachable from **unauthenticated** surfaces: the `rightmove_listing` MCP tool, `GET /v1/rightmove/listings`, and `GET /v1/rightmove/listing/{id}`.

Verified against the unfixed code — all three payloads reached the network layer, with `RightmoveError` raised only *after* the request went out (which is why "it raises an error" was never evidence of safety):

| Payload | Before | After |
|---|---|---|
| `http://169.254.169.254/latest/meta-data/…` | **REACHED** | blocked, no request |
| `https://www.rightmove.co.uk@evil.example/steal` | **REACHED** | blocked, no request |
| `http://127.0.0.1:8080/internal/admin` | **REACHED** | blocked, no request |

New `property_core/url_safety.py`: exact host allowlist, https only, no userinfo, default port only, no suffix/substring matching. It returns a **canonical URL rebuilt from validated components**, and every caller fetches that returned value rather than the raw input — closing the `requests`/`urllib3`-vs-`urlparse` parser-differential gap rather than assuming the two parsers agree. Redirects are resolved and re-validated per hop instead of delegated to the HTTP client; responses are size-capped.

The `/img` proxy used `url.startswith("https://media.rightmove.co.uk")`, which lookalike hosts (`…co.uk.evil.example`) and userinfo tricks (`…co.uk@evil.example`) both defeat. It now validates with **httpx's own parser** — the parser that issues the request, so the two cannot disagree about the host — streams with a byte cap, refuses non-image `Content-Type`s, and sets `nosniff`.

### Downstream compatibility preserved
`property-descriptions-mcp` and `uk-property-mcp` both advertise "URL or ID" and depend on `property-shared>=1.10.0` / `>=1.12.0`, so a numeric-only library contract would break them on next clean install. `fetch_listing()` therefore still accepts a canonical `rightmove.co.uk/properties/<id>` URL — but **only as a source of digits**: it is host-validated, the ID is extracted, and the fetch URL is rebuilt internally. The caller's URL is never requested. Any other path (`/redirect?to=...`), host, scheme or port raises.

The original parameter name **`property_url_or_id` is retained**, so both positional and keyword callers (`fetch_listing(property_url_or_id="...")`) work unchanged — the library is published on PyPI, so external keyword callers exist beyond the two known sibling servers. The name has no bearing on validation; the value still goes through `extract_property_id()`. Four regression tests pin this, including that the legacy keyword form is still fully validated and that the parameter name itself cannot be renamed silently.

Public REST/MCP/CLI surfaces remain numeric-ID-only, with tests pinning that split.

## 2. Incorrect EPC/MEES regulatory text

Both MCP servers claimed — in the `epc-ratings://reference` resource **and** in the `investment_analysis` prompt — that band C has been required for new tenancies since April 2025, with existing tenancies by 2028. Verified against gov.uk: the current legal minimum is **band E** (since 1 April 2020, subject to exemptions), and band C is proposed for a **single** compliance date of **1 October 2030** (an earlier date for new tenancies was explicitly rejected), not yet in force. Because this reached users through a resource and a prompt, it could distort an analysis with no tool call involved.

## 3. `record_status` AttributeError

`sparql_search()` filtered `PPDTransaction` on `record_status`, a field that only exists on `PPDTransactionRecord` (built by the Linked Data lookup, not SPARQL search) — so any non-`None` value crashed on the first returned row. Reproduced, then replaced with `UnsupportedRecordStatusFilterError` raised before the query is built. The REST route maps it to **422** via a dedicated exception subclass, deliberately narrow so unrelated errors still surface as 502. Real SPARQL-level filtering is deferred until the triple shape is verified against the live ontology.

## Also fixed
- **Latent CLI `TypeError`** — `rightmove listing` passed `include_raw=` to `fetch_listing()`, which never accepted it; the core-mode branch failed on every invocation.
- **Two tests stale since v1.12.0's** `get_epc_certificate` → `epc_certificate` rename — the suite was red at the deployment base.
- **`pytest` collection footgun** — the default `*_test.py` glob matched `scripts/epc_token_test.py`, so a bare `pytest` imported and ran a live-network script. Renamed + `testpaths` added.
- **Documented test commands** in `CLAUDE.md`/`GUIDELINES.md` omitted `--extra api` and could not collect two test modules.

## Verification

- **286 passed, exit code 0**, on **Python 3.11 (production's version, per Dockerfile) and 3.12**. Dependency versions are identical to production (`uv.lock` frozen).
- **Mutation-tested**: deleting `allow_redirects=False`, or flipping the proxy's `follow_redirects`, now **fails** the suite. Before these assertions were added, both mutations left it fully green while reopening the vulnerability.
- **Adversarial review** probed 28 hostile URL forms (IDN homographs, percent-encoded hosts, trailing dots, IPv6, decimal-IP, empty netloc) and found no bypass; its findings on the `/img` cap, `Content-Type` forwarding, a `pydantic.ValidationError`-as-422 misclassification, and the test gaps are all fixed here.
- **Live probes**: Rightmove search, numeric-ID fetch, URL-form fetch, and the legacy `property_url_or_id=` keyword form all confirmed against production Rightmove on Python 3.11.

## Not included, deliberately
- The `_HttpGuard` claude.ai experiment — unverified, not currently deployed, and needs its own A/B against the live client.
- The wider README/GitHub/PyPI documentation sweep (release-version metadata is consistent here: `pyproject.toml`, `uv.lock`, both `server.json` fields, changelog heading all at 1.13.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
