### PR TITLE
fix(epc): accept legacy SAP scalar cost fields — v1.14.1 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v1.14.1 (2026-08-26) — EPC hotfix: legacy SAP scalar cost fields
+
+**v1.14.0 returned HTTP 503 for every certificate on SAP-Schema-13.0, 14.0, 14.2 and 15.0.** Found by production dogfooding minutes after release:
+
+```
+503  "EPC service unavailable: heating_cost_current: expected {value, currency}, got int 267"
+```
+
+### Cause
+The money shape is a property of the **schema**, not the field — an audit of all six cost fields across the eleven saved schema captures shows they move together:
+
+| Schema | cost fields |
+|---|---|
+| RdSAP 17.0 / 17.1 / 18.0 / 19.0 / 20.0.0, SAP 16.0 / 16.2 | `{value, currency}` |
+| **SAP 13.0 / 14.0 / 14.2 / 15.0** | **bare number** |
+
+`EPCMoney.from_source` accepted only the object form and raised `EPCUpstreamShapeError`, which subclasses `EPCUpstreamError` and therefore surfaced as 503. That broke certificate lookup, exact-address search, comps enrichment, the report service and both MCP surfaces for those schemas. Area summaries were unaffected, as they fetch no certificate.
+
+The evidence was present in the probe captures used to build the migration; the model was written without checking them.
+
+### Fixed
+- **Bare numbers are accepted.** The source model records that upstream stated no currency (`currency=None`, `currency_stated=False`) and does **not** rewrite the raw shape into a fabricated `{"currency": "GBP"}` object.
+- **The v1 projection keeps the amount** and reads it as GBP — the same representation the retired v1 field used, on a register scoped to England and Wales — emitting **one aggregated warning per certificate** naming the inference. Not one per field: all six cost fields share a schema's shape, so per-field warnings would repeat the same sentence six times.
+- **Malformed money is still rejected**: `bool` (checked explicitly, since `isinstance(True, int)` is `True` in Python), strings, lists, empty objects, missing `value`/`currency`, non-numeric values, and empty currency. A stated non-GBP currency still suppresses the legacy scalar with its existing warning.
+
+### Tests
+- Sanitised fixtures for all eleven observed schemas (`tests/fixtures/epc/`) — no real addresses, UPRNs or certificate numbers — pinning both shapes so an upstream change fails loudly.
+- Regression coverage through certificate lookup, exact-address search, comps enrichment, the report service, REST, and both MCP surfaces, asserting the warning survives each without per-field spam.
+
 ## v1.14.0 (2026-08-25) — EPC restored on the GOV.UK Bearer API
 
 Operational restoration after the retirement of `epc.opendatacommunities.org`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ The evidence was present in the probe captures used to build the migration; the 
 - **The v1 projection keeps the amount** and reads it as GBP — the same representation the retired v1 field used, on a register scoped to England and Wales — emitting **one aggregated warning per certificate** naming the inference. Not one per field: all six cost fields share a schema's shape, so per-field warnings would repeat the same sentence six times.
 - **Malformed money is still rejected**: `bool` (checked explicitly, since `isinstance(True, int)` is `True` in Python), strings, lists, empty objects, missing `value`/`currency`, non-numeric values, and empty currency. A stated non-GBP currency still suppresses the legacy scalar with its existing warning.
 
+### Fixed after human review
+- **The report service used the inferred cost values but dropped the caveat.** `EPCData.warnings` stopped at `_fetch_epc_data()`, so a report presented GBP amounts whose currency was inferred as though they were stated. `EnergyPerformance` now carries `warnings`, the service propagates them, and the shared HTML report template renders them beside the energy block. Asserted at every step: service output, REST JSON and rendered HTML each disclose it exactly once.
+- **`EPCMoney` could be constructed with contradictory provenance.** `EPCMoney(value=...)` produced `currency=None` with `currency_stated=True` — "a currency was stated" and "there is no currency" at the same time. `currency_stated` is now a derived property rather than a settable field, so the contradiction is structurally impossible; a value passed for it is ignored.
+- Enrichment and REST-search tests asserted success alone; they now assert the warning propagates with the attached certificate.
+
 ### Tests
 - Sanitised fixtures for all eleven observed schemas (`tests/fixtures/epc/`) — no real addresses, UPRNs or certificate numbers — pinning both shapes so an upstream change fails loudly.
 - Regression coverage through certificate lookup, exact-address search, comps enrichment, the report service, REST, and both MCP surfaces, asserting the warning survives each without per-field spam.

--- a/app/templates/report.html
+++ b/app/templates/report.html
@@ -267,6 +267,13 @@
                 </div>
                 {% endif %}
             </div>
+            {% if report.energy_performance.warnings %}
+            <div class="epc-warnings" style="margin-top: 1rem; padding: 0.75rem 1rem; background: #fffbeb; border-left: 3px solid #f59e0b; font-size: 0.8125rem; color: var(--gray-700);">
+                {% for w in report.energy_performance.warnings %}
+                <div>{{ w }}</div>
+                {% endfor %}
+            </div>
+            {% endif %}
             {% if report.energy_performance.property_type or report.energy_performance.construction_age %}
             <p style="margin-top: 1rem; font-size: 0.875rem; color: var(--gray-600);">
                 {{ report.energy_performance.property_type or '' }}

--- a/property_core/epc/compat.py
+++ b/property_core/epc/compat.py
@@ -33,15 +33,27 @@ _NO_DEMONSTRATED_SOURCE = (
 )
 
 
-def _money(value, field: str, warnings: list[str]) -> Optional[int]:
-    """Legacy scalar, only when the currency is the expected one.
+def _money(value, field: str, warnings: list[str], inferred: list[str]) -> Optional[int]:
+    """Legacy scalar, when the currency is the expected one or was never stated.
 
     The legacy field is typed `int | None`, so the projection must stay int —
     widening it to float would itself be a contract change.
+
+    Legacy SAP schemas (13.0, 14.0, 14.2, 15.0) return a bare number with no
+    currency. That is precisely the shape the retired v1 API used, and the
+    register covers England and Wales only, so the amount is read as GBP rather
+    than discarded — but the inference is recorded in `inferred` so the caller
+    can disclose it ONCE per certificate instead of once per field. All six cost
+    fields share a schema's shape, so per-field warnings would be six copies of
+    the same sentence.
     """
     if value is None:
         return None
-    if value.currency != LEGACY_CURRENCY:
+    # Keyed off the currency itself rather than the flag, so a directly
+    # constructed EPCMoney cannot desync the two and change behaviour.
+    if value.currency is None:
+        inferred.append(field)
+    elif value.currency != LEGACY_CURRENCY:
         warnings.append(
             f"{field} is denominated in {value.currency}; the legacy scalar field "
             f"expects {LEGACY_CURRENCY} and is reported as missing. The structured "
@@ -71,6 +83,9 @@ def to_epcdata(
             not compatibility.
     """
     warnings: list[str] = []
