### PR TITLE
docs(epc): correct active EPC surface and identifier wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ What the new upstream supports, and what it does not:
 - **Summary search** by postcode — returns address, UPRN (often absent), energy
   band, registration date and schema type. It does **not** return energy score,
   floor area or property type; those exist only on a full certificate.
+- **A postcode selects an area, never a property.** Identifying one property
+  needs a UPRN or an address matching a certificate exactly (case, punctuation
+  and a leading `Flat`/`Apartment` designator aside). Anything less — no address,
+  no match, or several matches — is refused rather than resolved to a best guess.
+  See [USER_GUIDE.md](USER_GUIDE.md) for the CLI and REST surfaces.
 - **Area statistics** are limited to the record count and, when the bounded
   response contains every matching summary, the rating distribution.
   Property-type breakdown and floor-area statistics are reported as `None` —

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -53,11 +53,9 @@ A postcode identifies an *area*, not a property, so `epc search` has two distinc
 modes:
 
 ```bash
-# AREA MODE — postcode only. Returns a summary OF THE POSTCODE (certificate count
-# and rating distribution). It does not return any single property's certificate.
-property-cli epc search "SW1A 1AA"
-
-# PROPERTY MODE — requires identity evidence. --address names the property.
+# PROPERTY MODE — the normal way to get a certificate. --address names the
+# property, and the full certificate is returned directly. You do NOT need a
+# certificate number to get here.
 property-cli epc search "SW1A 1AA" --address "10 Downing Street" --include-raw
 
 # Combined query (the postcode is parsed off the end). This reaches property mode
@@ -65,18 +63,36 @@ property-cli epc search "SW1A 1AA" --address "10 Downing Street" --include-raw
 # carries no address and falls back to area mode.
 property-cli epc search --q "10 Downing Street, SW1A 2AA"
 
-# Direct lookup by GOV.UK certificate number
+# AREA MODE — postcode only. AGGREGATE STATISTICS ONLY: certificate count and
+# rating distribution for the postcode. It does not list individual properties
+# and does not return certificate numbers.
+property-cli epc search "SW1A 1AA"
+
+# Optional shortcut, if you ALREADY have a certificate number (see below).
 property-cli epc certificate <certificate_number>
 ```
