### PR TITLE
test(epc): stop test collection loading a developer's .env

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Shared test fixtures.
+
+The EPC credential fixtures exist because `EPCClient(token=None)` does NOT mean
+"unconfigured" — the constructor falls back to `os.getenv("EPC_API_TOKEN")`, so a
+token in the ambient environment silently reconfigures the client and any test
+asserting unconfigured behaviour passes or fails depending on the developer's
+shell and whether a .env happens to exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+EPC_CREDENTIAL_VARS = ("EPC_API_TOKEN", "EPC_API_EMAIL", "EPC_API_KEY")
+
+
+@pytest.fixture
+def no_epc_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guarantee an unconfigured EPC environment for the duration of a test.
+
+    Removes every EPC credential variable, so a test asserting unconfigured
+    behaviour is deterministic whether or not the developer exports credentials
+    or keeps a .env. monkeypatch restores the previous values afterwards.
+    """
+    for var in EPC_CREDENTIAL_VARS:
+        monkeypatch.delenv(var, raising=False)

--- a/tests/test_block_service_live.py
+++ b/tests/test_block_service_live.py
@@ -2,13 +2,20 @@
 
 import os
 
-try:
-    from dotenv import load_dotenv
-except ImportError:
-    load_dotenv = None
-
-if load_dotenv:
-    load_dotenv()
+# Credentials are loaded ONLY when live tests are explicitly enabled.
+#
+# This used to run at import time, so merely HAVING a .env on disk leaked
+# credentials into os.environ for the whole pytest session — and unit tests
+# asserting unconfigured behaviour then saw a configured client and failed.
+# Collection must never configure an integration as a side effect: a .env is a
+# convenience for the developer, not an instruction to talk to live services.
+if os.getenv("RUN_LIVE_TESTS") == "1":  # pragma: no cover - live-only path
+    try:
+        from dotenv import load_dotenv
+    except ImportError:  # optional local dev dependency
+        pass
+    else:
+        load_dotenv()
 
 import pytest
 

--- a/tests/test_companies_house_live.py
+++ b/tests/test_companies_house_live.py
@@ -2,13 +2,20 @@
 
 import os
 
-try:
-    from dotenv import load_dotenv
-except ImportError:
-    load_dotenv = None
-
-if load_dotenv:
-    load_dotenv()
+# Credentials are loaded ONLY when live tests are explicitly enabled.
+#
+# This used to run at import time, so merely HAVING a .env on disk leaked
+# credentials into os.environ for the whole pytest session — and unit tests
+# asserting unconfigured behaviour then saw a configured client and failed.
+# Collection must never configure an integration as a side effect: a .env is a
+# convenience for the developer, not an instruction to talk to live services.
+if os.getenv("RUN_LIVE_TESTS") == "1":  # pragma: no cover - live-only path
+    try:
+        from dotenv import load_dotenv
+    except ImportError:  # optional local dev dependency
+        pass
+    else:
+        load_dotenv()
 
 import pytest
 

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -1,0 +1,121 @@
+"""Test collection must not configure integrations as a side effect.
+
+Reproduced on 0e267d7: the primary worktree reported 3 failed / 607 passed while
+every other worktree on the SAME commit reported 610 passed. The only difference
+was a .env on disk. Three live modules called load_dotenv() at import time, which
+loaded EPC_API_TOKEN into os.environ for the whole session; unit tests asserting
+unconfigured EPC behaviour then saw a configured client.
+
+The defect had two halves and so does the fix:
+  * credentials load only behind the explicit RUN_LIVE_TESTS gate, so merely
+    having a .env never activates or configures a live integration;
+  * unconfigured-behaviour tests strip the credential variables via monkeypatch,
+    so they hold even when the developer's shell exports them.
+
+These tests pin the PATTERN rather than the three modules that happened to
+exhibit it, so a newly added live module reintroducing it fails here.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+
+import pytest
+
+TESTS_DIR = pathlib.Path(__file__).parent
+CREDENTIAL_VARS = (
+    "EPC_API_TOKEN", "EPC_API_EMAIL", "EPC_API_KEY",
+    "COMPANIES_HOUSE_API_KEY", "OPENAI_API_KEY",
+)
+
+
+def _test_modules():
+    return sorted(p for p in TESTS_DIR.glob("test_*.py"))
+
+
+def _ungated_dotenv_calls(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Module-level load_dotenv() calls not gated specifically on RUN_LIVE_TESTS.
+
+    Checking merely "is it inside some `if`" is not enough: the original code was
+    `if load_dotenv:` — inside an if, and still loading a .env on every import.
+    Each enclosing `if` test is inspected for the RUN_LIVE_TESTS name, so only the
+    real gate counts. Calls inside functions are ignored: they run on demand
+    rather than at collection.
+    """
+    tree = ast.parse(path.read_text())
+    findings: list[tuple[int, str]] = []
+
+    def gate_mentions_run_live_tests(node: ast.If) -> bool:
+        return any(
+            isinstance(n, ast.Constant) and n.value == "RUN_LIVE_TESTS"
+            for n in ast.walk(node.test)
+        ) or any(
+            isinstance(n, ast.Name) and n.id == "RUN_LIVE_TESTS"
+            for n in ast.walk(node.test)
+        )
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self):
+            self.gates: list[ast.If] = []
+
+        def visit_If(self, node):
+            self.gates.append(node)
+            self.generic_visit(node)
+            self.gates.pop()
+
+        def visit_FunctionDef(self, node):
+            pass  # not import-time
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+        def visit_Call(self, node):
+            func = node.func
+            name = getattr(func, "id", None) or getattr(func, "attr", None)
+            if name == "load_dotenv":
+                if not any(gate_mentions_run_live_tests(g) for g in self.gates):
+                    where = "ungated" if not self.gates else "gated on something else"
+                    findings.append((node.lineno, where))
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return findings
+
+
+class TestNoImportTimeCredentialLoading:
+    @pytest.mark.parametrize("path", _test_modules(), ids=lambda p: p.name)
+    def test_dotenv_is_gated_on_run_live_tests(self, path):
+        findings = _ungated_dotenv_calls(path)
+        assert not findings, (
+            f"{path.name} calls load_dotenv() at import time {findings}. Collection "
+            "would then load a developer's .env into os.environ for the whole "
+            "session, silently configuring integrations for every other test. "
+            'Gate it on `if os.getenv("RUN_LIVE_TESTS") == "1":` specifically — '
+            "`if load_dotenv:` is not a gate, it only checks the import succeeded."
+        )
+
+
+class TestUnconfiguredFixtureActuallyWorks:
+    def test_fixture_removes_every_epc_variable(self, monkeypatch, no_epc_credentials):
+        for var in ("EPC_API_TOKEN", "EPC_API_EMAIL", "EPC_API_KEY"):
+            assert os.getenv(var) is None, f"{var} survived the fixture"
+
+    def test_client_is_unconfigured_even_with_an_ambient_token(
+        self, monkeypatch, no_epc_credentials
+    ):
+        """The scenario that broke: a real token exported in the environment."""
+        from property_core.epc_client import EPCClient
+
+        assert EPCClient().is_configured() is False
+        assert EPCClient(token=None).is_configured() is False
+
+    def test_without_the_fixture_an_ambient_token_does_configure(self, monkeypatch):
+        """Pins WHY the fixture is needed: token=None is not 'unconfigured'."""
+        from property_core.epc_client import EPCClient
+
+        monkeypatch.setenv("EPC_API_TOKEN", "ambient-token-from-the-shell")
+        assert EPCClient(token=None).is_configured() is True, (
+            "EPCClient no longer falls back to the environment; the fixture's "
+            "rationale has changed and this test should be revisited"
+        )

--- a/tests/test_epc_honest_failure.py
+++ b/tests/test_epc_honest_failure.py
@@ -104,7 +104,7 @@ class TestUpstreamFailuresRaise:
         with pytest.raises(EPCUpstreamShapeError):
             _run(c.search_summaries("AA1 1AA"))
 
-    def test_unconfigured_raises_without_any_request(self):
+    def test_unconfigured_raises_without_any_request(self, no_epc_credentials):
         called = []
 
         def handler(request):
@@ -117,7 +117,7 @@ class TestUpstreamFailuresRaise:
             _run(c.search_summaries("AA1 1AA"))
         assert called == [], "no request may be made without a credential"
 
-    def test_legacy_credentials_alone_are_not_a_fallback(self):
+    def test_legacy_credentials_alone_are_not_a_fallback(self, no_epc_credentials):
         """Never silently ignore legacy creds while reporting as configured."""
         c = _client(lambda req: httpx.Response(200, json=SEARCH_BODY), token=None)
         c._legacy_email, c._legacy_api_key = "a@b.c", "key"

--- a/tests/test_epc_review_regressions.py
+++ b/tests/test_epc_review_regressions.py
@@ -169,7 +169,7 @@ class TestRestErrorTaxonomy:
         got = tc.get("/v1/epc/search", params={"postcode": "AA1 1AA", "address": "24 Alexandra Road"})
         assert got.status_code == 409
 
-    def test_configuration_error_is_501_not_500(self):
+    def test_configuration_error_is_501_not_500(self, no_epc_credentials):
         from app.api.v1 import epc as R
 
         c = EPCClient(token=None)

--- a/tests/test_epc_service_live.py
+++ b/tests/test_epc_service_live.py
@@ -5,14 +5,20 @@ import pytest
 
 from property_core.epc_client import EPCClient
 
-try:
-    from dotenv import load_dotenv
-except ImportError:  # pragma: no cover - optional local dev dependency
-    load_dotenv = None
-
-
-if load_dotenv:
-    load_dotenv()
+# Credentials are loaded ONLY when live tests are explicitly enabled.
+#
+# This used to run at import time, so merely HAVING a .env on disk leaked
+# EPC_API_TOKEN into os.environ for the whole pytest session — and unit tests
+# asserting unconfigured behaviour then saw a configured client and failed.
+# Collection must never configure an integration as a side effect: a .env is a
+# convenience for the developer, not an instruction to talk to live services.
+if os.getenv("RUN_LIVE_TESTS") == "1":  # pragma: no cover - live-only path
+    try:
+        from dotenv import load_dotenv
+    except ImportError:  # optional local dev dependency
+        pass
+    else:
+        load_dotenv()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
**Test-only.** No production code, version artifact, release, deployment or secret change.

## The defect

The primary worktree reported **3 failed / 607 passed** while every other worktree on the **same commit** reported 610 passed. The only difference was a `.env` on disk.

Three live modules called `load_dotenv()` at *import* time, so merely **having** a `.env` loaded `EPC_API_TOKEN` into `os.environ` for the whole pytest session. Unit tests asserting unconfigured EPC behaviour then saw a configured client — because `EPCClient(token=None)` does **not** mean "unconfigured": the constructor falls back to `os.getenv("EPC_API_TOKEN")`.

Results therefore depended on the developer's filesystem and shell.

## Both halves fixed

**1. Collection never configures an integration as a side effect.** All three live modules evaluate `RUN_LIVE_TESTS` first and load credentials only behind that gate. A `.env` is a convenience for the developer, not an instruction to talk to live services.

**2. Unconfigured-behaviour tests are deterministic.** A `no_epc_credentials` fixture (`tests/conftest.py`) monkeypatch-deletes `EPC_API_TOKEN`, `EPC_API_EMAIL` and `EPC_API_KEY`. Applied to all three such tests; a search found no others — remaining `is_configured()` uses are live-test skip gates, which is correct.

**3. The pattern is pinned, not the three instances.** `tests/test_env_isolation.py` walks every test module's AST and fails any module-level `load_dotenv()` whose enclosing `if` does not reference `RUN_LIVE_TESTS`.

That strictness is deliberate and was earned: **my first version of the guard failed its own mutation test.** It asked "is the call inside some `if`?" — but the original code *was* inside one, `if load_dotenv:`, which only checks the import succeeded. It also accepted any module merely mentioning `RUN_LIVE_TESTS` anywhere, which every live module does in its skip checks. Both holes are closed.

## Verification — 658 passed, 24 skipped in every configuration

| Condition | Result |
|---|---|
| `.env` present (the original failure condition) | 658 passed |
| `EPC_API_TOKEN` / `EPC_API_EMAIL` / `EPC_API_KEY` exported ambiently | 658 passed |
| no `.env` at all | 658 passed |
| live tests | still **skip** (24), never silently activated |

**No live network requests**, enforced rather than assumed: a plugin replaces `socket.connect`/`connect_ex` with a hard failure and reports the count.

```
NETWORK: 0 real connection attempt(s) — none
```

The blocker was itself verified to fire on a genuine connection, so the zero is meaningful rather than a no-op.

## Mutation-verified

| Mutation | Result |
|---|---|
| revert one module's gate to `if load_dotenv:` | AST guard **fails** |
| drop the fixture from one unconfigured test, full suite with ambient token | that test **fails** |

Both were run twice: the first attempt at each was a faulty setup on my part — one mutation didn't apply, the other ran a single file when the pollution is cross-module — and neither caught anything until corrected.

`git diff --check` clean. 7 files, all under `tests/`.