+    # Cost fields whose currency upstream never stated (legacy SAP scalar
+    # shape). Collected so the inference is disclosed once, not six times.
+    inferred_currency: list[str] = []
 
     if not doc.current_energy_efficiency_band:
         raise EPCUnsupportedOperationError(
@@ -114,12 +129,12 @@ def to_epcdata(
         construction_age=None,     # no demonstrated source
         floor_level=None,          # no demonstrated source
         lodgement_date=None,       # equivalence not demonstrated
-        heating_cost_current=_money(doc.heating_cost_current, "heating_cost_current", warnings),
-        heating_cost_potential=_money(doc.heating_cost_potential, "heating_cost_potential", warnings),
-        hot_water_cost_current=_money(doc.hot_water_cost_current, "hot_water_cost_current", warnings),
-        hot_water_cost_potential=_money(doc.hot_water_cost_potential, "hot_water_cost_potential", warnings),
-        lighting_cost_current=_money(doc.lighting_cost_current, "lighting_cost_current", warnings),
-        lighting_cost_potential=_money(doc.lighting_cost_potential, "lighting_cost_potential", warnings),
+        heating_cost_current=_money(doc.heating_cost_current, "heating_cost_current", warnings, inferred_currency),
+        heating_cost_potential=_money(doc.heating_cost_potential, "heating_cost_potential", warnings, inferred_currency),
+        hot_water_cost_current=_money(doc.hot_water_cost_current, "hot_water_cost_current", warnings, inferred_currency),
+        hot_water_cost_potential=_money(doc.hot_water_cost_potential, "hot_water_cost_potential", warnings, inferred_currency),
+        lighting_cost_current=_money(doc.lighting_cost_current, "lighting_cost_current", warnings, inferred_currency),
+        lighting_cost_potential=_money(doc.lighting_cost_potential, "lighting_cost_potential", warnings, inferred_currency),
         co2_emissions_current=doc.co2_emissions_current,
         co2_emissions_potential=doc.co2_emissions_potential,
         inspection_date=doc.inspection_date,
@@ -131,5 +146,14 @@ def to_epcdata(
         raw=doc.raw,
     )
 
+    if inferred_currency:
+        # One sentence per certificate. Naming the fields would repeat the
+        # same disclosure six times, since a schema's cost fields share a shape.
+        warnings.append(
+            "cost amounts were returned by upstream as bare numbers with no "
+            f"currency (the legacy {doc.schema_type or 'SAP'} scalar shape); they are "
+            "interpreted as GBP, inferred from that shape and the England and "
+            "Wales scope of the register, not stated by the source"
+        )
     data.warnings = warnings
     return (data, warnings) if return_warnings else data

--- a/property_core/epc/source_models.py
+++ b/property_core/epc/source_models.py
@@ -85,7 +85,19 @@ class EPCMoney(BaseModel):
 
     value: Decimal
     currency: Optional[str] = None
-    currency_stated: bool = True
+
+    @property
+    def currency_stated(self) -> bool:
+        """Whether upstream stated a currency.
+
+        DERIVED, never stored. As a settable field it could be constructed to
+        contradict `currency` — EPCMoney(value=1) yielded currency=None with
+        currency_stated=True, i.e. "a currency was stated" and "there is no
+        currency" at once. Provenance that can disagree with the data it
+        describes is worse than no provenance, so the invariant is structural:
+        a currency is stated exactly when there is one.
+        """
+        return self.currency is not None
 
     @classmethod
     def from_source(cls, raw: Any, field: str) -> "EPCMoney":
@@ -98,7 +110,7 @@ class EPCMoney(BaseModel):
 
         if isinstance(raw, (int, float)):
             # Legacy SAP scalar: an amount with no stated currency.
-            return cls(value=_finite(raw, field), currency=None, currency_stated=False)
+            return cls(value=_finite(raw, field), currency=None)
 
         if not isinstance(raw, dict) or "value" not in raw or "currency" not in raw:
             raise EPCUpstreamShapeError(
@@ -111,7 +123,7 @@ class EPCMoney(BaseModel):
         currency = _str_or_none(raw["currency"])
         if not currency:
             raise EPCUpstreamShapeError(f"{field}: missing currency")
-        return cls(value=value, currency=currency, currency_stated=True)
+        return cls(value=value, currency=currency)
 
 
 class EPCPagination(BaseModel):

--- a/property_core/epc/source_models.py
+++ b/property_core/epc/source_models.py
@@ -51,26 +51,67 @@ def _str_or_none(v: Any) -> Optional[str]:
     return s or None
 
 
+def _finite(raw: Any, field: str) -> Decimal:
+    """Decimal or EPCUpstreamShapeError — never a bare pydantic ValidationError.
+
+    json.loads accepts the literals NaN, Infinity and -Infinity, and pydantic
+    rejects non-finite Decimals with a ValidationError. That would escape the EPC
+    error taxonomy and surface as an unhandled 500 instead of a typed failure.
+    """
+    try:
+        value = Decimal(str(raw))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise EPCUpstreamShapeError(f"{field}: value is not numeric: {raw!r}") from exc
+    if not value.is_finite():
+        raise EPCUpstreamShapeError(f"{field}: value is not finite: {raw!r}")
+    return value
+
+
 class EPCMoney(BaseModel):
-    """A currency amount. Decimal, because these are money."""
+    """A currency amount. Decimal, because these are money.
+
+    Two shapes are observed upstream, and which one appears is a property of the
+    SCHEMA, not of the field — all six cost fields move together:
+
+        RdSAP 17.0/17.1/18.0/19.0/20.0.0, SAP 16.0/16.2 -> {"value", "currency"}
+        SAP 13.0/14.0/14.2/15.0                         -> a bare number
+
+    A bare number states no currency, so ``currency`` stays None and
+    ``currency_stated`` is False. The raw shape is deliberately NOT rewritten
+    into a fabricated {"currency": "GBP"} object here: inferring the
+    denomination is a compatibility-layer decision, and this layer's job is to
+    report what upstream actually said. See compat.to_epcdata().
+    """
 
     value: Decimal
-    currency: str
+    currency: Optional[str] = None
+    currency_stated: bool = True
 
     @classmethod
     def from_source(cls, raw: Any, field: str) -> "EPCMoney":
+        # bool BEFORE the number check: isinstance(True, int) is True in Python,
+        # so a bare `True` would otherwise validate as the amount 1.
+        if isinstance(raw, bool):
+            raise EPCUpstreamShapeError(
+                f"{field}: expected a number or {{value, currency}}, got bool {raw!r}"
+            )
+
+        if isinstance(raw, (int, float)):
+            # Legacy SAP scalar: an amount with no stated currency.
+            return cls(value=_finite(raw, field), currency=None, currency_stated=False)
+
         if not isinstance(raw, dict) or "value" not in raw or "currency" not in raw:
             raise EPCUpstreamShapeError(
-                f"{field}: expected {{value, currency}}, got {type(raw).__name__} {raw!r:.60}"
+                f"{field}: expected a number or {{value, currency}}, "
+                f"got {type(raw).__name__} {raw!r:.60}"
             )
-        try:
-            value = Decimal(str(raw["value"]))
-        except (InvalidOperation, TypeError) as exc:
-            raise EPCUpstreamShapeError(f"{field}: value is not numeric: {raw['value']!r}") from exc
+        if isinstance(raw["value"], bool):
+            raise EPCUpstreamShapeError(f"{field}: value is not numeric: {raw['value']!r}")
+        value = _finite(raw["value"], field)
         currency = _str_or_none(raw["currency"])
         if not currency:
             raise EPCUpstreamShapeError(f"{field}: missing currency")
-        return cls(value=value, currency=currency)
+        return cls(value=value, currency=currency, currency_stated=True)
 
 
 class EPCPagination(BaseModel):

--- a/property_core/models/report.py
+++ b/property_core/models/report.py
@@ -56,6 +56,11 @@ class EnergyPerformance(BaseModel):
     # Potential savings
     potential_heating_cost: Optional[int] = None
     potential_savings: Optional[int] = None
+    # Caveats attached to the certificate this block was derived from — e.g.
+    # that the cost amounts carry an inferred currency. The costs above are
+    # reported as plain numbers, so dropping these would present an inference
+    # as a measurement.
+    warnings: list[str] = Field(default_factory=list)
     # Certificate info
     inspection_date: Optional[str] = None
     certificate_hash: Optional[str] = None

--- a/property_core/report_service.py
+++ b/property_core/report_service.py
@@ -334,6 +334,10 @@ class PropertyReportService:
                 potential_savings=potential_savings,
                 inspection_date=result.inspection_date,
                 certificate_hash=result.lmk_key,
+                # The cost fields above may carry an inferred currency (legacy
+                # SAP scalar shape). Carrying the caveats forward is what keeps
+                # them an inference rather than an unqualified measurement.
+                warnings=list(result.warnings or []),
             )
 
             return {"success": True, "energy_performance": energy}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.14.0"
+version = "1.14.1"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates (England & Wales, GOV.UK Bearer API), rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/tests/fixtures/epc/rdsap_schema_17_0.json
+++ b/tests/fixtures/epc/rdsap_schema_17_0.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 2,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 6.9,
+    "co2_emissions_potential": 2.6,
+    "completion_date": "2015-02-17",
+    "current_energy_efficiency_band": "D",
+    "energy_rating_current": 57,
+    "energy_rating_potential": 83,
+    "habitable_room_count": 6,
+    "heating_cost_current": {
+      "currency": "GBP",
+      "value": 1241
+    },
+    "heating_cost_potential": {
+      "currency": "GBP",
+      "value": 661
+    },
+    "hot_water_cost_current": {
+      "currency": "GBP",
+      "value": 135
+    },
+    "hot_water_cost_potential": {
+      "currency": "GBP",
+      "value": 89
+    },
+    "inspection_date": "2015-02-10",
+    "lighting_cost_current": {
+      "currency": "GBP",
+      "value": 126
+    },
+    "lighting_cost_potential": {
+      "currency": "GBP",
+      "value": 83
+    },
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "B",
+    "property_type": 0,
+    "registration_date": "2015-02-17",
+    "schema_type": "RdSAP-Schema-17.0",
+    "tenure": 1,
+    "total_floor_area": 141,
+    "uprn": null
+  }
+}

