### PR TITLE
fix(epc): stop reporting EPC outages as "no certificate exists" (v1.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.13.1 (2026-08-24) — EPC honest-failure hotfix
+
+### Fixed
+- **EPC lookups reported service outages as "no certificate exists".** The API host hardcoded in `EPCClient.BASE_URL` (`epc.opendatacommunities.org`) has been retired and now 301-redirects. Because every failure was caught by a broad `except (httpx.HTTPError, KeyError, ValueError)` and converted to `None`/`[]`, the deployed product answered `404 "No EPC certificate found"` for **every postcode in England and Wales**, and `/v1/epc/search-area` returned **HTTP 200 with `count: 0`** — an outage rendered as valid data. MCP tools returned `null` with `isError: false` alongside docstrings telling the model "Returns None if no certificates exist", so an LLM would state that a property has no EPC.
+
+  EPC lookups now raise `EPCUpstreamError` when the service cannot be consulted — non-success status (redirects included), transport failure, unparseable body, an unrecognised response envelope, or missing credentials. A reachable upstream holding no certificate still returns `None`/`[]`, so genuine absence is unchanged. REST maps the error to **503** (never 404, never an empty 200); MCP tools surface it as a tool error rather than a null result; tool docstrings no longer instruct consumers to infer absence.
+
+  This is a stop-the-bleeding fix: it stops the system asserting a falsehood. **It does not restore EPC data** — the replacement GOV.UK API uses different auth, envelope, field casing and identifiers, and migrating to it is tracked separately.
+- `enrich_comps_with_epc()` used `asyncio.gather` without `return_exceptions=True`. With EPC lookups now raising, a single failing postcode would have discarded every successfully-fetched postcode in the batch and propagated out of the whole comps request. Failed postcodes are now left un-enriched and logged; successful ones survive.
+
 ## v1.13.0 (2026-08-24) — security hotfix
 
 ### Security

--- a/app/api/v1/epc.py
+++ b/app/api/v1/epc.py
@@ -9,11 +9,20 @@ from fastapi import APIRouter, HTTPException, Query
 
 from app.schemas.epc import EPCAreaResponse, EPCAreaSummary, EPCRecordResponse
 from property_core.address_matching import parse_address
-from property_core.epc_client import EPCClient
+from property_core.epc_client import EPCClient, EPCUpstreamError
 from property_core.models.epc import EPCData
 
 router = APIRouter(prefix="/epc", tags=["epc"])
 _client = EPCClient()
+
+
+def _upstream_unavailable(exc: EPCUpstreamError) -> HTTPException:
+    """Map an EPC outage to 503, never to 404 or an empty 200.
+
+    Reporting an outage as "not found" (or as a zero-count area summary) states
+    a falsehood about the property, which is worse than failing.
+    """
+    return HTTPException(status_code=503, detail=f"EPC service unavailable: {exc}")
 
 
 def _build_area_summary(certs: list[EPCData]) -> EPCAreaSummary:
@@ -41,7 +50,10 @@ async def get_certificate(
     if not _client.is_configured():
         raise HTTPException(status_code=501, detail="EPC client not configured")
 
-    result = await _client.get_certificate(certificate_hash)
+    try:
+        result = await _client.get_certificate(certificate_hash)
+    except EPCUpstreamError as exc:
+        raise _upstream_unavailable(exc) from exc
     if result is None:
         raise HTTPException(status_code=404, detail="No EPC certificate found")
     return EPCRecordResponse(record=result, raw=result.raw if include_raw else None)
@@ -77,7 +89,10 @@ async def search(
     if not postcode:
         raise HTTPException(status_code=422, detail="postcode or q parameter required")
 
-    result = await _client.search_by_postcode(postcode, address=address)
+    try:
+        result = await _client.search_by_postcode(postcode, address=address)
+    except EPCUpstreamError as exc:
+        raise _upstream_unavailable(exc) from exc
     if result is None:
         raise HTTPException(status_code=404, detail="No EPC certificate found")
     return EPCRecordResponse(record=result, raw=result.raw if include_raw else None)
@@ -96,7 +111,12 @@ async def search_area(
     if not _client.is_configured():
         raise HTTPException(status_code=501, detail="EPC client not configured")
 
-    certs = await _client.search_all_by_postcode(postcode)
+    try:
+        certs = await _client.search_all_by_postcode(postcode)
+    except EPCUpstreamError as exc:
+        # Never return a zero-count summary for an outage: it is indistinguishable
+        # from a postcode that genuinely has no certificates.
+        raise _upstream_unavailable(exc) from exc
     return EPCAreaResponse(
         postcode=postcode,
         summary=_build_area_summary(certs),

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -259,7 +259,7 @@ async def property_epc(postcode: str, address: str | None = None) -> dict | None
     postcode — count, rating distribution, property-type breakdown, floor-area
     range — plus a hint to call again with an address for single-property detail.
 
-    Returns None if no certificates exist for the postcode at all.
+    Returns null only when no certificates are lodged for the postcode. A null result means no such certificate is lodged. If the EPC service cannot be reached the tool raises an error instead — never treat an error as evidence that a property has no certificate.
     """
     from collections import Counter
 
@@ -318,7 +318,7 @@ async def property_epc_search(postcode: str) -> list[dict] | None:
          If floor_area is unavailable on the listing, filter by property_type only
          and return all candidates.
 
-    Returns None if no certificates exist for the postcode.
+    Returns null only when no certificates are lodged for the postcode. A null result means no such certificate is lodged. If the EPC service cannot be reached the tool raises an error instead — never treat an error as evidence that a property has no certificate.
     """
     from property_core import EPCClient
 
@@ -347,7 +347,7 @@ async def epc_certificate(lmk_key: str) -> dict | None:
 
     lmk_key is returned in every property_epc_search result.
 
-    Returns the full EPC certificate or None if not found.
+    Returns the full EPC certificate, or null only when no such certificate is lodged. A null result means no such certificate is lodged. If the EPC service cannot be reached the tool raises an error instead — never treat an error as evidence that a property has no certificate.
     """
     from property_core import EPCClient
 

--- a/property_app/tools.py
+++ b/property_app/tools.py
@@ -316,7 +316,7 @@ async def epc_search(
          If floor_area is unavailable on the listing, filter by property_type only
          and return all candidates.
 
-    Returns None if no certificates exist for the postcode.
+    Returns null only when no certificates are lodged for the postcode. A null result means no such certificate is lodged. If the EPC service cannot be reached the tool raises an error instead — never treat an error as evidence that a property has no certificate.
     """
     return await browse_epc_certs(postcode)
 
@@ -348,7 +348,7 @@ async def epc_certificate(
 
     lmk_key is returned in every epc_search result.
 
-    Returns the full EPC certificate or None if not found.
+    Returns the full EPC certificate, or null only when no such certificate is lodged. A null result means no such certificate is lodged. If the EPC service cannot be reached the tool raises an error instead — never treat an error as evidence that a property has no certificate.
     """
     return await fetch_epc_certificate(lmk_key)
 

--- a/property_core/enrichment.py
+++ b/property_core/enrichment.py
@@ -8,12 +8,15 @@ derived price-per-sqft metrics.
 from __future__ import annotations
 
 import asyncio
+import logging
 from statistics import median
 from typing import Dict, List, Optional
 
 from property_core.epc_client import EPCClient
 from property_core.models.epc import EPCData
 from property_core.models.ppd import PPDCompsResponse, PPDTransaction
+
+_log = logging.getLogger(__name__)
 
 # Conversion factor
 _SQM_TO_SQFT = 10.7639
@@ -78,9 +81,27 @@ async def enrich_comps_with_epc(
             certs = await epc_client.search_all_by_postcode(postcode)
             postcode_certs[postcode] = certs
 
-    await asyncio.gather(
-        *[_fetch_postcode(pc) for pc in postcode_groups.keys()]
+    # return_exceptions=True is load-bearing: EPC lookups now raise on upstream
+    # failure, and enrichment is a best-effort augmentation of comps. Without
+    # this, one failing postcode would discard every successfully-fetched
+    # postcode in the batch AND propagate out of the comps request entirely.
+    # Failed postcodes are simply left un-enriched.
+    results = await asyncio.gather(
+        *[_fetch_postcode(pc) for pc in postcode_groups.keys()],
+        return_exceptions=True,
     )
+    failed = [
+        (pc, exc)
+        for pc, exc in zip(postcode_groups.keys(), results)
+        if isinstance(exc, BaseException)
+    ]
+    if failed:
+        _log.warning(
+            "EPC enrichment degraded: %d of %d postcodes could not be fetched (%s)",
+            len(failed),
+            len(postcode_groups),
+            "; ".join(f"{pc}: {type(exc).__name__}" for pc, exc in failed[:3]),
+        )
 
     # Match each comp against its postcode's certs
     for postcode, indices in postcode_groups.items():

--- a/property_core/epc_client.py
+++ b/property_core/epc_client.py
@@ -15,6 +15,20 @@ from property_core.address_matching import match_epc_address
 from property_core.models.epc import EPCData
 
 
+class EPCUpstreamError(RuntimeError):
+    """The EPC service could not be consulted, so absence cannot be concluded.
+
+    Deliberately NOT a ValueError: this is an upstream/configuration fault, not
+    caller error, and must not be mapped to a 4xx or reported to an LLM as
+    "no certificate exists for this property".
+
+    Raised for: unreachable or erroring upstream (including redirects — the
+    original API host was retired and now 301s), unparseable responses, an
+    unrecognised response envelope, and missing credentials. A reachable
+    upstream that genuinely holds no certificate still returns None/[].
+    """
+
+
 class EPCClient:
     """Client for UK EPC Register API."""
 
@@ -29,9 +43,69 @@ class EPCClient:
         self.email = email or os.getenv("EPC_API_EMAIL")
         self.api_key = api_key or os.getenv("EPC_API_KEY")
         self.timeout = timeout
+        # Overridable transport, so failure modes can be exercised in tests.
+        self._transport: httpx.AsyncBaseTransport | None = None
 
     def is_configured(self) -> bool:
         return bool(self.email and self.api_key)
+
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=self.timeout, transport=self._transport)
+
+    def _require_configured(self) -> None:
+        if not self.is_configured():
+            raise EPCUpstreamError(
+                "EPC service is not configured (set EPC_API_EMAIL and EPC_API_KEY). "
+                "Absence of a certificate cannot be concluded."
+            )
+
+    async def _get_rows(self, url: str, params: dict | None = None) -> list[dict]:
+        """Fetch and unwrap an EPC response, raising rather than degrading.
+
+        Any non-success status (redirects included), transport error, parse
+        failure, or unrecognised envelope raises EPCUpstreamError. Only a
+        successful response whose envelope is understood yields rows — which
+        may legitimately be empty.
+        """
+        self._require_configured()
+        try:
+            async with self._client() as client:
+                resp = await client.get(
+                    url,
+                    params=params,
+                    headers={"Accept": "application/json", **self._auth_header()},
+                )
+        except httpx.HTTPError as exc:
+            raise EPCUpstreamError(f"EPC request to {url} failed: {exc}") from exc
+
+        if resp.is_redirect or resp.status_code >= 300:
+            raise EPCUpstreamError(
+                f"EPC upstream returned HTTP {resp.status_code} for {url}"
+                + (
+                    f" (redirect to {resp.headers.get('Location')!r} — the API host may have moved)"
+                    if resp.is_redirect
+                    else ""
+                )
+            )
+
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise EPCUpstreamError(
+                f"EPC upstream returned a non-JSON body for {url}: {exc}"
+            ) from exc
+
+        if not isinstance(data, dict) or "rows" not in data:
+            raise EPCUpstreamError(
+                f"EPC upstream returned an unrecognised response envelope for {url} "
+                f"(expected a 'rows' key, got keys: {sorted(data)[:6] if isinstance(data, dict) else type(data).__name__}). "
+                "The upstream contract may have changed."
+            )
+
+        rows = data.get("rows") or []
+        if not isinstance(rows, list):
+            raise EPCUpstreamError(f"EPC upstream returned a non-list 'rows' for {url}")
+        return rows
 
     def _auth_header(self) -> dict[str, str]:
         if not self.email or not self.api_key:
@@ -45,28 +119,16 @@ class EPCClient:
         """Get EPC certificate by lmk-key (certificate hash).
 
         Returns:
-            EPCData model or None.
+            EPCData, or None if the certificate genuinely does not exist.
+
+        Raises:
+            EPCUpstreamError: If the EPC service could not be consulted, so
+                absence cannot be concluded.
         """
-        if not self.is_configured():
+        rows = await self._get_rows(f"{self.BASE_URL}/domestic/certificate/{certificate_hash}")
+        if not rows:
             return None
-
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            try:
-                resp = await client.get(
-                    f"{self.BASE_URL}/domestic/certificate/{certificate_hash}",
-                    headers={"Accept": "application/json", **self._auth_header()},
-                )
-                resp.raise_for_status()
-                data = resp.json()
-
-                rows = data.get("rows", [])
-                if not rows:
-                    return None
-
-                return EPCData.from_api_row(rows[0])
-
-            except (httpx.HTTPError, KeyError, ValueError):
-                return None
+        return EPCData.from_api_row(rows[0])
 
     async def search_all_by_postcode(
         self, postcode: str
@@ -77,24 +139,17 @@ class EPCClient:
         certificates (e.g. enriching PPD comparables with floor area).
 
         Returns:
-            List of EPCData models (may be empty).
-        """
-        if not self.is_configured():
-            return []
+            List of EPCData models. Empty means the postcode genuinely has no
+            certificates lodged — never that the lookup failed.
 
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            try:
-                resp = await client.get(
-                    f"{self.BASE_URL}/domestic/search",
-                    params={"postcode": postcode.replace(" ", "")},
-                    headers={"Accept": "application/json", **self._auth_header()},
-                )
-                resp.raise_for_status()
-                data = resp.json()
-                rows = data.get("rows", [])
-                return [EPCData.from_api_row(row) for row in rows]
-            except (httpx.HTTPError, KeyError, ValueError):
-                return []
+        Raises:
+            EPCUpstreamError: If the EPC service could not be consulted.
+        """
+        rows = await self._get_rows(
+            f"{self.BASE_URL}/domestic/search",
+            params={"postcode": postcode.replace(" ", "")},
+        )
+        return [EPCData.from_api_row(row) for row in rows]
 
     def match_address(
         self, certificates: list[EPCData], address: str, min_score: int = 30
@@ -119,33 +174,24 @@ class EPCClient:
         """Search for EPC by postcode, optionally matching address.
 
         Returns:
-            EPCData model or None.
+            EPCData, or None if the postcode genuinely has no certificates (or
+            none matched ``address``).
+
+        Raises:
+            EPCUpstreamError: If the EPC service could not be consulted.
         """
-        if not self.is_configured():
+        rows = await self._get_rows(
+            f"{self.BASE_URL}/domestic/search",
+            params={"postcode": postcode.replace(" ", "")},
+        )
+        if not rows:
             return None
 
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            try:
-                resp = await client.get(
-                    f"{self.BASE_URL}/domestic/search",
-                    params={"postcode": postcode.replace(" ", "")},
-                    headers={"Accept": "application/json", **self._auth_header()},
-                )
-                resp.raise_for_status()
-                data = resp.json()
+        if address:
+            certs = [EPCData.from_api_row(row) for row in rows]
+            result = match_epc_address(certs, address, min_score=30)
+            if result:
+                return result[0]  # return the EPCData
+            return None  # BUG FIX: was falling through to rows[0]
 
-                rows = data.get("rows", [])
-                if not rows:
-                    return None
-
-                if address:
-                    certs = [EPCData.from_api_row(row) for row in rows]
-                    result = match_epc_address(certs, address, min_score=30)
-                    if result:
-                        return result[0]  # return the EPCData
-                    return None  # BUG FIX: was falling through to rows[0]
-
-                return EPCData.from_api_row(rows[0])
-
-            except (httpx.HTTPError, KeyError, ValueError):
-                return None
+        return EPCData.from_api_row(rows[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.13.0"
+version = "1.13.1"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates, rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/tests/test_epc_honest_failure.py
+++ b/tests/test_epc_honest_failure.py
@@ -1,0 +1,233 @@
+"""EPC upstream failures must not be reported as "no certificate exists".
+
+Context: the API host hardcoded in EPCClient.BASE_URL was retired and now 301s
+to a GOV.UK landing page. Because every failure was caught by a broad
+`except (httpx.HTTPError, KeyError, ValueError)` and turned into None/[], the
+deployed product answered "No EPC certificate found" for every postcode in
+England and Wales, and the area endpoint returned HTTP 200 with count: 0.
+
+The distinction these tests pin is narrow and deliberate:
+  * upstream reachable, genuinely nothing lodged  -> None / []   (unchanged)
+  * upstream unreachable/erroring/misconfigured   -> EPCUpstreamError
+
+Migrating to the replacement API is explicitly NOT in scope here. The goal is
+that the system stops asserting a falsehood.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from property_core.epc_client import EPCClient, EPCUpstreamError
+
+
+def _client(handler, *, configured=True):
+    c = EPCClient(email="t@example.com" if configured else None,
+                  api_key="k" if configured else None)
+    c._transport = httpx.MockTransport(handler)  # honoured by the client under test
+    return c
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --------------------------------------------------------------------------
+# Upstream failure must raise, not return "no data"
+# --------------------------------------------------------------------------
+
+
+class TestUpstreamFailuresRaise:
+    @pytest.mark.parametrize(
+        "status",
+        [301, 302, 400, 401, 403, 404, 429, 500, 502, 503],
+    )
+    def test_non_success_status_raises(self, status):
+        """A redirect is the live failure mode — the retired host 301s."""
+        c = _client(lambda req: httpx.Response(status, text="nope"))
+        with pytest.raises(EPCUpstreamError):
+            _run(c.search_all_by_postcode("NG7 1FN"))
+        with pytest.raises(EPCUpstreamError):
+            _run(c.search_by_postcode("NG7 1FN"))
+        with pytest.raises(EPCUpstreamError):
+            _run(c.get_certificate("abc"))
+
+    def test_network_error_raises(self):
+        def boom(request):
+            raise httpx.ConnectError("dns failure", request=request)
+
+        c = _client(boom)
+        with pytest.raises(EPCUpstreamError):
+            _run(c.search_all_by_postcode("NG7 1FN"))
+
+    def test_malformed_json_raises(self):
+        c = _client(lambda req: httpx.Response(200, text="<html>not json</html>"))
+        with pytest.raises(EPCUpstreamError):
+            _run(c.search_all_by_postcode("NG7 1FN"))
+
+    def test_unexpected_envelope_raises(self):
+        """The replacement API returns {"data": [...]}, not {"rows": [...]}.
+
+        Silently reading .get("rows", []) off a foreign envelope is exactly how
+        a migrated-but-unadapted upstream would look like an empty result.
+        """
+        c = _client(lambda req: httpx.Response(200, json={"data": [{"x": 1}], "pagination": {}}))
+        with pytest.raises(EPCUpstreamError):
+            _run(c.search_all_by_postcode("NG7 1FN"))
+
+    def test_unconfigured_raises_not_empty(self):
+        """Missing credentials is an operator error, not an absence of data."""
+        c = _client(lambda req: httpx.Response(200, json={"rows": []}), configured=False)
+        with pytest.raises(EPCUpstreamError):
+            _run(c.search_all_by_postcode("NG7 1FN"))
+        with pytest.raises(EPCUpstreamError):
+            _run(c.get_certificate("abc"))
+
+
+# --------------------------------------------------------------------------
+# Genuine absence must still be absence
+# --------------------------------------------------------------------------
+
+
+class TestGenuineAbsenceUnchanged:
+    def test_empty_rows_returns_empty_list(self):
+        c = _client(lambda req: httpx.Response(200, json={"rows": []}))
+        assert _run(c.search_all_by_postcode("NG7 1FN")) == []
+
+    def test_empty_rows_returns_none_for_single_lookups(self):
+        c = _client(lambda req: httpx.Response(200, json={"rows": []}))
+        assert _run(c.search_by_postcode("NG7 1FN")) is None
+        assert _run(c.get_certificate("abc")) is None
+
+    def test_real_rows_still_parse(self):
+        row = {
+            "lmk-key": "abc123",
+            "address": "1 TEST STREET",
+            "postcode": "NG7 1FN",
+            "current-energy-rating": "C",
+            "current-energy-efficiency": "72",
+            "total-floor-area": "55.5",
+        }
+        c = _client(lambda req: httpx.Response(200, json={"rows": [row]}))
+        certs = _run(c.search_all_by_postcode("NG7 1FN"))
+        assert len(certs) == 1
+        assert certs[0].rating == "C" and certs[0].score == 72
+
+    def test_address_matching_no_match_is_absence_not_failure(self):
+        row = {"lmk-key": "k", "address": "1 OTHER STREET", "current-energy-rating": "C"}
+        c = _client(lambda req: httpx.Response(200, json={"rows": [row]}))
+        assert _run(c.search_by_postcode("NG7 1FN", address="999 NOWHERE LANE")) is None
+
+
+# --------------------------------------------------------------------------
+# The error must be distinguishable and actionable
+# --------------------------------------------------------------------------
+
+
+class TestErrorSemantics:
+    def test_error_message_names_the_upstream_and_cause(self):
+        c = _client(lambda req: httpx.Response(301, headers={"Location": "https://example.gov.uk/"}))
+        with pytest.raises(EPCUpstreamError) as exc:
+            _run(c.search_all_by_postcode("NG7 1FN"))
+        msg = str(exc.value)
+        assert "EPC" in msg
+        assert "301" in msg or "redirect" in msg.lower()
+
+    def test_is_not_a_valueerror_subclass_that_would_read_as_bad_input(self):
+        """Must not be mistaken for caller error (which would map to 4xx)."""
+        assert not issubclass(EPCUpstreamError, ValueError)
+
+
+# --------------------------------------------------------------------------
+# Enrichment must degrade per-postcode, not lose the whole batch
+# --------------------------------------------------------------------------
+
+
+class TestEnrichmentDegradesGracefully:
+    def test_one_failing_postcode_does_not_abort_the_batch(self):
+        """asyncio.gather without return_exceptions=True loses everything.
+
+        With EPC now raising, an un-hardened gather would 500 every
+        comps?enrich_epc=true request while the upstream is down.
+        """
+        from property_core.enrichment import enrich_comps_with_epc
+        from property_core.models.ppd import PPDTransaction
+
+        good_row = {
+            "lmk-key": "k", "address": "10 GOOD STREET", "postcode": "AA1 1AA",
+            "current-energy-rating": "B", "current-energy-efficiency": "85",
+            "total-floor-area": "50",
+        }
+
+        def handler(request):
+            if "BB2" in str(request.url):
+                return httpx.Response(503, text="upstream down")
+            return httpx.Response(200, json={"rows": [good_row]})
+
+        comps = [
+            PPDTransaction(transaction_id="1", price=200000, postcode="AA1 1AA",
+                           paon="10", street="GOOD STREET"),
+            PPDTransaction(transaction_id="2", price=300000, postcode="BB2 2BB",
+                           paon="20", street="BAD STREET"),
+        ]
+        client = _client(handler)
+
+        result = _run(enrich_comps_with_epc(comps, epc_client=client))
+
+        # The healthy postcode is still enriched...
+        assert result[0].epc_rating == "B", "successful postcode must survive a sibling failure"
+        # ...and the failing one is simply un-enriched, not fatal.
+        assert result[1].epc_rating is None
+
+
+# --------------------------------------------------------------------------
+# REST boundary: an outage must be 503, never 404 or an empty 200
+# --------------------------------------------------------------------------
+
+
+class TestRestBoundary:
+    @pytest.fixture()
+    def client(self, monkeypatch):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from app.api.v1 import epc as epc_router
+
+        dead = _client(lambda req: httpx.Response(301, headers={"Location": "https://gov.uk/"}))
+        monkeypatch.setattr(epc_router, "_client", dead)
+        app = FastAPI()
+        app.include_router(epc_router.router, prefix="/v1")
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_search_returns_503_not_404(self, client):
+        r = client.get("/v1/epc/search", params={"postcode": "NG7 1FN"})
+        assert r.status_code == 503, f"outage must not read as 'not found' (got {r.status_code})"
+        assert "unavailable" in r.json()["detail"].lower()
+
+    def test_certificate_returns_503_not_404(self, client):
+        r = client.get("/v1/epc/certificate/abc123")
+        assert r.status_code == 503
+
+    def test_search_area_returns_503_not_empty_200(self, client):
+        """The worst failure mode: a 200 with count:0 looks like real data."""
+        r = client.get("/v1/epc/search-area", params={"postcode": "NG7 1FN"})
+        assert r.status_code == 503, "an outage must never render as a zero-count summary"
+
+    def test_genuine_absence_still_404s(self, monkeypatch):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from app.api.v1 import epc as epc_router
+
+        empty = _client(lambda req: httpx.Response(200, json={"rows": []}))
+        monkeypatch.setattr(epc_router, "_client", empty)
+        app = FastAPI()
+        app.include_router(epc_router.router, prefix="/v1")
+        c = TestClient(app, raise_server_exceptions=False)
+
+        assert c.get("/v1/epc/search", params={"postcode": "NG7 1FN"}).status_code == 404
+        area = c.get("/v1/epc/search-area", params={"postcode": "NG7 1FN"})
+        assert area.status_code == 200 and area.json()["summary"]["count"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1175,7 +1175,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.13.0"
+version = "1.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
**Production incident fix.** Discovered during the source-contract audit.

## What is happening in production right now

The API host hardcoded at `property_core/epc_client.py:21` (`epc.opendatacommunities.org`) has been **retired** and 301-redirects to a GOV.UK landing page. The client does not follow redirects, so `raise_for_status()` raises — and every failure was caught by a broad `except (httpx.HTTPError, KeyError, ValueError)` and turned into `None`/`[]`.

Credentials **are** configured in production, so this is not a config problem. Verified against the deployed service:

| Request | Response |
|---|---|
| `/v1/epc/search?postcode=NG7 1FN` | `404 {"detail":"No EPC certificate found"}` |
| `/v1/epc/search?postcode=SW1A 2AA` | `404 {"detail":"No EPC certificate found"}` |
| `/v1/epc/search?postcode=B1 1AA` | `404 {"detail":"No EPC certificate found"}` |
| `/v1/epc/search-area?postcode=NG7 1FN` | **`200`** `{"count":0,"rating_distribution":{},"certificates":[]}` |

Every EPC lookup in England and Wales answers "not found". The area endpoint is worse: an outage renders as a **well-formed empty summary with HTTP 200**, indistinguishable from real data.

The MCP surface is the most damaging. Tools returned `null` with `isError: false`, while their docstrings read *"Returns None if no certificates exist for the postcode"* — actively instructing the model to conclude absence. An LLM asked about a property's energy rating would state that it has no EPC.

## What this changes

EPC lookups raise `EPCUpstreamError` when the service **cannot be consulted**: non-success status (redirects included), transport failure, unparseable body, an unrecognised response envelope, or missing credentials. A reachable upstream that genuinely holds no certificate still returns `None`/`[]`, so real absence is unchanged and still 404s.

- **REST** → **503**, never 404, never an empty 200.
- **MCP** → surfaces as a tool error rather than a null result; docstrings no longer instruct consumers to infer absence.
- `EPCUpstreamError` deliberately **does not** subclass `ValueError`, so it cannot be mistaken for caller error and mapped to a 4xx.

**`enrich_comps_with_epc()` hardening was mandatory here, not optional.** It used `asyncio.gather` without `return_exceptions=True`. With EPC now raising — and EPC currently failing 100% of the time — one failing postcode would have discarded every successfully-fetched postcode *and* propagated out of the whole comps request, 500-ing every `comps?enrich_epc=true` call. Failed postcodes are now left un-enriched and logged; successful ones survive.

## Scope — deliberately narrow

This **does not restore EPC data**. The replacement GOV.UK API is a different contract (Bearer auth, `{"data":[],"pagination":{}}` envelope, camelCase fields, `certificateNumber`/RRN instead of `lmk-key`), so all ~30 field mappings in `models/epc.py` need rewriting against the real API. That migration is tracked separately and will be probed against the live service rather than written from documentation.

The goal here is only that **the system stops asserting a falsehood**.

## Verification

- **311 passed, exit code 0**, on Python 3.11 (production's version).
- 25 new tests pin the distinction: 10 HTTP statuses, transport failure, malformed JSON, a foreign envelope, and missing credentials all raise; empty-but-reachable still returns `None`/`[]`; real rows still parse; a non-matching address is still absence, not failure.
- **Live proof against the real retired host**: all three methods raise `EPCUpstreamError` carrying the actual `301` and URL, where they previously returned `None`/`[]`.
- REST boundary tests assert 503 for an outage and confirm genuine absence still 404s / still returns a `count: 0` summary.
- An enrichment test proves a healthy postcode survives a sibling postcode's failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)