+
+**Area mode gives you statistics, not a way in.** It reports how many
+certificates a postcode holds and how their ratings are distributed. It does not
+enumerate the properties behind those numbers, and it does not expose their
+certificate numbers — so it is not a step on the way to fetching one. To get a
+certificate over REST or the CLI, go straight to property mode with an exact
+address; it returns the whole certificate in one call.
+
+**Where a certificate number comes from.** `epc certificate` is an optional
+shortcut for a number you already hold — from the
+[GOV.UK EPC register](https://www.gov.uk/find-energy-certificate) directly, from
+a previous result, or from an MCP summary-listing tool (`property_epc_summaries`
+on the plain MCP server, `epc_search` on the MCP app), which do enumerate
+candidates. Neither the REST API nor the CLI exposes such a listing surface in
+v1.14.0. If you do not have a number, use property mode — you do not need one.
 
 **Ambiguous matches are refused, not guessed.** In property mode the supplied
 address must match a certificate exactly — allowing only for case, punctuation,
 and a leading `Flat`/`Apartment` designator, so `Flat 2` and `Apartment 2` are the
 same property but `Flat 2` and `Flat 3` are not. If no candidate matches exactly,
 or more than one does, the command reports the ambiguity and fetches nothing
-rather than returning a neighbouring property's certificate. Use area mode to see
-what is at the postcode, then `epc certificate <certificate_number>` for the one
-you want.
+rather than returning a neighbouring property's certificate.
 
 ### Rightmove
 
@@ -223,26 +239,42 @@ Results include `locality` and `district` fields from the Land Registry address 
 ### EPC
 
 Three distinct surfaces. Picking the wrong one is the most common EPC mistake —
-`search` is for one property, `search-area` is for a postcode.
+`search` is for one property, `search-area` is for a postcode's statistics.
 
-- `GET /v1/epc/search-area?postcode=SW1A%201AA` — **postcode area summary.**
-  Certificate count and rating distribution for the postcode. Returns no single
-  property's certificate. `count: null` means the upstream did not report a
-  total — unknown, not zero.
 - `GET /v1/epc/search?postcode=SW1A%201AA&address=10%20Downing%20Street` —
-  **specific property lookup, requires identity evidence.** The address must
-  match a certificate exactly (case, punctuation and a leading `Flat`/`Apartment`
-  designator aside). A postcode with no address, an address matching nothing, or
-  an address matching several candidates all return **409 Conflict** — the
-  service refuses rather than guessing.
+  **specific property lookup, and the normal way to obtain a certificate.**
+  Returns the full certificate, so no certificate number is needed to get one.
+  The address must match a certificate exactly (case, punctuation and a leading
+  `Flat`/`Apartment` designator aside).
 - `GET /v1/epc/search?q=10%20Downing%20Street,%20SW1A%202AA` — same as above via
   a combined query; the postcode is parsed off the end.
-- `GET /v1/epc/certificate/{certificate_hash}` — **direct lookup by the GOV.UK
-  certificate number**, skipping matching entirely. The `{certificate_hash}` path
-  segment is a compatibility alias: pass the certificate number returned by
-  `search-area`.
+- `GET /v1/epc/search-area?postcode=SW1A%201AA` — **postcode aggregate statistics
+  only.** Certificate count and rating distribution. It does not list individual
+  properties, and `certificates` is always `null` — per-certificate detail is not
+  returned by a summary search, so this endpoint cannot supply certificate
+  numbers and is not a step towards fetching one. `count: null` means the
+  upstream did not report a total — unknown, not zero.
+- `GET /v1/epc/certificate/{certificate_hash}` — **optional shortcut for a
+  certificate number you already hold**, skipping address matching entirely.
+  Sources for that number are the [GOV.UK EPC
+  register](https://www.gov.uk/find-energy-certificate) or an MCP summary-listing
+  tool (`property_epc_summaries` / `epc_search`); REST does not expose a listing
+  surface in v1.14.0. The `{certificate_hash}` path segment is a compatibility
+  alias — pass the certificate number. Without a number, use `/search` instead.
 
-All three require `EPC_API_TOKEN`.
+Status codes on `/search`:
+
+| Status | Meaning |
+|---|---|
+| `200` | one certificate identified |
+| `404` | the postcode holds no certificates at all — genuine absence |
+| `409` | candidates exist, but none or several matched: no address supplied, no exact match, or an ambiguous match. The service refuses rather than guessing |
+| `501` / `502` / `503` / `429` | not configured / upstream auth failure / upstream outage / rate limited |
+
+`404` and `409` are distinct on purpose: `404` says the area has nothing, `409`
+says the area has candidates but your evidence did not single one out.
+
+All three surfaces require `EPC_API_TOKEN`.
 
 ### Rightmove
 - `GET /v1/rightmove/search-url?postcode=SW1A%201AA&property_type=sale&radius=0.25` — Sales

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -267,12 +267,16 @@ Status codes on `/search`:
 | Status | Meaning |
 |---|---|
 | `200` | one certificate identified |
+| `422` | **local validation failure** — neither `postcode` nor `q` supplied, a `q` whose postcode could not be parsed, or a FastAPI query-validation error. Nothing was sent upstream |
+| `400` | **the upstream EPC service rejected the query** — the request was well-formed locally but the register refused it |
 | `404` | the postcode holds no certificates at all — genuine absence |
 | `409` | candidates exist, but none or several matched: no address supplied, no exact match, or an ambiguous match. The service refuses rather than guessing |
 | `501` / `502` / `503` / `429` | not configured / upstream auth failure / upstream outage / rate limited |
 
-`404` and `409` are distinct on purpose: `404` says the area has nothing, `409`
-says the area has candidates but your evidence did not single one out.
+Three of these are easy to conflate, so they are kept deliberately distinct:
+`422` is *your request was malformed* (caught locally, no upstream call), `400`
+is *upstream rejected it*, and `404` versus `409` is *the area has nothing* versus
+*the area has candidates but your evidence did not single one out*.
 
 All three surfaces require `EPC_API_TOKEN`.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -49,17 +49,34 @@ property-cli ppd download-url --kind monthly           # Latest monthly update
 
 Requires `EPC_API_TOKEN` in `.env`. Area mode returns the record count and, when the bounded response is complete, the rating distribution; property-type and floor-area statistics are unavailable because the EPC service exposes them only on individual certificates. England & Wales only.
 
+A postcode identifies an *area*, not a property, so `epc search` has two distinct
+modes:
+
 ```bash
-# Search by postcode (returns first/best match)
+# AREA MODE — postcode only. Returns a summary OF THE POSTCODE (certificate count
+# and rating distribution). It does not return any single property's certificate.
 property-cli epc search "SW1A 1AA"
+
+# PROPERTY MODE — requires identity evidence. --address names the property.
 property-cli epc search "SW1A 1AA" --address "10 Downing Street" --include-raw
 
-# Combined address query (parses postcode from end)
+# Combined query (the postcode is parsed off the end). This reaches property mode
+# only when the text before the postcode names a property; --q "SW1A 2AA" alone
+# carries no address and falls back to area mode.
 property-cli epc search --q "10 Downing Street, SW1A 2AA"
 
-# Direct lookup by certificate hash (lmk-key)
-property-cli epc certificate <certificate_hash>
+# Direct lookup by GOV.UK certificate number
+property-cli epc certificate <certificate_number>
 ```
+
+**Ambiguous matches are refused, not guessed.** In property mode the supplied
+address must match a certificate exactly — allowing only for case, punctuation,
+and a leading `Flat`/`Apartment` designator, so `Flat 2` and `Apartment 2` are the
+same property but `Flat 2` and `Flat 3` are not. If no candidate matches exactly,
+or more than one does, the command reports the ambiguity and fetches nothing
+rather than returning a neighbouring property's certificate. Use area mode to see
+what is at the postcode, then `epc certificate <certificate_number>` for the one
+you want.
 
 ### Rightmove
 
@@ -204,9 +221,28 @@ property-cli report generate "SW1A 2AA" --api-url http://localhost:8000
 Results include `locality` and `district` fields from the Land Registry address data.
 
 ### EPC
-- `GET /v1/epc/search?postcode=SW1A%201AA&address=10%20Downing%20Street` (requires creds)
-- `GET /v1/epc/search?q=10%20Downing%20Street,%20SW1A%202AA` (combined address query)
-- `GET /v1/epc/certificate/{certificate_hash}` (direct lookup by lmk-key)
+
+Three distinct surfaces. Picking the wrong one is the most common EPC mistake —
+`search` is for one property, `search-area` is for a postcode.
+
+- `GET /v1/epc/search-area?postcode=SW1A%201AA` — **postcode area summary.**
+  Certificate count and rating distribution for the postcode. Returns no single
+  property's certificate. `count: null` means the upstream did not report a
+  total — unknown, not zero.
+- `GET /v1/epc/search?postcode=SW1A%201AA&address=10%20Downing%20Street` —
+  **specific property lookup, requires identity evidence.** The address must
+  match a certificate exactly (case, punctuation and a leading `Flat`/`Apartment`
+  designator aside). A postcode with no address, an address matching nothing, or
+  an address matching several candidates all return **409 Conflict** — the
+  service refuses rather than guessing.
+- `GET /v1/epc/search?q=10%20Downing%20Street,%20SW1A%202AA` — same as above via
+  a combined query; the postcode is parsed off the end.
+- `GET /v1/epc/certificate/{certificate_hash}` — **direct lookup by the GOV.UK
+  certificate number**, skipping matching entirely. The `{certificate_hash}` path
+  segment is a compatibility alias: pass the certificate number returned by
+  `search-area`.
+
+All three require `EPC_API_TOKEN`.
 
 ### Rightmove
 - `GET /v1/rightmove/search-url?postcode=SW1A%201AA&property_type=sale&radius=0.25` — Sales

--- a/app/api/v1/epc.py
+++ b/app/api/v1/epc.py
@@ -69,7 +69,12 @@ async def get_certificate(
     certificate_hash: str,
     include_raw: bool = Query(False, description="Include raw EPC API JSON"),
 ) -> EPCRecordResponse:
-    """Get EPC certificate by lmk-key (certificate hash)."""
+    """Get an EPC certificate by its GOV.UK certificate number.
+
+    The `{certificate_hash}` path parameter is a compatibility alias kept from
+    the retired API; the value to pass is the certificate number returned by
+    `/search-area`.
+    """
     if not _client.is_configured():
         raise HTTPException(status_code=501, detail="EPC client not configured")
 

--- a/app/api/v1/epc.py
+++ b/app/api/v1/epc.py
@@ -111,9 +111,16 @@ async def search(
     The address must match a certificate exactly, allowing only for case,
     punctuation and a leading Flat/Apartment designator.
 
-    404 = the postcode holds no certificates at all. 409 = candidates exist but
-    none or several matched; the service refuses rather than guessing. For a
-    postcode's aggregate statistics use /search-area instead.
+    Status outcomes:
+      422 - local validation failure: neither postcode nor q supplied, a q whose
+            postcode could not be parsed, or FastAPI query validation. Nothing
+            is sent upstream.
+      400 - the upstream EPC service rejected the query.
+      404 - the postcode holds no certificates at all (genuine absence).
+      409 - candidates exist but none or several matched; the service refuses
+            rather than guessing.
+
+    For a postcode's aggregate statistics use /search-area instead.
     """
     if not _client.is_configured():
         raise HTTPException(status_code=501, detail="EPC client not configured")

--- a/app/api/v1/epc.py
+++ b/app/api/v1/epc.py
@@ -71,9 +71,14 @@ async def get_certificate(
 ) -> EPCRecordResponse:
     """Get an EPC certificate by its GOV.UK certificate number.
 
+    An optional shortcut for a certificate number already in hand — from the
+    GOV.UK EPC register or an MCP summary-listing tool. `/search-area` does NOT
+    supply one: it returns aggregate statistics with `certificates: null`. To
+    fetch a certificate without knowing its number, use `/search` with an exact
+    address, which returns the full certificate directly.
+
     The `{certificate_hash}` path parameter is a compatibility alias kept from
-    the retired API; the value to pass is the certificate number returned by
-    `/search-area`.
+    the retired API; the value to pass is the certificate number.
     """
     if not _client.is_configured():
         raise HTTPException(status_code=501, detail="EPC client not configured")
@@ -94,11 +99,21 @@ async def search(
     q: Optional[str] = Query(None, description="Combined address query, e.g. '10 Downing Street, SW1A 2AA'"),
     include_raw: bool = Query(False, description="Include raw EPC API JSON"),
 ) -> EPCRecordResponse:
-    """Search for an EPC certificate by postcode (optional address match).
+    """Find ONE property's EPC certificate. Returns the full certificate.
 
-    Supports two modes:
+    An address is required in practice: a postcode identifies an area, not a
+    property, so a postcode alone cannot single one out and returns 409.
+
+    Two ways to supply it:
     1. Explicit: postcode=SW1A+2AA&address=10+Downing+Street
     2. Combined: q=10+Downing+Street,+SW1A+2AA (postcode parsed from end)
+
+    The address must match a certificate exactly, allowing only for case,
+    punctuation and a leading Flat/Apartment designator.
+
+    404 = the postcode holds no certificates at all. 409 = candidates exist but
+    none or several matched; the service refuses rather than guessing. For a
+    postcode's aggregate statistics use /search-area instead.
     """
     if not _client.is_configured():
         raise HTTPException(status_code=501, detail="EPC client not configured")

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -381,12 +381,13 @@ async def property_epc_summaries(postcode: str, page: int = 1) -> dict:
 async def epc_certificate(lmk_key: str) -> dict | None:
     """Fetch a single EPC certificate by its GOV.UK certificate number.
 
-    Use after property_epc_search has identified the correct cert — this is
-    faster than property_epc(postcode, address) as it makes a direct lookup
-    with no address matching or postcode re-fetch.
+    Use after property_epc_summaries has listed the candidates and you have
+    picked one — this is faster than property_epc(postcode, address) as it makes
+    a direct lookup with no address matching or postcode re-fetch.
 
     The parameter is named lmk_key as a compatibility alias; pass the
-    certificate number, which is returned in every property_epc_search result.
+    certificate number, which is returned in every property_epc_summaries row.
+    (property_epc_search is deprecated and raises — do not call it.)
 
     Returns the full EPC certificate, or null only when no such certificate is lodged. A null result means no such certificate is lodged. If the EPC service cannot be reached the tool raises an error instead — never treat an error as evidence that a property has no certificate.
     """

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -379,13 +379,14 @@ async def property_epc_summaries(postcode: str, page: int = 1) -> dict:
 @mcp.tool(annotations={"readOnlyHint": True})
 @_timed_tool
 async def epc_certificate(lmk_key: str) -> dict | None:
-    """Fetch a single EPC certificate by its lmk_key (certificate hash).
+    """Fetch a single EPC certificate by its GOV.UK certificate number.
 
     Use after property_epc_search has identified the correct cert — this is
     faster than property_epc(postcode, address) as it makes a direct lookup
-    with no fuzzy matching or postcode re-fetch.
+    with no address matching or postcode re-fetch.
 
-    lmk_key is returned in every property_epc_search result.
+    The parameter is named lmk_key as a compatibility alias; pass the
+    certificate number, which is returned in every property_epc_search result.
 
     Returns the full EPC certificate, or null only when no such certificate is lodged. A null result means no such certificate is lodged. If the EPC service cannot be reached the tool raises an error instead — never treat an error as evidence that a property has no certificate.
     """

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -260,55 +260,67 @@ uv run uvicorn app.main:app --reload        # dev mode
 ### PPD Comps
 
 ```bash
-curl "http://localhost:8000/api/v1/ppd/comps?postcode=NG1+1GF&months=24&limit=5"
+curl "http://localhost:8000/v1/ppd/comps?postcode=NG1+1GF&months=24&limit=5"
 ```
 
 ### PPD Comps with Address Match
 
 ```bash
-curl "http://localhost:8000/api/v1/ppd/comps?postcode=NG1+1GF&address=3+Broadway&months=24"
+curl "http://localhost:8000/v1/ppd/comps?postcode=NG1+1GF&address=3+Broadway&months=24"
 ```
 
 ### PPD Comps with EPC Enrichment
 
 ```bash
-curl "http://localhost:8000/api/v1/ppd/comps?postcode=NG1+1GF&enrich_epc=true"
+curl "http://localhost:8000/v1/ppd/comps?postcode=NG1+1GF&enrich_epc=true"
 ```
 
 ### PPD Transactions
 
 ```bash
-curl "http://localhost:8000/api/v1/ppd/transactions?postcode=NG1+1GF&limit=5"
+curl "http://localhost:8000/v1/ppd/transactions?postcode=NG1+1GF&limit=5"
 ```
 
 ### Rightmove Search URL
 
 ```bash
-curl "http://localhost:8000/api/v1/rightmove/search-url?postcode=NG1+1GF&property_type=sale&radius=0.5"
+curl "http://localhost:8000/v1/rightmove/search-url?postcode=NG1+1GF&property_type=sale&radius=0.5"
 ```
 
 ### EPC Search (combined address query)
 
 ```bash
-curl "http://localhost:8000/api/v1/epc/search?q=10+Downing+Street,+SW1A+2AA"
+curl "http://localhost:8000/v1/epc/search?q=10+Downing+Street,+SW1A+2AA"
 ```
 
 ### EPC Certificate by Certificate Number
 
 ```bash
-curl "http://localhost:8000/api/v1/epc/certificate/{certificate_number}"
+curl "http://localhost:8000/v1/epc/certificate/{certificate_number}"
 ```
 
-### Planning Council
+### Planning Council — not available over HTTP
+
+The planning router is **not mounted** by `property-api` (see `app/api/routes.py`):
+scraping council portals requires a UK residential IP, so the endpoint is
+disabled rather than shipped as a route that fails. There is no
+`/v1/planning/...` endpoint to call.
+
+Use the CLI or the library instead:
 
 ```bash
-curl "http://localhost:8000/api/v1/planning/council-for-postcode?postcode=NG1+1GF"
+property-cli planning council "NG1 1GF"
+```
+
+```python
+from property_core import PlanningService
+PlanningService().council_for_postcode("NG1 1GF")
 ```
 
 ### Property Report (full multi-source)
 
 ```bash
-curl -X POST "http://localhost:8000/api/v1/property/report" \
+curl -X POST "http://localhost:8000/v1/property/report" \
   -H "Content-Type: application/json" \
   -d '{"address": "3 Broadway, NG1 1GF"}'
 ```
@@ -316,5 +328,5 @@ curl -X POST "http://localhost:8000/api/v1/property/report" \
 ### Health Check
 
 ```bash
-curl "http://localhost:8000/api/v1/health"
+curl "http://localhost:8000/v1/health"
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -293,10 +293,10 @@ curl "http://localhost:8000/api/v1/rightmove/search-url?postcode=NG1+1GF&propert
 curl "http://localhost:8000/api/v1/epc/search?q=10+Downing+Street,+SW1A+2AA"
 ```
 
-### EPC Certificate by Key
+### EPC Certificate by Certificate Number
 
 ```bash
-curl "http://localhost:8000/api/v1/epc/certificate/{lmk_key}"
+curl "http://localhost:8000/api/v1/epc/certificate/{certificate_number}"
 ```
 
 ### Planning Council

--- a/docs/examples.py
+++ b/docs/examples.py
@@ -601,11 +601,14 @@ def example_api():
     Rightmove Listings:
         curl "http://localhost:8000/api/v1/rightmove/listings?postcode=NG1+1GF&property_type=sale&radius=0.5&max_pages=1"
 
-    EPC Search:
+    EPC Search (one property; needs an address, refuses ambiguity):
         curl "http://localhost:8000/api/v1/epc/search?q=10+Downing+Street,+SW1A+2AA"
 
-    EPC Certificate:
-        curl "http://localhost:8000/api/v1/epc/certificate/{lmk_key}"
+    EPC Area Summary (a postcode, not a property):
+        curl "http://localhost:8000/api/v1/epc/search-area?postcode=SW1A+1AA"
+
+    EPC Certificate (by GOV.UK certificate number):
+        curl "http://localhost:8000/api/v1/epc/certificate/{certificate_number}"
 
     Planning Council:
         curl "http://localhost:8000/api/v1/planning/council-for-postcode?postcode=NG1+1GF"

--- a/docs/examples.py
+++ b/docs/examples.py
@@ -571,7 +571,7 @@ def example_api():
         uv run uvicorn app.main:app --reload        # dev mode
 
     PPD Comps:
-        curl "http://localhost:8000/api/v1/ppd/comps?postcode=NG1+1GF&months=24&limit=5"
+        curl "http://localhost:8000/v1/ppd/comps?postcode=NG1+1GF&months=24&limit=5"
 
         {
           "query": {"postcode": "NG1 1GF", "months": 24, "limit": 5},
@@ -587,55 +587,57 @@ def example_api():
         }
 
     PPD Comps with Address Match:
-        curl "http://localhost:8000/api/v1/ppd/comps?postcode=NG1+1GF&address=3+Broadway&months=24"
+        curl "http://localhost:8000/v1/ppd/comps?postcode=NG1+1GF&address=3+Broadway&months=24"
 
     PPD Comps with EPC Enrichment:
-        curl "http://localhost:8000/api/v1/ppd/comps?postcode=NG1+1GF&enrich_epc=true"
+        curl "http://localhost:8000/v1/ppd/comps?postcode=NG1+1GF&enrich_epc=true"
 
     PPD Transactions:
-        curl "http://localhost:8000/api/v1/ppd/transactions?postcode=NG1+1GF&limit=5"
+        curl "http://localhost:8000/v1/ppd/transactions?postcode=NG1+1GF&limit=5"
 
     Rightmove Search URL:
-        curl "http://localhost:8000/api/v1/rightmove/search-url?postcode=NG1+1GF&property_type=sale&radius=0.5"
+        curl "http://localhost:8000/v1/rightmove/search-url?postcode=NG1+1GF&property_type=sale&radius=0.5"
 
     Rightmove Listings:
-        curl "http://localhost:8000/api/v1/rightmove/listings?postcode=NG1+1GF&property_type=sale&radius=0.5&max_pages=1"
+        curl "http://localhost:8000/v1/rightmove/listings?postcode=NG1+1GF&property_type=sale&radius=0.5&max_pages=1"
 
     EPC Search (one property; needs an address, refuses ambiguity):
-        curl "http://localhost:8000/api/v1/epc/search?q=10+Downing+Street,+SW1A+2AA"
+        curl "http://localhost:8000/v1/epc/search?q=10+Downing+Street,+SW1A+2AA"
 
     EPC Area Summary (a postcode, not a property):
-        curl "http://localhost:8000/api/v1/epc/search-area?postcode=SW1A+1AA"
+        curl "http://localhost:8000/v1/epc/search-area?postcode=SW1A+1AA"
 
     EPC Certificate (by GOV.UK certificate number):
-        curl "http://localhost:8000/api/v1/epc/certificate/{certificate_number}"
+        curl "http://localhost:8000/v1/epc/certificate/{certificate_number}"
 
-    Planning Council:
-        curl "http://localhost:8000/api/v1/planning/council-for-postcode?postcode=NG1+1GF"
+    Planning Council — NOT AVAILABLE over HTTP:
+        The planning router is not mounted by property-api (app/api/routes.py):
+        scraping council portals needs a UK residential IP. Use the CLI instead:
+            property-cli planning council "NG1 1GF"
 
     Property Report (full multi-source):
-        curl -X POST "http://localhost:8000/api/v1/property/report" \\
+        curl -X POST "http://localhost:8000/v1/property/report" \\
           -H "Content-Type: application/json" \\
           -d '{"address": "3 Broadway, NG1 1GF"}'
 
     Health Check:
-        curl "http://localhost:8000/api/v1/health"
+        curl "http://localhost:8000/v1/health"
     """
     print("=== HTTP API Examples ===")
     print("Start the server:")
     print("  uv run property-api")
     print()
     print("PPD Comps:")
-    print('  curl "http://localhost:8000/api/v1/ppd/comps?postcode=NG1+1GF&months=24&limit=5"')
+    print('  curl "http://localhost:8000/v1/ppd/comps?postcode=NG1+1GF&months=24&limit=5"')
     print()
     print("Rightmove Listings:")
-    print('  curl "http://localhost:8000/api/v1/rightmove/search-url?postcode=NG1+1GF&property_type=sale"')
+    print('  curl "http://localhost:8000/v1/rightmove/search-url?postcode=NG1+1GF&property_type=sale"')
     print()
     print("EPC Search:")
-    print('  curl "http://localhost:8000/api/v1/epc/search?q=10+Downing+Street,+SW1A+2AA"')
+    print('  curl "http://localhost:8000/v1/epc/search?q=10+Downing+Street,+SW1A+2AA"')
     print()
     print("Property Report:")
-    print('  curl -X POST "http://localhost:8000/api/v1/property/report" \\')
+    print('  curl -X POST "http://localhost:8000/v1/property/report" \\')
     print('    -H "Content-Type: application/json" \\')
     print('    -d \'{"address": "3 Broadway, NG1 1GF"}\'')
     print()

--- a/property_app/tools.py
+++ b/property_app/tools.py
@@ -366,13 +366,14 @@ async def fetch_epc_certificate(lmk_key: str) -> dict | None:
 async def epc_certificate(
     lmk_key: Annotated[str, Field(description="EPC certificate number (accepted as lmk_key for compatibility)")],
 ) -> dict | None:
-    """Fetch a single EPC certificate by its lmk_key (certificate hash).
+    """Fetch a single EPC certificate by its GOV.UK certificate number.
 
     Use after epc_search has identified the correct cert — this is faster
     than epc_lookup(postcode, address) as it makes a direct lookup with no
-    fuzzy matching or postcode re-fetch.
+    address matching or postcode re-fetch.
 
-    lmk_key accepts the certificate_number returned by the summary search (the parameter name is retained for compatibility).
+    The parameter is named lmk_key as a compatibility alias; pass the
+    certificate_number returned by the summary search.
 
     Returns the full EPC certificate, or null only when no such certificate is lodged. A null result means no such certificate is lodged. If the EPC service cannot be reached the tool raises an error instead — never treat an error as evidence that a property has no certificate.
     """

--- a/property_cli/main.py
+++ b/property_cli/main.py
@@ -476,11 +476,15 @@ def epc_search(
 
 @epc.command("certificate")
 def epc_certificate(
-    certificate_hash: str = typer.Argument(..., help="EPC certificate hash (lmk-key)"),
+    certificate_hash: str = typer.Argument(..., help="GOV.UK EPC certificate number"),
     include_raw: bool = typer.Option(False, help="Show raw EPC payload"),
     api_url: Optional[str] = typer.Option(None, help="Call API instead of core"),
 ) -> None:
-    """Get EPC certificate by hash (lmk-key)."""
+    """Get an EPC certificate by its GOV.UK certificate number.
+
+    The argument is named ``certificate_hash`` for backward compatibility; the
+    value to pass is the certificate number returned by an area search.
+    """
     http = _maybe_http_client(api_url)
     if http:
         data = http.get(
@@ -498,7 +502,7 @@ def epc_certificate(
 
     result = asyncio.run(client.get_certificate(certificate_hash))
     if not result:
-        typer.echo("No EPC found for this certificate hash")
+        typer.echo("No EPC found for this certificate number")
         raise typer.Exit(code=1)
     output = {"record": result.model_dump(), "raw": result.raw if include_raw else None}
     _echo_json(output)

--- a/property_cli/main.py
+++ b/property_cli/main.py
@@ -482,8 +482,14 @@ def epc_certificate(
 ) -> None:
     """Get an EPC certificate by its GOV.UK certificate number.
 
+    An optional shortcut for a number already in hand — from the GOV.UK EPC
+    register or an MCP summary-listing tool. Area mode (``epc search`` with a
+    postcode only) reports aggregate statistics and does NOT supply certificate
+    numbers. Without a number, use ``epc search --address`` instead: it returns
+    the full certificate directly.
+
     The argument is named ``certificate_hash`` for backward compatibility; the
-    value to pass is the certificate number returned by an area search.
+    value to pass is the certificate number.
     """
     http = _maybe_http_client(api_url)
     if http:


### PR DESCRIPTION
Documentation-only, no behaviour change. Branched from `3ed1bfa` (current `origin/main`). Python 3.11 suite: **499 passed, 24 skipped** — identical to main.

## 1. `USER_GUIDE.md` — the "first/best match" claim was wrong

It said postcode search *"returns first/best match"*. It does not, and has not since v1.14. Now documented:

- **postcode-only CLI search returns an area summary** (certificate count + rating distribution), not any property's certificate;
- **a property certificate requires `--address`**, or a `--q` specific enough to carry one — `--q "SW1A 2AA"` alone has no address and falls back to area mode;
- **ambiguous matches are refused, not guessed** — no exact match, or several, fetches nothing rather than returning a neighbour's certificate.

Verified against `property_cli/main.py` and `EPCClient.search_by_postcode`, not assumed.

## 2. REST surfaces — `search-area` was missing entirely

Previously two endpoints were listed. Now three, distinguished:

| Endpoint | Purpose |
|---|---|
| `/v1/epc/search-area` | postcode area summary; `count: null` = unknown, not zero |
| `/v1/epc/search` | one property; requires identity evidence — **409** on no-address / no-match / multiple-match |
| `/v1/epc/certificate/...` | direct lookup by GOV.UK certificate number |

## 3. "certificate hash" / "lmk-key" → "certificate number"

Corrected in active help and docs: CLI argument help + docstring, both MCP tool docstrings (`app/mcp/server.py`, `property_app/tools.py`), the REST route docstring (**surfaces in OpenAPI at `/docs`** — this one was easy to miss), and the curl examples.

**No breaking rename.** `/certificate/{certificate_hash}`, the CLI `certificate_hash` argument and the MCP `lmk_key` parameter all keep their names, now each documented explicitly as a compatibility alias.

## 4. README

One clarification in the EPC notes: a postcode selects an area, never a property. The README carries no EPC search examples, so nothing else there could imply postcode-only selection — no broader edit was needed.

## Deliberately untouched

`.gitignore`; historical CHANGELOG entries; the deprecated `EPC_API_EMAIL`/`EPC_API_KEY` documentation; the wider README/GitHub/PyPI metadata sweep.

`property_core/models/epc.py` keeps `"lmk-key"` as a **data key** — it parses the retired kebab-case payload inside the deprecated `from_api_row`. `epc_client.py`'s "formerly lmk-key" is the intended compatibility note.

## Verification

- stale-wording grep across active docs/help: clean (remaining hits are the compatibility note and the retired-payload data key)
- `git diff --check`: clean
- Python 3.11 full suite: 499 passed, 24 skipped
- 8 files, +77 / −22

No release, deploy, secret change, or worktree/branch deletion.