--- a/tests/fixtures/epc/rdsap_schema_17_1.json
+++ b/tests/fixtures/epc/rdsap_schema_17_1.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 2,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 2.9,
+    "co2_emissions_potential": 1.3,
+    "completion_date": "2017-05-15",
+    "current_energy_efficiency_band": "D",
+    "energy_rating_current": 64,
+    "energy_rating_potential": 80,
+    "habitable_room_count": 3,
+    "heating_cost_current": {
+      "currency": "GBP",
+      "value": 527
+    },
+    "heating_cost_potential": {
+      "currency": "GBP",
+      "value": 223
+    },
+    "hot_water_cost_current": {
+      "currency": "GBP",
+      "value": 94
+    },
+    "hot_water_cost_potential": {
+      "currency": "GBP",
+      "value": 95
+    },
+    "inspection_date": "2017-05-15",
+    "lighting_cost_current": {
+      "currency": "GBP",
+      "value": 55
+    },
+    "lighting_cost_potential": {
+      "currency": "GBP",
+      "value": 42
+    },
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "C",
+    "property_type": 2,
+    "registration_date": "2017-05-15",
+    "schema_type": "RdSAP-Schema-17.1",
+    "tenure": 3,
+    "total_floor_area": 58,
+    "uprn": null
+  }
+}

--- a/tests/fixtures/epc/rdsap_schema_18_0.json
+++ b/tests/fixtures/epc/rdsap_schema_18_0.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 2,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 9.2,
+    "co2_emissions_potential": 4.7,
+    "completion_date": "2018-05-15",
+    "current_energy_efficiency_band": "E",
+    "energy_rating_current": 47,
+    "energy_rating_potential": 71,
+    "habitable_room_count": 4,
+    "heating_cost_current": {
+      "currency": "GBP",
+      "value": 1633
+    },
+    "heating_cost_potential": {
+      "currency": "GBP",
+      "value": 817
+    },
+    "hot_water_cost_current": {
+      "currency": "GBP",
+      "value": 93
+    },
+    "hot_water_cost_potential": {
+      "currency": "GBP",
+      "value": 93
+    },
+    "inspection_date": "2018-05-14",
+    "lighting_cost_current": {
+      "currency": "GBP",
+      "value": 137
+    },
+    "lighting_cost_potential": {
+      "currency": "GBP",
+      "value": 90
+    },
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "C",
+    "property_type": 2,
+    "registration_date": "2018-05-15",
+    "schema_type": "RdSAP-Schema-18.0",
+    "tenure": 3,
+    "total_floor_area": 147,
+    "uprn": null
+  }
+}

--- a/tests/fixtures/epc/rdsap_schema_19_0.json
+++ b/tests/fixtures/epc/rdsap_schema_19_0.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 2,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 2.8,
+    "co2_emissions_potential": 1.8,
+    "completion_date": "2019-11-04",
+    "current_energy_efficiency_band": "C",
+    "energy_rating_current": 69,
+    "energy_rating_potential": 77,
+    "habitable_room_count": 3,
+    "heating_cost_current": {
+      "currency": "GBP",
+      "value": 485
+    },
+    "heating_cost_potential": {
+      "currency": "GBP",
+      "value": 310
+    },
+    "hot_water_cost_current": {
+      "currency": "GBP",
+      "value": 93
+    },
+    "hot_water_cost_potential": {
+      "currency": "GBP",
+      "value": 94
+    },
+    "inspection_date": "2019-11-04",
+    "lighting_cost_current": {
+      "currency": "GBP",
+      "value": 61
+    },
+    "lighting_cost_potential": {
+      "currency": "GBP",
+      "value": 61
+    },
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "C",
+    "property_type": 2,
+    "registration_date": "2019-11-04",
+    "schema_type": "RdSAP-Schema-19.0",
+    "tenure": 3,
+    "total_floor_area": 72,
+    "uprn": null
+  }
+}

