### PR TITLE
fix: point bouch.dev links at the restored server pages

### DIFF
--- a/server.json
+++ b/server.json
@@ -4,7 +4,7 @@
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
   "version": "1.14.2",
-  "websiteUrl": "https://bouch.dev/products/property-report",
+  "websiteUrl": "https://bouch.dev/products/property-mcp",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
     "source": "github"


### PR DESCRIPTION
`websiteUrl` pointed at `/products/property-report`, a skill page from the pre-relaunch bouch.dev that 404s. Now **https://bouch.dev/products/property-mcp**.

Propagated by the MCP registry to the aggregators, so it decides where registry traffic lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)