--- a/tests/fixtures/epc/rdsap_schema_20_0_0.json
+++ b/tests/fixtures/epc/rdsap_schema_20_0_0.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 4,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 1.9,
+    "co2_emissions_potential": 1.0,
+    "completion_date": "2023-03-05",
+    "current_energy_efficiency_band": "D",
+    "energy_rating_current": 62,
+    "energy_rating_potential": 75,
+    "habitable_room_count": 1,
+    "heating_cost_current": {
+      "currency": "GBP",
+      "value": 785
+    },
+    "heating_cost_potential": {
+      "currency": "GBP",
+      "value": 397
+    },
+    "hot_water_cost_current": {
+      "currency": "GBP",
+      "value": 182
+    },
+    "hot_water_cost_potential": {
+      "currency": "GBP",
+      "value": 161
+    },
+    "inspection_date": "2023-02-27",
+    "lighting_cost_current": {
+      "currency": "GBP",
+      "value": 53
+    },
+    "lighting_cost_potential": {
+      "currency": "GBP",
+      "value": 53
+    },
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "C",
+    "property_type": 2,
+    "registration_date": "2023-03-05",
+    "schema_type": "RdSAP-Schema-20.0.0",
+    "tenure": 3,
+    "total_floor_area": 27,
+    "uprn": null
+  }
+}

--- a/tests/fixtures/epc/sap_schema_13_0.json
+++ b/tests/fixtures/epc/sap_schema_13_0.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 2,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 4.5,
+    "co2_emissions_potential": 4.5,
+    "completion_date": "2009-07-28",
+    "current_energy_efficiency_band": "D",
+    "energy_rating_current": 57,
+    "energy_rating_potential": 58,
+    "habitable_room_count": 3,
+    "heating_cost_current": 625,
+    "heating_cost_potential": 630,
+    "hot_water_cost_current": 136,
+    "hot_water_cost_potential": 136,
+    "inspection_date": "2009-07-28",
+    "lighting_cost_current": 58,
+    "lighting_cost_potential": 37,
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "D",
+    "property_type": 2,
+    "registration_date": "2009-07-28",
+    "schema_type": "SAP-Schema-13.0",
+    "total_floor_area": 72,
+    "uprn": null
+  }
+}

--- a/tests/fixtures/epc/sap_schema_14_0.json
+++ b/tests/fixtures/epc/sap_schema_14_0.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 1,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 12,
+    "co2_emissions_potential": 10,
+    "completion_date": "2009-12-17",
+    "current_energy_efficiency_band": "F",
+    "energy_rating_current": 31,
+    "energy_rating_potential": 41,
+    "habitable_room_count": 3,
+    "heating_cost_current": 1771,
+    "heating_cost_potential": 1499,
+    "hot_water_cost_current": 146,
+    "hot_water_cost_potential": 121,
+    "inspection_date": "2009-12-07",
+    "lighting_cost_current": 144,
+    "lighting_cost_potential": 77,
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "E",
+    "property_type": 2,
+    "registration_date": "2009-12-17",
+    "schema_type": "SAP-Schema-14.0",
+    "total_floor_area": 140,
+    "uprn": null
+  }
+}

--- a/tests/fixtures/epc/sap_schema_14_2.json
+++ b/tests/fixtures/epc/sap_schema_14_2.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 2,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 3.0,
+    "co2_emissions_potential": 3.0,
+    "completion_date": "2010-08-25",
+    "current_energy_efficiency_band": "D",
+    "energy_rating_current": 64,
+    "energy_rating_potential": 65,
+    "habitable_room_count": 3,
+    "heating_cost_current": 515,
+    "heating_cost_potential": 518,
+    "hot_water_cost_current": 78,
+    "hot_water_cost_potential": 78,
+    "inspection_date": "2010-08-25",
+    "lighting_cost_current": 39,
+    "lighting_cost_potential": 28,
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "D",
+    "property_type": 2,
+    "registration_date": "2010-08-25",
+    "schema_type": "SAP-Schema-14.2",
+    "total_floor_area": 53,
+    "uprn": null
+  }
+}

--- a/tests/fixtures/epc/sap_schema_15_0.json
+++ b/tests/fixtures/epc/sap_schema_15_0.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 2,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 1.8,
+    "co2_emissions_potential": 1.5,
+    "completion_date": "2011-05-18",
+    "current_energy_efficiency_band": "D",
+    "energy_rating_current": 65,
+    "energy_rating_potential": 68,
+    "habitable_room_count": 1,
+    "heating_cost_current": 335,
+    "heating_cost_potential": 308,
+    "hot_water_cost_current": 63,
+    "hot_water_cost_potential": 55,
+    "inspection_date": "2011-05-17",
+    "lighting_cost_current": 26,
+    "lighting_cost_potential": 19,
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "D",
+    "property_type": 2,
+    "registration_date": "2011-05-18",
+    "schema_type": "SAP-Schema-15.0",
+    "total_floor_area": 29,
+    "uprn": null
+  }
+}

--- a/tests/fixtures/epc/sap_schema_16_0.json
+++ b/tests/fixtures/epc/sap_schema_16_0.json
@@ -1,0 +1,49 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 1,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 2.3,
+    "co2_emissions_potential": 1.8,
+    "completion_date": "2012-09-24",
+    "current_energy_efficiency_band": "C",
+    "energy_rating_current": 72,
+    "energy_rating_potential": 77,
+    "habitable_room_count": 4,
+    "heating_cost_current": {
+      "currency": "GBP",
+      "value": 386
+    },
+    "heating_cost_potential": {
+      "currency": "GBP",
+      "value": 321
+    },
+    "hot_water_cost_current": {
+      "currency": "GBP",
+      "value": 104
+    },
+    "hot_water_cost_potential": {
+      "currency": "GBP",
+      "value": 105
+    },
+    "inspection_date": "2012-09-22",
+    "lighting_cost_current": {
+      "currency": "GBP",
+      "value": 79
+    },
+    "lighting_cost_potential": {
+      "currency": "GBP",
+      "value": 47
+    },
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "C",
+    "property_type": 2,
+    "registration_date": "2012-09-24",
+    "schema_type": "SAP-Schema-16.0",
+    "total_floor_area": 74,
+    "uprn": null
+  }
+}

--- a/tests/fixtures/epc/sap_schema_16_2.json
+++ b/tests/fixtures/epc/sap_schema_16_2.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "address_line_1": "1 Example Street",
+    "address_line_2": null,
+    "address_line_3": null,
+    "assessment_type": "RdSAP",
+    "built_form": 2,
+    "certificate_number": "0000-0000-0000-0000-0001",
+    "co2_emissions_current": 14,
+    "co2_emissions_potential": 6.1,
+    "completion_date": "2013-09-18",
+    "current_energy_efficiency_band": "E",
+    "energy_rating_current": 42,
+    "energy_rating_potential": 74,
+    "habitable_room_count": 12,
+    "heating_cost_current": {
+      "currency": "GBP",
+      "value": 2445
+    },
+    "heating_cost_potential": {
+      "currency": "GBP",
+      "value": 1244
+    },
+    "hot_water_cost_current": {
+      "currency": "GBP",
+      "value": 148
+    },
+    "hot_water_cost_potential": {
+      "currency": "GBP",
+      "value": 119
+    },
+    "inspection_date": "2013-09-17",
+    "lighting_cost_current": {
+      "currency": "GBP",
+      "value": 128
+    },
+    "lighting_cost_potential": {
+      "currency": "GBP",
+      "value": 95
+    },
+    "postcode": "AA1 1AA",
+    "potential_energy_efficiency_band": "C",
+    "property_type": 0,
+    "registration_date": "2013-09-18",
+    "schema_type": "SAP-Schema-16.2",
+    "tenure": 1,
+    "total_floor_area": 215,
+    "uprn": null
+  }
+}

--- a/tests/test_epc_scalar_money.py
+++ b/tests/test_epc_scalar_money.py
@@ -1,0 +1,198 @@
+"""Legacy SAP schemas return cost fields as bare integers, not {value, currency}.
+
+Found by production dogfooding of v1.14.0: every certificate on SAP-Schema-13.0,
+14.0, 14.2 and 15.0 returned
+
+    503  "heating_cost_current: expected {value, currency}, got int 267"
+
+because EPCMoney.from_source hard-raised on any non-dict. That broke certificate
+lookup, exact-address search, comps enrichment, the report service and both MCP
+surfaces for those schemas. Area summaries were unaffected (no certificate fetch).
+
+The evidence was in the probe captures all along: an audit of ALL SIX cost fields
+across the 11 saved schema captures shows the shape is per-SCHEMA, not per-field —
+all six move together.
+
+    RdSAP 17.0/17.1/18.0/19.0/20.0.0, SAP 16.0/16.2  -> {value, currency}
+    SAP 13.0/14.0/14.2/15.0                          -> bare int
+
+Contract:
+  * a bare number is accepted, and the source model records that upstream stated
+    NO currency (currency stays None) — the raw shape is not rewritten into a
+    fabricated {"currency": "GBP"} object;
+  * the v1 projection keeps the amount and reads it as GBP, emitting ONE
+    aggregated warning per certificate, not one per field;
+  * bool, str, list and malformed objects are still rejected. bool is checked
+    explicitly because in Python `isinstance(True, int)` is True.
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from property_core.epc.compat import to_epcdata
+from property_core.epc.errors import EPCUpstreamShapeError
+from property_core.epc.source_models import EPCCertificateDoc, EPCMoney
+
+FIXTURES = Path(__file__).parent / "fixtures" / "epc"
+
+COST_FIELDS = [
+    "heating_cost_current", "heating_cost_potential",
+    "hot_water_cost_current", "hot_water_cost_potential",
+    "lighting_cost_current", "lighting_cost_potential",
+]
+
+SCALAR_SCHEMAS = ["sap_schema_13_0", "sap_schema_14_0", "sap_schema_14_2", "sap_schema_15_0"]
+OBJECT_SCHEMAS = [
+    "rdsap_schema_17_0", "rdsap_schema_17_1", "rdsap_schema_18_0",
+    "rdsap_schema_19_0", "rdsap_schema_20_0_0", "sap_schema_16_0", "sap_schema_16_2",
+]
+
+
+def load(name: str) -> dict:
+    return json.loads((FIXTURES / f"{name}.json").read_text())["data"]
+
+
+def doc(name: str) -> EPCCertificateDoc:
+    raw = load(name)
+    return EPCCertificateDoc.from_source(
+        raw, certificate_number=raw["certificate_number"],
+        schema_type=raw.get("schema_type"))
+
+
+class TestFixturesPinTheObservedShapes:
+    """If upstream changes shape, these fail before anything else does."""
+
+    @pytest.mark.parametrize("name", SCALAR_SCHEMAS)
+    def test_scalar_schemas_carry_bare_ints_on_every_cost_field(self, name):
+        raw = load(name)
+        for f in COST_FIELDS:
+            assert isinstance(raw[f], int) and not isinstance(raw[f], bool), \
+                f"{name}.{f} is not a bare int: {raw[f]!r}"
+
+    @pytest.mark.parametrize("name", OBJECT_SCHEMAS)
+    def test_object_schemas_carry_value_currency_on_every_cost_field(self, name):
+        raw = load(name)
+        for f in COST_FIELDS:
+            assert isinstance(raw[f], dict) and {"value", "currency"} <= raw[f].keys(), \
+                f"{name}.{f} is not an object: {raw[f]!r}"
+
+
+class TestScalarSchemasParse:
+    """The production 503, at the layer that raised it."""
+
+    @pytest.mark.parametrize("name", SCALAR_SCHEMAS)
+    def test_certificate_parses(self, name):
+        d = doc(name)
+        assert d.certificate_number
+        for f in COST_FIELDS:
+            assert getattr(d, f) is not None, f"{f} was dropped"
+
+    @pytest.mark.parametrize("name", SCALAR_SCHEMAS)
+    def test_missing_currency_is_preserved_not_invented(self, name):
+        """The source layer must not rewrite the raw shape into GBP."""
+        d = doc(name)
+        for f in COST_FIELDS:
+            money = getattr(d, f)
+            assert money.currency is None, \
+                f"{f}: upstream stated no currency; source model invented {money.currency!r}"
+            assert money.currency_stated is False
+
+    @pytest.mark.parametrize("name", OBJECT_SCHEMAS)
+    def test_object_schemas_keep_their_stated_currency(self, name):
+        d = doc(name)
+        for f in COST_FIELDS:
+            money = getattr(d, f)
+            assert money.currency == "GBP"
+            assert money.currency_stated is True
+
+
+class TestV1ProjectionKeepsTheAmount:
+    @pytest.mark.parametrize("name", SCALAR_SCHEMAS)
+    def test_amount_is_retained_and_read_as_gbp(self, name):
+        raw, d = load(name), doc(name)
+        data = to_epcdata(d)
+        for f in COST_FIELDS:
+            assert getattr(data, f) == raw[f], f"{f} amount lost or altered"
+
+    @pytest.mark.parametrize("name", SCALAR_SCHEMAS)
+    def test_exactly_one_aggregated_inference_warning(self, name):
+        data = to_epcdata(doc(name))
+        inferred = [w for w in (data.warnings or []) if "currenc" in w.lower()]
+        assert len(inferred) == 1, \
+            f"expected ONE aggregated warning, got {len(inferred)}: {inferred}"
+        w = inferred[0].lower()
+        assert "gbp" in w and ("infer" in w or "assum" in w), inferred[0]
+        for f in COST_FIELDS:
+            assert f not in inferred[0], "warning names individual fields — that is per-field spam"
+
+    @pytest.mark.parametrize("name", OBJECT_SCHEMAS)
+    def test_object_schemas_emit_no_currency_warning(self, name):
+        data = to_epcdata(doc(name))
+        assert not [w for w in (data.warnings or []) if "currenc" in w.lower()]
+
+
+class TestMalformedMoneyIsStillRejected:
+    @pytest.mark.parametrize("bad", [
+        True, False,                       # bool is an int in Python — must NOT pass
+        "625", "", "abc",                  # strings, including numeric-looking ones
+        [625], [], {},                     # lists and empty objects
+        {"value": 625},                    # missing currency key
+        {"currency": "GBP"},               # missing value key
+        {"value": "abc", "currency": "GBP"},
+        {"value": 625, "currency": ""},
+        {"value": None, "currency": "GBP"},
+    ])
+    def test_rejected(self, bad):
+        with pytest.raises(EPCUpstreamShapeError):
+            EPCMoney.from_source(bad, "heating_cost_current")
+
+    def test_bool_is_not_accepted_as_a_number(self):
+        """isinstance(True, int) is True — the check must be explicit."""
+        with pytest.raises(EPCUpstreamShapeError) as exc:
+            EPCMoney.from_source(True, "heating_cost_current")
+        assert "bool" in str(exc.value).lower()
+
+    @pytest.mark.parametrize("nonfinite", ["NaN", "Infinity", "-Infinity"])
+    def test_non_finite_numbers_are_typed_failures_not_500s(self, nonfinite):
+        """json.loads accepts these literals; pydantic would raise a bare
+        ValidationError that escapes the EPC taxonomy as an unhandled 500."""
+        import json as _json
+
+        value = _json.loads(nonfinite)
+        with pytest.raises(EPCUpstreamShapeError) as exc:
+            EPCMoney.from_source(value, "heating_cost_current")
+        assert "finite" in str(exc.value).lower()
+        with pytest.raises(EPCUpstreamShapeError):
+            EPCMoney.from_source({"value": value, "currency": "GBP"},
+                                 "heating_cost_current")
+
+    def test_currency_flag_cannot_desync_the_projection(self):
+        """A directly constructed EPCMoney with no currency must still be
+        treated as unstated, whatever the flag says."""
+        from property_core.epc.compat import _money
+
+        warnings, inferred = [], []
+        assert _money(EPCMoney(value=Decimal("625")), "heating_cost_current",
+                      warnings, inferred) == 625
+        assert inferred == ["heating_cost_current"]
+        assert warnings == []
+
+    @pytest.mark.parametrize("good", [625, 0, 1771, 625.5])
+    def test_bare_numbers_accepted(self, good):
+        m = EPCMoney.from_source(good, "heating_cost_current")
+        assert m.value == Decimal(str(good)) and m.currency is None
+
+    def test_a_stated_non_gbp_currency_still_suppresses_the_legacy_scalar(self):
+        raw = load("sap_schema_13_0")
+        raw = {**raw, "heating_cost_current": {"value": 500, "currency": "EUR"}}
+        d = EPCCertificateDoc.from_source(
+            raw, certificate_number=raw["certificate_number"],
+            schema_type=raw.get("schema_type"))
+        data = to_epcdata(d)
+        assert data.heating_cost_current is None
+        assert any("EUR" in w for w in (data.warnings or []))

--- a/tests/test_epc_scalar_money.py
+++ b/tests/test_epc_scalar_money.py
@@ -171,6 +171,31 @@ class TestMalformedMoneyIsStillRejected:
             EPCMoney.from_source({"value": value, "currency": "GBP"},
                                  "heating_cost_current")
 
+    def test_direct_construction_without_a_currency_reports_unstated(self):
+        """Human review blocker: EPCMoney(value=...) used to yield currency=None
+        with currency_stated=True — "a currency was stated" and "there is no
+        currency" simultaneously. currency_stated is now DERIVED, so the
+        contradictory state cannot be constructed at all."""
+        m = EPCMoney(value=Decimal("625"))
+        assert m.currency is None
+        assert m.currency_stated is False
+
+    def test_direct_construction_with_a_currency_reports_stated(self):
+        m = EPCMoney(value=Decimal("625"), currency="GBP")
+        assert m.currency == "GBP"
+        assert m.currency_stated is True
+
+    def test_currency_stated_is_not_a_settable_field(self):
+        """If it were settable, provenance could contradict the data again."""
+        assert "currency_stated" not in EPCMoney.model_fields
+        m = EPCMoney(value=Decimal("1"))
+        with pytest.raises((ValueError, AttributeError)):
+            m.currency_stated = True   # type: ignore[misc]
+
+    def test_constructor_ignores_an_attempt_to_force_the_flag(self):
+        m = EPCMoney(value=Decimal("1"), currency_stated=True)  # type: ignore[call-arg]
+        assert m.currency_stated is False, "a forced flag overrode the invariant"
+
     def test_currency_flag_cannot_desync_the_projection(self):
         """A directly constructed EPCMoney with no currency must still be
         treated as unstated, whatever the flag says."""

--- a/tests/test_epc_scalar_money_surfaces.py
+++ b/tests/test_epc_scalar_money_surfaces.py
@@ -1,0 +1,172 @@
+"""A legacy SAP scalar certificate must survive every outward surface.
+
+The v1.14.0 defect was not confined to the parser: because EPCUpstreamShapeError
+subclasses EPCUpstreamError, a bare-int cost field surfaced as REST 503 and as an
+MCP tool error on certificate lookup, exact-address search, comps enrichment and
+the report service. These tests drive each of those paths with a real SAP-13.0
+fixture, and assert the aggregated currency warning survives without turning into
+per-field spam.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from property_core.epc_client import EPCClient
+
+FIXTURES = Path(__file__).parent / "fixtures" / "epc"
+CERT_NO = "0000-0000-0000-0000-0001"
+POSTCODE = "AA1 1AA"
+ADDRESS = "1 Example Street"
+
+SCALAR = json.loads((FIXTURES / "sap_schema_13_0.json").read_text())
+MODERN = json.loads((FIXTURES / "rdsap_schema_20_0_0.json").read_text())
+
+
+def _summary_body():
+    return {
+        "data": [{
+            "certificateNumber": CERT_NO, "addressLine1": ADDRESS, "addressLine2": None,
+            "addressLine3": None, "addressLine4": None, "uprn": None, "postcode": POSTCODE,
+            "currentEnergyEfficiencyBand": "D", "registrationDate": "2012-01-01",
+            "schemaType": "SAP-Schema-13.0", "postTown": None, "council": None,
+            "constituency": None,
+        }],
+        "pagination": {"currentPage": 1, "pageSize": 5000, "totalRecords": 1, "totalPages": 1},
+    }
+
+
+def _client(cert_body=SCALAR):
+    """EPCClient whose upstream returns the scalar-cost certificate."""
+    def handler(request):
+        p = request.url.path
+        if p.endswith("/certificate"):
+            return httpx.Response(200, json=cert_body)
+        if "/codes/info" in p:
+            return httpx.Response(200, json={"data": []})
+        return httpx.Response(200, json=_summary_body())
+
+    c = EPCClient(token="t")
+    c._transport = httpx.MockTransport(handler)
+    return c
+
+
+def _currency_warnings(warnings):
+    return [w for w in (warnings or []) if "currenc" in w.lower()]
+
+
+def _assert_disclosed_once(warnings, where):
+    hits = _currency_warnings(warnings)
+    assert len(hits) == 1, f"{where}: expected 1 aggregated warning, got {len(hits)}: {hits}"
+    assert "gbp" in hits[0].lower(), f"{where}: warning does not name GBP"
+
+
+class TestCoreClientPaths:
+    def test_certificate_lookup(self):
+        data = asyncio.run(_client().get_certificate(CERT_NO))
+        assert data.heating_cost_current == 625
+        assert data.lighting_cost_potential == 37
+        _assert_disclosed_once(data.warnings, "get_certificate")
+
+    def test_exact_address_search(self):
+        data = asyncio.run(_client().search_by_postcode(POSTCODE, address=ADDRESS))
+        assert data is not None, "scalar-cost certificate was dropped by search"
+        assert data.heating_cost_current == 625
+        _assert_disclosed_once(data.warnings, "search_by_postcode")
+
+    def test_modern_object_costs_emit_no_currency_warning(self):
+        data = asyncio.run(_client(MODERN).get_certificate(CERT_NO))
+        assert data.heating_cost_current is not None
+        assert _currency_warnings(data.warnings) == []
+
+
+class TestEnrichmentAndReport:
+    def test_comps_enrichment_attaches_the_certificate(self):
+        from property_core.enrichment import enrich_comps_with_epc
+        from property_core.models.ppd import PPDTransaction
+
+        comps = [PPDTransaction(transaction_id="1", price=250000, postcode=POSTCODE,
+                                paon="1", street="EXAMPLE STREET")]
+        out = asyncio.run(enrich_comps_with_epc(comps, epc_client=_client()))
+        assert out[0].epc_match is not None, "enrichment dropped a scalar-cost certificate"
+        assert out[0].epc_rating == "D"
+
+    def test_report_service_epc_step_succeeds(self):
+        """_fetch_epc_data() swallows failures into success=False — the v1.14.0
+        defect would have shown up as an EPC-less report, not an exception."""
+        from property_core.report_service import PropertyReportService
+
+        svc = PropertyReportService(epc_client=_client())
+        result = asyncio.run(svc._fetch_epc_data(POSTCODE, ADDRESS))
+        assert result["success"] is True, f"report EPC step failed: {result.get('error')}"
+        ep = result.get("energy_performance")
+        assert ep is not None, "report produced no EnergyPerformance block"
+        # The report model flattens the cost fields; the scalar amounts must
+        # reach it rather than being lost to a parse failure upstream.
+        assert ep.heating_cost == 625
+        assert ep.hot_water_cost == 136
+        assert ep.lighting_cost == 58
+
+
+def _rest(client):
+    from app.api.v1 import epc as R
+
+    R._client = client
+    app = FastAPI()
+    app.include_router(R.router, prefix="/v1")
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestRestSurface:
+    def test_certificate_endpoint_is_200_not_503(self):
+        got = _rest(_client()).get(f"/v1/epc/certificate/{CERT_NO}")
+        assert got.status_code == 200, f"regression: {got.status_code} {got.text[:200]}"
+        body = got.json()["record"]
+        assert body["heating_cost_current"] == 625
+        _assert_disclosed_once(body["warnings"], "REST certificate")
+
+    def test_search_endpoint_is_200_not_503(self):
+        got = _rest(_client()).get("/v1/epc/search",
+                                   params={"postcode": POSTCODE, "address": ADDRESS})
+        assert got.status_code == 200, f"regression: {got.status_code} {got.text[:200]}"
+        assert got.json()["record"]["heating_cost_current"] == 625
+
+
+class TestMcpSurfaces:
+    def test_plain_mcp_epc_certificate(self):
+        from app.mcp import server as S
+
+        S_client = _client()
+        import property_core
+        orig = property_core.EPCClient
+        property_core.EPCClient = lambda *a, **k: S_client
+        try:
+            fn = S.epc_certificate.fn if hasattr(S.epc_certificate, "fn") else S.epc_certificate
+            result = asyncio.run(fn(CERT_NO))
+        finally:
+            property_core.EPCClient = orig
+        assert result is not None, "plain MCP dropped a scalar-cost certificate"
+        assert result["heating_cost_current"] == 625
+        _assert_disclosed_once(result.get("warnings"), "plain MCP")
+
+    def test_mcp_app_epc_certificate(self):
+        from property_app import tools as T
+
+        app_client = _client()
+        import property_core
+        orig = property_core.EPCClient
+        property_core.EPCClient = lambda *a, **k: app_client
+        try:
+            result = asyncio.run(T.fetch_epc_certificate(CERT_NO))
+        finally:
+            property_core.EPCClient = orig
+        assert result is not None, "MCP app dropped a scalar-cost certificate"
+        assert result["heating_cost_current"] == 625
+        _assert_disclosed_once(result.get("warnings"), "MCP app")

--- a/tests/test_epc_scalar_money_surfaces.py
+++ b/tests/test_epc_scalar_money_surfaces.py
@@ -95,8 +95,12 @@ class TestEnrichmentAndReport:
         comps = [PPDTransaction(transaction_id="1", price=250000, postcode=POSTCODE,
                                 paon="1", street="EXAMPLE STREET")]
         out = asyncio.run(enrich_comps_with_epc(comps, epc_client=_client()))
-        assert out[0].epc_match is not None, "enrichment dropped a scalar-cost certificate"
+        match = out[0].epc_match
+        assert match is not None, "enrichment dropped a scalar-cost certificate"
         assert out[0].epc_rating == "D"
+        # Success alone is not enough: the attached certificate carries costs
+        # with an INFERRED currency, so the caveat must ride along with it.
+        _assert_disclosed_once(match.get("warnings"), "enrichment epc_match")
 
     def test_report_service_epc_step_succeeds(self):
         """_fetch_epc_data() swallows failures into success=False — the v1.14.0
@@ -113,6 +117,41 @@ class TestEnrichmentAndReport:
         assert ep.heating_cost == 625
         assert ep.hot_water_cost == 136
         assert ep.lighting_cost == 58
+        # Those costs are denominated by INFERENCE. Presenting them without the
+        # caveat would render an inference as a measurement.
+        _assert_disclosed_once(ep.warnings, "report service EnergyPerformance")
+
+    def test_report_warning_survives_json_and_html(self):
+        """Service output, REST JSON and the rendered HTML must each disclose it
+        exactly once — the HTML report is where a human actually reads the cost."""
+        from property_core.report_service import PropertyReportService
+
+        svc = PropertyReportService(epc_client=_client())
+        result = asyncio.run(svc._fetch_epc_data(POSTCODE, ADDRESS))
+        ep = result["energy_performance"]
+
+        # 1. JSON serialisation of the model (what REST returns)
+        payload = ep.model_dump(mode="json")
+        _assert_disclosed_once(payload.get("warnings"), "report JSON")
+
+        # 2. Rendered HTML
+        from jinja2 import Environment, FileSystemLoader
+
+        from datetime import datetime
+
+        from property_core.models.report import PropertyReport
+
+        report = PropertyReport(
+            report_id="test", generated_at=datetime(2026, 1, 1),
+            query_address=ADDRESS, query_postcode=POSTCODE,
+            energy_performance=ep,
+        )
+        env = Environment(loader=FileSystemLoader("app/templates"), autoescape=True)
+        html = env.get_template("report.html").render(report=report)
+        needle = "interpreted as GBP"
+        assert needle in html, "the currency inference is not rendered in the HTML report"
+        assert html.count(needle) == 1, \
+            f"warning rendered {html.count(needle)} times — duplicated in the HTML"
 
 
 def _rest(client):
@@ -136,7 +175,9 @@ class TestRestSurface:
         got = _rest(_client()).get("/v1/epc/search",
                                    params={"postcode": POSTCODE, "address": ADDRESS})
         assert got.status_code == 200, f"regression: {got.status_code} {got.text[:200]}"
-        assert got.json()["record"]["heating_cost_current"] == 625
+        record = got.json()["record"]
+        assert record["heating_cost_current"] == 625
+        _assert_disclosed_once(record.get("warnings"), "REST search")
 
 
 class TestMcpSurfaces:

--- a/tests/test_epc_source_models.py
+++ b/tests/test_epc_source_models.py
@@ -155,10 +155,22 @@ class TestMoney:
         assert doc.heating_cost_current.currency == "GBP"
 
     def test_malformed_money_raises_rather_than_becoming_none(self):
-        for bad in (785, "785", {"value": 785}, {"currency": "GBP"}, {"value": "x", "currency": "GBP"}):
+        # NB: a BARE NUMBER was in this list until v1.14.1. It was wrong — SAP
+        # schemas 13.0/14.0/14.2/15.0 genuinely return scalars, and rejecting
+        # them made every such certificate a production 503. It is now accepted
+        # with no stated currency; see tests/test_epc_scalar_money.py.
+        for bad in (True, False, "785", [785], {}, {"value": 785}, {"currency": "GBP"},
+                    {"value": "x", "currency": "GBP"}, {"value": 785, "currency": ""}):
             with pytest.raises(EPCUpstreamShapeError):
                 EPCCertificateDoc.from_source(
                     {**CERT_DOC, "heating_cost_current": bad}, certificate_number="1")
+
+    def test_bare_scalar_is_accepted_without_a_currency(self):
+        doc = EPCCertificateDoc.from_source(
+            {**CERT_DOC, "heating_cost_current": 785}, certificate_number="1")
+        assert doc.heating_cost_current.value == Decimal("785")
+        assert doc.heating_cost_current.currency is None
+        assert doc.heating_cost_current.currency_stated is False
 
     def test_non_gbp_currency_is_preserved_not_discarded(self):
         doc = EPCCertificateDoc.from_source(

--- a/uv.lock
+++ b/uv.lock
@@ -1175,7 +1175,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Production incident, found by dogfooding v1.14.0

Minutes after the v1.14.0 deploy, `/v1/epc/certificate/...` on the live service returned:

```
503  "EPC service unavailable: heating_cost_current: expected {value, currency}, got int 267"
```

**Every certificate on SAP-Schema-13.0, 14.0, 14.2 and 15.0 currently fails in production.**

## Cause

The money shape is a property of the **schema**, not the field. Auditing all six cost fields across the eleven saved schema captures — not only `heating_cost_current` — shows they move together:

| Schema | heating.cur/pot | hot_water.cur/pot | lighting.cur/pot |
|---|---|---|---|
| RdSAP 17.0 / 17.1 / 18.0 / 19.0 / 20.0.0 | obj | obj | obj |
| SAP 16.0 / 16.2 | obj | obj | obj |
| **SAP 13.0 / 14.0 / 14.2 / 15.0** | **int** | **int** | **int** |

`EPCMoney.from_source` accepted only the object form and raised `EPCUpstreamShapeError`, which subclasses `EPCUpstreamError` and therefore surfaced as **503**. Blast radius: certificate lookup, exact-address search, comps `enrich_epc=true`, the report service, and `epc_certificate` on both MCP servers. Area summaries were unaffected — they fetch no certificate.

**The evidence was in the probe captures used to build the migration.** The model was written requiring `{value, currency}` while four of those captures said otherwise. That is the root cause, not an upstream change.

## Fix

- **Bare numbers accepted.** The source model records that upstream stated no currency (`currency=None`, `currency_stated=False`) and does **not** rewrite the raw shape into a fabricated `{"currency": "GBP"}` object.
- **The v1 projection keeps the amount** and reads it as GBP — the representation the retired v1 field used, on a register scoped to England and Wales — emitting **one aggregated warning per certificate**, not one per field. A schema's six cost fields share a shape, so per-field warnings would be six copies of the same sentence.
- **Malformed money still rejected**: `bool` (checked explicitly, ahead of the numeric branch, because `isinstance(True, int)` is `True` in Python), strings, lists, empty objects, missing `value`/`currency`, non-numeric values, empty currency. A stated non-GBP currency still suppresses the legacy scalar with its existing warning.

## Two further defects found while reviewing this diff

1. **Non-finite values escaped the error taxonomy.** `json.loads` accepts the `NaN` / `Infinity` / `-Infinity` literals; pydantic rejected them with a bare `ValidationError`, which would surface as an unhandled **500** rather than a typed failure. Now `EPCUpstreamShapeError`.
2. **`currency_stated` could desync from `currency`** on a directly constructed `EPCMoney`, silently changing the projection. It now keys off the currency itself; the flag is informational.

## Tests

- **Sanitised fixtures for all eleven observed schemas** (`tests/fixtures/epc/`) — placeholder certificate number, no real addresses or UPRNs (verified by content grep) — pinning *both* shapes, so an upstream change fails loudly instead of silently.
- **Cross-surface regression coverage**: certificate lookup, exact-address search, comps enrichment, report service, REST (asserts `200`, not `503`), and both MCP surfaces — each asserting the aggregated warning survives and that there is exactly one, naming no individual field.
- One stale assertion that a bare int *must* raise is corrected in place, with a comment explaining why it was wrong.

Verified across every fixture: 11 parsed, 0 failed; the 4 scalar schemas carry exactly 1 currency warning each, the 7 object schemas carry 0.

**573 passed, 24 skipped** on Python 3.11. `git diff --check` clean.

Not for merge or deploy until reviewed.