### PR TITLE
PR 4: PPD snapshot adapter, source routing, coverage handling and provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Changelog
 
-## Unreleased — v1.15.0 (pending): PPD snapshot foundations + live-path correctness containment
+## Unreleased — v1.15.0 (pending): PPD snapshot source routing + live-path correctness containment
 
-Not released. No version bump. Two merged/pending PRs against the frozen design in
+Not released. No version bump. Four PRs against the frozen design in
 `docs/design/ppd-source-routing.md`.
+
+**`PPD_SNAPSHOT_ENABLED` is off by default, and nothing about the deployed
+behaviour changes while it stays off.** With no snapshot materialized every PPD
+surface answers from live SPARQL exactly as before, with one addition: an
+additive `provenance` block declaring `source: "sparql"` and null coverage
+fields. The behavioural changes listed under *Changed* below that mention
+coverage take effect only once a snapshot is enabled and materialized.
 
 ### Changed — behavioural, read before upgrading
 
@@ -38,8 +45,37 @@ Not released. No version bump. Two merged/pending PRs against the frozen design 
   A failure warns; a genuine no-match does not. Previously both were a silent
   `null`.
 - Both `ppd_transactions` tool descriptions no longer claim "every recorded
-  transaction"; they state a bounded, most-recent result that is not a complete
-  history.
+  transaction"; they state a coverage-bounded, most-recent result that is not a
+  complete history, and point at `provenance.older_records_exist` and
+  `provenance.sample_complete`.
+
+**Only when a snapshot is enabled and materialized:**
+
+- **`GET /v1/ppd/transactions` and `GET /v1/ppd/blocks` return a typed 422
+  `ppd_coverage_error`** when the requested range starts before
+  `coverage_from`, instead of a 200 from live SPARQL. The body carries
+  structured `requested` and `available` ranges plus a remedy — never prose to
+  parse, and never a partial 200, which would be indistinguishable from a
+  complete answer. **Callers passing an old `from_date` must narrow the range
+  or use `GET /v1/ppd/transaction/{id}`,** which stays on Linked Data and keeps
+  working for transactions of any age. The CLI equivalents exit non-zero and
+  print both ranges.
+- **An absent `from_date` is narrowed to `coverage_from` and warned**, rather
+  than continuing to mean "all time".
+- **`comps` and everything derived from it narrow rather than refuse.** Their
+  `months` is bounded by every surface that exposes it (60 or 120), and the
+  snapshot is sized to cover the maximum, so a window reaching past coverage
+  means a stale snapshot rather than an impossible request.
+- **An empty dateless result is never allowed to read as "never sold".** On zero
+  rows from a narrowed window, one bounded existence probe runs against the live
+  source: `LIMIT 1`, three-second timeout, no retries. `older_records_exist` is
+  `true` (warn), `false` (honest empty, no warning) or `null` (warn). A probe
+  that failed or timed out yields `null` and never `false` — `false` is a
+  positive claim about the world and only a completed probe may make it. No
+  probe is issued when the snapshot returned rows.
+- **Every typed snapshot failure falls back to the live source** and says so in
+  a warning. A coverage refusal and a malformed postcode are not snapshot
+  failures and are never softened into a live retry.
 
 ### Added
 
@@ -83,12 +119,48 @@ Not released. No version bump. Two merged/pending PRs against the frozen design 
   and unified dashboards — including each dashboard's LLM-facing text, not only
   its visual tree. A derived figure is never presented without the caveat
   attached to the data it came from.
+- **Provenance block on every PPD-bearing response** — `source`,
+  `source_release`, `snapshot_imported_at`, `coverage_from`/`coverage_to`,
+  `freshness_days`, `recent_period_provisional`, `older_records_exist`,
+  `sample_count`/`sample_limit`/`sample_complete`, `completeness_basis`,
+  `attribution_ref` and `warnings`. Additive and nullable: a caller that ignores
+  it sees no change. Carried through REST (`/v1/ppd/comps`,
+  `/v1/ppd/transactions`, `/v1/ppd/address-search`, `/v1/ppd/transaction/{id}`),
+  both MCP servers, and the CLI. **Mixed-source responses declare both halves
+  separately:** comps may come from the snapshot while `subject_property`
+  carries its own `source: "sparql"`, because a property's history routinely
+  predates coverage. `YieldAnalysis` carries `sale_provenance` for the same
+  reason a yield carries its comps warnings.
+- **`sample_complete` is never inferred from counts.** It defaults `false` and
+  is `true` only with a stated `completeness_basis`: `limit_plus_one` from the
+  snapshot adapter, or `source_exhausted` from an explicit transport-layer
+  observation. `sample_count = 3` against `sample_limit = 5` is legitimately
+  incomplete.
+- **DuckDB snapshot adapter** (`property_core.snapshot.adapter`) — the layer that
+  turns a structurally verified snapshot into a routable one. Before it answers
+  anything it validates the column schema and types, checks the row count
+  against the verification record, and executes a real query. Each failure is a
+  typed `SnapshotFailure`, so an unusable snapshot becomes a live fallback and
+  never an empty result set. Geography is `outcode = ?` / `sector = ?` against
+  materialized columns, so `B5` cannot match `B50` by construction; filters are
+  pushed into SQL, which is what makes its `limit + 1` completeness evidence
+  independent of the caller's page size.
+- **Boot wiring through the FastMCP lifespan** (`property_core.snapshot.bootstrap`)
+  — once per server process, never per request and never lazily on first use.
+  `app/main.py` awaits the FastMCP lifespan explicitly from inside its FastAPI
+  lifespan, because mounting does not chain them. Runtime state is
+  process-scoped, never MCP session state, and the filesystem single-flight lock
+  still coordinates the workers on a Machine. **A boot failure is not a startup
+  error:** the server comes up and serves from the live source.
+- **HM Land Registry attribution at `GET /v1/meta`**, in CLI `meta`, and in both
+  MCP `instructions` strings. Responses carry the compact `attribution_ref`
+  pointing there; licence prose is never inlined into a data payload.
 - Provenance and evidence models (`PPDProvenance`, `TransportEvidence`,
-  `SourceKind`, `CompletenessBasis`) and the typed error taxonomy
-  (`PPDError`, `PPDCoverageError`, `InvalidPostcodeError`,
-  `TransactionNotFoundError`, `UpstreamShapeError`, `SnapshotUnavailableError`,
-  `UpstreamUnavailableError`), all exported from `property_core`. Provenance is
-  **not yet wired into any response**.
+  `SourceKind`, `CompletenessBasis`), `CoveragePolicy`, and the typed error
+  taxonomy (`PPDError`, `PPDCoverageError`, `InvalidPostcodeError`,
+  `TransactionNotFoundError`, `UpstreamShapeError`, `SnapshotFailure`,
+  `SnapshotUnavailableError`, `UpstreamUnavailableError`), all exported from
+  `property_core`.
 - Optional `snapshot` extra (`duckdb==1.5.5`) and `PPD_SNAPSHOT_ENABLED`
   (default **off**). The published library gains no required dependency.
 - `docs/design/ppd-source-routing.md` — the frozen specification governing this
@@ -99,7 +171,24 @@ Not released. No version bump. Two merged/pending PRs against the frozen design 
 - `record_status` filtering stays disabled, but its documented rationale was
   factually wrong: `lrppi:recordStatus` **does** exist on the SPARQL transaction
   and binds to `.../ppi/add`. The honest reason is that it is not yet supported
-  under the verified binding and performance contract.
+  under the verified binding and performance contract. It is now rejected before
+  routing, so the snapshot path gives the same explanation and remedy as live.
+- **CLI JSON output is parseable again.** `_echo_json` went through rich's
+  `print`, which soft-wraps at the terminal width, so a long value — a coverage
+  warning, say — came out with a newline inserted mid-string and the document no
+  longer parsed. JSON output exists to be machine-read.
+
+### Not in this work
+
+- **Auto-escalation stays disabled on both sources.** The snapshot adapter does
+  supply the limit-independent evidence that would make widening defensible, but
+  changing which area a caller's request covers is a behaviour change of its
+  own. Both paths return the requested area with a warning saying why, and the
+  reason differs by source because the reasons genuinely differ.
+- The build pipeline, artifact distribution, the shadow corpus, and rollout
+  gates G1–G3. No Dockerfile, Fly config, image, secret or deployment is touched
+  here, and neither production image installs the `snapshot` extra yet — which
+  G3 requires **before** the flag may be enabled.
 
 
 ## v1.14.2 (2026-08-26) — MCP server card version; inferred-GBP warning ordering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,15 @@ coverage take effect only once a snapshot is enabled and materialized.
   because the caller never chose that window.
 - **`offset` is honoured on the snapshot path.** Paging is exact — the ordering
   is total, so successive pages neither repeat nor omit a row.
+- **Malformed and inverted date ranges are typed caller errors (422
+  `invalid_date_range`), on both sources, before either is queried.** Coverage
+  decisions compare ISO strings lexically, which is meaningful only for
+  well-formed dates: `"nonsense"` sorts after `"2026-06-30"`, so a garbage
+  `to_date` read as "beyond coverage" and was silently clamped to it. An
+  inverted range (`from_date` after `to_date`) describes an empty window, so it
+  passed both coverage checks, matched nothing, and was reported as a
+  **complete** empty result. On the live path the same inputs previously gave a
+  **502** (a caller error dressed as an upstream outage) and an empty **200**.
 
 ### Added
 
@@ -149,7 +158,9 @@ coverage take effect only once a snapshot is enabled and materialized.
   interval reaching past either coverage bound was only partly searched — and is
   **withdrawn whenever `offset > 0`**, because a short final page says the page
   ended, not that the pages skipped over were examined. Both withdrawals happen
-  where the block is built, so no call site can omit one.
+  where the block is built, so no call site can omit one — and `SnapshotPage`,
+  which is exported, no longer hands out a basis at a non-zero offset in the
+  first place. Its `exhausted` flag remains page-scoped and true.
 - **Every Parquet partition is validated individually** before the union view
   exists. `union_by_name` fills a column a partition lacks with NULLs, so a
   single partition missing `outcode` passed a check over the combined view,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,16 @@ coverage take effect only once a snapshot is enabled and materialized.
 - **Every typed snapshot failure falls back to the live source** and says so in
   a warning. A coverage refusal and a malformed postcode are not snapshot
   failures and are never softened into a live retry.
+- **The whole requested interval is checked against coverage, not just its
+  start.** A range disjoint from coverage — one beginning after `coverage_to`,
+  or ending before `coverage_from` — is refused with a remedy naming the
+  boundary that was crossed. A range extending past `coverage_to`, which
+  includes every request with no `to_date`, is clamped to `coverage_to` with a
+  warning naming what was excluded. On bounded-`months` surfaces a disjoint
+  window is a `snapshot_coverage_gap` failure and the live source answers,
+  because the caller never chose that window.
+- **`offset` is honoured on the snapshot path.** Paging is exact — the ordering
+  is total, so successive pages neither repeat nor omit a row.
 
 ### Added
 
@@ -135,7 +145,23 @@ coverage take effect only once a snapshot is enabled and materialized.
   is `true` only with a stated `completeness_basis`: `limit_plus_one` from the
   snapshot adapter, or `source_exhausted` from an explicit transport-layer
   observation. `sample_count = 3` against `sample_limit = 5` is legitimately
-  incomplete.
+  incomplete. It is additionally **scoped to the requested interval** — an
+  interval reaching past either coverage bound was only partly searched — and is
+  **withdrawn whenever `offset > 0`**, because a short final page says the page
+  ended, not that the pages skipped over were examined. Both withdrawals happen
+  where the block is built, so no call site can omit one.
+- **Every Parquet partition is validated individually** before the union view
+  exists. `union_by_name` fills a column a partition lacks with NULLs, so a
+  single partition missing `outcode` passed a check over the combined view,
+  silently contributed no rows to any outcode search, and the short result was
+  then reported as exhaustive — a whole year of sales gone, with the response
+  saying nothing was missing.
+- **Coverage metadata is a routing precondition.** Both bounds must be present,
+  valid ISO dates and correctly ordered, and `provisional_from` must lie inside
+  them; anything else is a typed `snapshot_metadata_invalid` failure and the
+  caller uses live. A record with no bounds previously answered a 1995 request
+  from an eleven-year snapshot, reported null coverage, and claimed the sample
+  was complete.
 - **DuckDB snapshot adapter** (`property_core.snapshot.adapter`) — the layer that
   turns a structurally verified snapshot into a routable one. Before it answers
   anything it validates the column schema and types, checks the row count
@@ -173,6 +199,14 @@ coverage take effect only once a snapshot is enabled and materialized.
   and binds to `.../ppi/add`. The honest reason is that it is not yet supported
   under the verified binding and performance contract. It is now rejected before
   routing, so the snapshot path gives the same explanation and remedy as live.
+- **The HM Land Registry attribution statement was emitting the wrong year.**
+  `hmlr_attribution()` substituted the current year, so it rendered "2026". The
+  year is part of the wording HM Land Registry prescribes, not a copyright
+  notice for today: the required statement pins **2021**, as the frozen
+  specification quotes it and as the Price Paid Data downloads page states
+  (checked 2026-08-28). Now a fixed constant, with the runtime value pinned in
+  test alongside the specification — the existing test checked only the
+  specification, which is how the wrong year passed review.
 - **CLI JSON output is parseable again.** `_echo_json` went through rich's
   `print`, which soft-wraps at the terminal width, so a long value — a coverage
   warning, say — came out with a newline inserted mid-string and the document no

--- a/app/api/v1/meta.py
+++ b/app/api/v1/meta.py
@@ -5,9 +5,28 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from app.core.config import get_settings
+from property_core.attribution import HMLR_LICENCE_URL, hmlr_attribution
 from property_core.epc_client import EPCClient
+from property_core.snapshot.bootstrap import snapshot_status
 
 router = APIRouter(prefix="/meta", tags=["meta"])
+
+
+@router.get("", summary="Service metadata and data attribution")
+async def meta() -> dict[str, object]:
+    """Dataset metadata, including the required HM Land Registry attribution.
+
+    This is what every PPD response's `attribution_ref` points at. Attribution
+    lives here rather than in each payload: the licence requires the statement
+    to be discoverable, not that it be repeated in every row of data, and
+    inlining it would put a paragraph of prose into an LLM's context on every
+    single call.
+    """
+    return {
+        "attribution": hmlr_attribution(),
+        "licence_url": HMLR_LICENCE_URL,
+        "snapshot": snapshot_status(),
+    }
 
 
 @router.get("/integrations", summary="Integration configuration status")

--- a/app/api/v1/ppd.py
+++ b/app/api/v1/ppd.py
@@ -15,6 +15,7 @@ from app.schemas.ppd import (
 from property_core.block_service import analyze_blocks
 from property_core.models.block import BlockAnalysisResponse
 from property_core.exceptions import (
+    InvalidDateRangeError,
     InvalidPostcodeError,
     PPDCoverageError,
     TransactionNotFoundError,
@@ -101,6 +102,11 @@ def transactions(
             include_raw=include_raw,
         )
         return PPDSearchResponse(**result)
+    except InvalidDateRangeError as exc:
+        # The caller's input, not an upstream failure. An unparseable date used
+        # to reach SPARQL's own validator and surface as a 502; an inverted
+        # range returned an empty 200 that looked like an answer.
+        raise HTTPException(status_code=422, detail=exc.to_dict()) from exc
     except PPDCoverageError as exc:
         # 422, not 404 or a partial 200: the request is unsatisfiable as stated,
         # and the body carries both ranges so the caller can reformulate it.

--- a/app/api/v1/ppd.py
+++ b/app/api/v1/ppd.py
@@ -16,6 +16,7 @@ from property_core.block_service import analyze_blocks
 from property_core.models.block import BlockAnalysisResponse
 from property_core.exceptions import (
     InvalidPostcodeError,
+    PPDCoverageError,
     TransactionNotFoundError,
     UpstreamUnavailableError,
 )
@@ -100,6 +101,10 @@ def transactions(
             include_raw=include_raw,
         )
         return PPDSearchResponse(**result)
+    except PPDCoverageError as exc:
+        # 422, not 404 or a partial 200: the request is unsatisfiable as stated,
+        # and the body carries both ranges so the caller can reformulate it.
+        raise HTTPException(status_code=422, detail=exc.to_dict()) from exc
     except InvalidPostcodeError as exc:
         # Caller error, not an upstream failure.
         raise HTTPException(status_code=422, detail=exc.to_dict()) from exc
@@ -227,6 +232,10 @@ async def comps(
             address=address,
             auto_escalate=auto_escalate,
         )
+    except PPDCoverageError as exc:
+        # 422, not 404 or a partial 200: the request is unsatisfiable as stated,
+        # and the body carries both ranges so the caller can reformulate it.
+        raise HTTPException(status_code=422, detail=exc.to_dict()) from exc
     except InvalidPostcodeError as exc:
         # Caller error, not an upstream failure.
         raise HTTPException(status_code=422, detail=exc.to_dict()) from exc
@@ -287,6 +296,10 @@ def blocks(
             min_transactions=min_transactions,
             search_level=search_level,
         )
+    except PPDCoverageError as exc:
+        # `months` is unbounded here, so a caller can ask for a window the
+        # snapshot cannot cover. Refused with both ranges, never clamped.
+        raise HTTPException(status_code=422, detail=exc.to_dict()) from exc
     except InvalidPostcodeError as exc:
         # Caller error, not an upstream failure.
         raise HTTPException(status_code=422, detail=exc.to_dict()) from exc

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -97,6 +97,22 @@ def _timed_tool(fn):
         return _wrapped
 
 
+def _with_provenance(result: dict) -> dict:
+    """Serialise a service search result, provenance included.
+
+    The provenance block is a Pydantic model; left as-is it is not JSON
+    serialisable, and dropping it would silently remove the coverage and
+    completeness facts an LLM needs to read this payload honestly.
+    """
+    provenance = result.get("provenance")
+    return {
+        **{k: v for k, v in result.items() if k not in ("results", "provenance")},
+        "results": [t.model_dump(mode="json", exclude_none=True)
+                    for t in result["results"]],
+        "provenance": provenance.model_dump(mode="json") if provenance else None,
+    }
+
+
 def _slim(obj: Any) -> Any:
     """Strip bulk fields (raw, images, floorplans, epc_match) recursively.
 
@@ -111,20 +127,35 @@ def _slim(obj: Any) -> Any:
         return [_slim(item) for item in obj]
     return obj
 
+from property_core.snapshot.bootstrap import fastmcp_lifespan, mark_installed
+
 mcp = FastMCP(
     "property-data",
     version=_pkg_version("property-shared"),
+    # Boot the PPD snapshot once per server process (spec 4.10). Not per
+    # request and not lazily on first use: a lazy boot would put the download in
+    # the path of whichever request happened to arrive first. `app/main.py`
+    # awaits this lifespan explicitly from inside the FastAPI one, because
+    # mounting does not chain lifespans -- a lifespan that is never awaited is a
+    # boot that never happens.
+    lifespan=fastmcp_lifespan(None),
     instructions=(
         "UK property data tools. For a comprehensive single-property analysis, "
         "invoke the `full_property_analysis` prompt — it instructs you to call "
         "property_comps, property_yield, property_epc and rightmove_search and "
         "synthesise. For postcode-only data fetches use property_comps and "
-        "property_yield separately. ppd_transactions for recent transactions at a postcode (bounded, not a full history), "
+        "property_yield separately. ppd_transactions for recent transactions at "
+        "a postcode -- bounded by the stated coverage in each response's "
+        "`provenance`, never a full property history; an empty result means "
+        "'no sales in coverage', not 'never sold'. "
         "rightmove_search to browse listings by postcode, rightmove_listing for "
         "full detail on one listing, property_epc for energy certificates, "
         "rental_analysis for rental market figures, stamp_duty for SDLT, "
         "property_blocks for block-buy analysis, planning_search for council "
-        "planning portals, company_search to find a company by name."
+        "planning portals, company_search to find a company by name. "
+        "Price Paid Data: contains HM Land Registry data (c) Crown copyright and "
+        "database right, licensed under the Open Government Licence v3.0; see "
+        "GET /v1/meta."
     ),
 )
 
@@ -568,14 +599,17 @@ def ppd_transactions(
 ) -> dict:
     """Land Registry Price Paid transactions for a postcode, most recent first.
 
-    Returns up to `limit` most recent transactions currently available from the
-    live Land Registry source. Unfiltered by default -- category-B bulk transfers
-    and commercial sales are included. Pass `property_type` (F=flat, D=detached,
-    S=semi, T=terraced, O=other) to restrict the result to a single type.
+    Returns up to `limit` most recent transactions **within snapshot coverage**
+    (`coverage_from`-`coverage_to` in the response's `provenance`).
+    Unfiltered by default -- category-B bulk transfers and commercial sales are
+    included. Pass `property_type` (F=flat, D=detached, S=semi, T=terraced,
+    O=other) to restrict the result to a single type.
 
-    This is a bounded result, not a complete property history: older sales may
-    exist beyond what is returned, and the result carries no completeness
-    guarantee. For clean residential comparable sales, use `property_comps` instead.
+    **Not a complete property history.** Check `provenance.older_records_exist`
+    and `provenance.sample_complete` before saying anything about what a
+    property has or has not sold for. An empty result means "no sales within
+    the stated coverage" -- never "never sold". For clean residential
+    comparable sales, use `property_comps`.
     """
     from property_core import PPDService
     result = PPDService().search_transactions(
@@ -584,10 +618,7 @@ def ppd_transactions(
         limit=limit,
         property_type=property_type,
     )
-    return _slim({
-        **{k: v for k, v in result.items() if k != "results"},
-        "results": [t.model_dump(mode="json", exclude_none=True) for t in result["results"]],
-    })
+    return _slim(_with_provenance(result))
 
 
 @mcp.resource("councils://list")
@@ -813,6 +844,8 @@ Then synthesise (3–5 short paragraphs):
 
 # Must be registered BEFORE create_streamable_http_app below — that call builds the
 # served ASGI app, and middleware added afterwards would never reach a request.
+mark_installed(mcp)
+
 mcp.add_middleware(ClientTrackingMiddleware())
 
 _http_app = create_streamable_http_app(

--- a/app/schemas/ppd.py
+++ b/app/schemas/ppd.py
@@ -18,6 +18,7 @@ from property_core.models.ppd import (  # noqa: F401
     PPDTransactionRecord,
     SubjectProperty,
 )
+from property_core.provenance import PPDProvenance  # noqa: F401
 
 
 class PPDSearchResponse(BaseModel):
@@ -28,6 +29,10 @@ class PPDSearchResponse(BaseModel):
     results: List[PPDTransaction] = Field(default_factory=list)
     warnings: List[str] = Field(default_factory=list)
     raw: Optional[List[dict[str, Any]]] = None
+    #: Where these rows came from, over what coverage, and how much of the
+    #: source was examined. Additive and nullable, so an existing caller that
+    #: ignores it sees no change.
+    provenance: Optional[PPDProvenance] = None
 
 
 class PPDDownloadURLResponse(BaseModel):
@@ -39,3 +44,6 @@ class PPDTransactionRecordResponse(BaseModel):
     """Normalized record with optional raw Linked Data payload."""
     record: PPDTransactionRecord
     raw: Optional[dict[str, Any]] = None
+    #: Always `linked_data`: exact-ID lookup never routes to the snapshot, so it
+    #: keeps working for transactions older than coverage.
+    provenance: Optional[PPDProvenance] = None

--- a/docs/design/ppd-source-routing.md
+++ b/docs/design/ppd-source-routing.md
@@ -6,13 +6,28 @@ document require a new decision round, not an edit in passing.
 **Implementation status.** Implemented by **PR 1**: this specification, the
 provenance and transport-evidence models, the protocol-neutral exception types,
 the optional `snapshot` dependency declaration, and the disabled
-`PPD_SNAPSHOT_ENABLED` flag. PR 1 changes no observable behaviour.
+`PPD_SNAPSHOT_ENABLED` flag (no observable behaviour change). By **PR 2**: the
+live-path correctness containment of section 2.7, the exact-ID taxonomy of
+section 2.8, and the subject-property taxonomy of section 2.6. By **PR 3**: the
+boot runtime of sections 4.1-4.7 — streaming fetch, verification, hardened
+extraction, atomic activation, single-flight locking and readiness states, all
+structural and wired to nothing. By **PR 4**: the DuckDB snapshot adapter with
+schema, row-count and queryability validation before it may route; lifespan
+wiring per section 4.10; coverage routing and the bounded existence probe of
+sections 2.4-2.5; live fallback on every typed snapshot failure; and response
+wiring of the provenance block across all four consumers.
 
-**Still unimplemented:** the snapshot adapter, the boot runtime (streaming fetch,
-verification, hardened extraction, atomic activation, locking, readiness,
-retention), source routing and coverage handling, the existence probe, response
-wiring of the provenance block, the build pipeline, and every rollout stage.
-No PPD response carries provenance yet, and no request is served from a snapshot.
+**Still unimplemented:** the build pipeline (PR 5), the fixed shadow corpus
+(PR 6), and rollout gates G1-G3 (PR 7) with the staged enablement that follows.
+`PPD_SNAPSHOT_ENABLED` remains off, neither production image installs the
+`snapshot` extra, and no request is served from a snapshot in production.
+
+**Deliberately not implemented, and not deferred by omission:** auto-escalation
+stays disabled on both sources. The snapshot adapter does supply the
+limit-independent evidence section 8 anticipated, but re-enabling widening
+changes which area a caller's request covers, which is a behaviour change of its
+own and was not in PR 4's scope. Both paths return the requested geography with
+a source-specific warning.
 
 **Governing rule:** this specification governs PRs 1–4; **no implementation PR
 may land before the specification that governs it.**

--- a/docs/design/ppd-source-routing.md
+++ b/docs/design/ppd-source-routing.md
@@ -1,7 +1,12 @@
-# PPD source-routing and implementation specification (rev 5 — FROZEN)
+# PPD source-routing and implementation specification (rev 6 — FROZEN)
 
-**Status:** **FROZEN.** Accepted. No further architecture work. Changes to this
-document require a new decision round, not an edit in passing.
+**Status:** **FROZEN at rev 6.** Accepted. No further architecture work. Changes
+to this document require a new decision round, not an edit in passing.
+
+**Revision 6** was authorised by the PR 4 review, which found that §2.5 checked
+only the lower coverage bound. It adds the disjoint and extends-past cases, the
+guaranteed-surface gap fallback (§2.5), the completeness scoping rule (§3.1.1a),
+and the coverage-metadata precondition (§2.5.1). No other section changed.
 
 **Implementation status.** Implemented by **PR 1**: this specification, the
 provenance and transport-evidence models, the protocol-neutral exception types,
@@ -185,14 +190,67 @@ No response may state or imply "never sold" while `older_records_exist` is `null
 
 ### 2.5 Explicit out-of-coverage dates — decision O2
 
+**Amended after PR 4 review (rev 6).** Rev 5 specified only the *lower* bound.
+That left a request for a period entirely after `coverage_to` — next month, say
+— running against the snapshot, matching nothing, and returning an empty result
+marked `sample_complete: true`: a confident statement that no such sales exist,
+made by a source that could not have known. **The whole interval is checked.**
+
 For surfaces taking explicit dates (`/v1/ppd/transactions`, `/v1/ppd/blocks` via
 `months`, and CLI equivalents), evaluated in order:
 
 1. Requested range inside coverage → SNAPSHOT, `source: "snapshot"`.
-2. Range starts before `coverage_from` → **HTTP 422, typed, structured. Never a
-   partial 200 that looks complete.**
-3. No `from_date` → treated as `coverage_from`, with warning
+2. **Range disjoint from coverage** — it starts after `coverage_to`, or ends
+   before `coverage_from` → **HTTP 422, typed, structured.** The remedy names
+   the boundary that was crossed; telling a caller who asked for next month to
+   "set `from_date >= coverage_from`" is advice that cannot work.
+3. Range starts before `coverage_from` (overlapping) → **HTTP 422, typed,
+   structured. Never a partial 200 that looks complete.**
+4. No `from_date` → treated as `coverage_from`, with warning
    `"unbounded from_date narrowed to snapshot coverage"`.
+5. **Range extends past `coverage_to`** — including every request with no
+   `to_date`, since that means "up to now" → the queried window is **clamped to
+   `coverage_to`**, a warning names what was excluded, and the response
+   **may not claim completeness** (§3.1.1a). This is deliberately not a refusal:
+   the overlap is a useful answer, and refusing every open-ended request would
+   make the snapshot unusable.
+
+**Guaranteed surfaces differ only in case 2 and 3.** Their `months` is bounded
+and the snapshot is sized for the maximum, so a window reaching past coverage
+means a *stale snapshot*, not a request the caller got wrong:
+
+* starts before `coverage_from` → narrow to `coverage_from` and warn;
+* **disjoint from coverage** → a typed `snapshot_coverage_gap` failure, which
+  routes to the **live source** with a warning. A refusal would blame the caller
+  for a window they never chose; an empty result would be a false claim.
+
+### 3.1.1a `sample_complete` is scoped to the requested interval
+
+`sample_complete` may be `true` **only when the caller's entire requested
+interval lies inside `[coverage_from, coverage_to]`.** The adapter's
+`limit_plus_one` evidence is a fact about what it searched; where part of the
+requested window was never in the snapshot, exhausting the remainder proves
+nothing about the rest.
+
+Likewise **`offset > 0` withdraws the basis.** A short final page establishes
+that the page ended, not that the pages skipped over were examined, and
+`sample_complete` is a claim about the whole matching set.
+
+Both withdrawals happen centrally, where the provenance block is built, so no
+call site can omit one.
+
+### 2.5.1 Coverage metadata is a routing precondition
+
+Routing answers every coverage question from `coverage_from`, `coverage_to` and
+`provisional_from`. Absent or contradictory values do not degrade those answers,
+they **remove them silently**: a verification record with no bounds answered a
+1995 request from an eleven-year snapshot, reported null coverage, and claimed
+the sample was complete.
+
+Before the adapter may route, it requires **both bounds present, valid ISO
+dates, and correctly ordered**, and `provisional_from` — if present — inside
+them. Anything else is a typed `snapshot_metadata_invalid` failure and the
+caller uses the live source.
 
 ```json
 { "error": "ppd_coverage_error",

--- a/property_app/server.py
+++ b/property_app/server.py
@@ -14,8 +14,14 @@ from fastmcp.server.middleware.caching import (
     ResponseCachingMiddleware,
 )
 # Main server — all tools registered directly via @mcp.tool()
+from property_core.snapshot.bootstrap import fastmcp_lifespan, mark_installed
+
 mcp = FastMCP(
     "property-app",
+    # Same boot, same rule (spec 4.10). This server is deployed on its own, so
+    # it must carry the lifespan itself -- there is no FastAPI app here to chain
+    # it from.
+    lifespan=fastmcp_lifespan(None),
     # Without this, FastMCP advertises its OWN version on the MCP card, so the
     # `initialize` response reported the framework version (3.2.4) while the
     # /.well-known/mcp/server-card.json route below reported the real one. The
@@ -28,9 +34,16 @@ mcp = FastMCP(
         "Use comps_dashboard, yield_dashboard, rental_dashboard, listings_dashboard for focused single-topic views. "
         "Use search_comps, get_yield, get_rental for raw data. "
         "Use stamp_duty, planning_search, epc_lookup, rightmove_search for quick lookups. "
-        "Use company_search to find a company by name."
+        "Use company_search to find a company by name. "
+        "Price Paid Data results are bounded by the coverage stated in each "
+        "response's `provenance`; an empty result means 'no sales in coverage', "
+        "never 'never sold'. Contains HM Land Registry data (c) Crown copyright "
+        "and database right, licensed under the Open Government Licence v3.0."
     ),
 )
+
+
+mark_installed(mcp)
 
 
 @mcp.resource("councils://list")

--- a/property_app/tools.py
+++ b/property_app/tools.py
@@ -536,9 +536,14 @@ def search_ppd_transactions(
         limit=limit,
         property_type=property_type,
     )
+    provenance = result.get("provenance")
     return {
-        **{k: v for k, v in result.items() if k != "results"},
-        "results": [_slim(t.model_dump(mode="json", exclude_none=True)) for t in result["results"]],
+        **{k: v for k, v in result.items() if k not in ("results", "provenance")},
+        "results": [_slim(t.model_dump(mode="json", exclude_none=True))
+                    for t in result["results"]],
+        # Serialised, not dropped: coverage and completeness are what make this
+        # payload readable without over-claiming.
+        "provenance": provenance.model_dump(mode="json") if provenance else None,
     }
 
 
@@ -556,14 +561,17 @@ def ppd_transactions(
 ) -> dict:
     """Land Registry Price Paid transactions for a postcode, most recent first.
 
-    Returns up to `limit` most recent transactions currently available from the
-    live Land Registry source. Unfiltered by default -- category-B bulk transfers
-    and commercial sales are included. Pass `property_type` (F=flat, D=detached,
-    S=semi, T=terraced, O=other) to restrict the result to a single type.
+    Returns up to `limit` most recent transactions **within snapshot coverage**
+    (`coverage_from`-`coverage_to` in the response's `provenance`).
+    Unfiltered by default -- category-B bulk transfers and commercial sales are
+    included. Pass `property_type` (F=flat, D=detached, S=semi, T=terraced,
+    O=other) to restrict the result to a single type.
 
-    This is a bounded result, not a complete property history: older sales may
-    exist beyond what is returned, and the result carries no completeness
-    guarantee. For clean residential comparable sales, use `search_comps` instead.
+    **Not a complete property history.** Check `provenance.older_records_exist`
+    and `provenance.sample_complete` before saying anything about what a
+    property has or has not sold for. An empty result means "no sales within
+    the stated coverage" -- never "never sold". For clean residential
+    comparable sales, use `search_comps`.
     """
     return search_ppd_transactions(
         postcode=postcode,

--- a/property_cli/main.py
+++ b/property_cli/main.py
@@ -39,7 +39,38 @@ def _maybe_http_client(api_url: Optional[str]) -> Optional["HTTPClient"]:
 
 
 def _echo_json(data: object) -> None:
-    rprint(json.dumps(data, indent=2, default=str))
+    """Emit JSON a caller can pipe into `jq`.
+
+    Deliberately NOT rich's `print`: it soft-wraps at the terminal width and
+    interprets square brackets as markup, so a long value -- a coverage warning,
+    say -- came out with a newline inserted mid-string and the document no
+    longer parsed. JSON output exists to be machine-read.
+    """
+    # ensure_ascii=False so the attribution's (c) renders as a character rather
+    # than an escape. Still valid JSON either way.
+    typer.echo(json.dumps(data, indent=2, default=str, ensure_ascii=False))
+
+
+def _ppd_errors(fn):
+    """Turn a typed PPD failure into a non-zero exit with a readable payload.
+
+    A coverage refusal is the CLI's answer, not a crash: the caller needs both
+    the range they asked for and the range that exists, or they cannot
+    reformulate the request. A bare traceback prints neither.
+    """
+    import functools
+
+    @functools.wraps(fn)
+    def _wrapped(*args, **kwargs):
+        from property_core.exceptions import PPDError
+
+        try:
+            return fn(*args, **kwargs)
+        except PPDError as exc:
+            _echo_json(exc.to_dict())
+            raise typer.Exit(code=1) from exc
+
+    return _wrapped
 
 
 def _join_tokens(tokens: Iterable[str] | str) -> str:
@@ -56,11 +87,19 @@ def meta(api_url: Optional[str] = typer.Option(None, help="Call API instead of c
         data = client.get("/v1/meta/integrations")
         _echo_json(data)
         return
-    rprint(
+    from property_core.attribution import HMLR_LICENCE_URL, hmlr_attribution
+    from property_core.snapshot.bootstrap import snapshot_status
+
+    _echo_json(
         {
             "ppd": True,
             "epc": bool(EPCClient().is_configured()),
             "rightmove": True,
+            # The licence requires the statement to be discoverable. Responses
+            # carry a reference; this is where the reference resolves offline.
+            "attribution": hmlr_attribution(),
+            "licence_url": HMLR_LICENCE_URL,
+            "ppd_snapshot": snapshot_status(),
         }
     )
 
@@ -70,6 +109,7 @@ app.add_typer(ppd, name="ppd")
 
 
 @ppd.command("comps")
+@_ppd_errors
 def ppd_comps(
     postcode: list[str] = typer.Argument(..., help="Postcode (can include spaces)"),
     property_type: Optional[str] = typer.Option(
@@ -162,6 +202,7 @@ def ppd_comps(
 
 
 @ppd.command("transaction")
+@_ppd_errors
 def ppd_transaction(
     transaction_id: str = typer.Argument(...),
     include_raw: bool = typer.Option(False, help="Include raw linked-data JSON"),
@@ -182,6 +223,7 @@ def ppd_transaction(
 
 
 @ppd.command("search")
+@_ppd_errors
 def ppd_search(
     postcode: Optional[str] = typer.Option(None),
     postcode_prefix: Optional[str] = typer.Option(None),
@@ -213,6 +255,7 @@ def ppd_search(
 
 
 @ppd.command("address-search")
+@_ppd_errors
 def ppd_address_search(
     paon: Optional[str] = typer.Option(None, help="Building name/number (e.g., '10' or 'Rose Cottage')"),
     saon: Optional[str] = typer.Option(None, help="Secondary address (e.g., 'Flat 2')"),
@@ -294,6 +337,7 @@ def ppd_download_url(
 
 
 @ppd.command("blocks")
+@_ppd_errors
 def ppd_blocks(
     postcode: list[str] = typer.Argument(..., help="Postcode (can include spaces)"),
     months: int = typer.Option(24, help="Lookback months"),
@@ -1070,6 +1114,7 @@ app.add_typer(analysis, name="analysis")
 
 
 @analysis.command("yield")
+@_ppd_errors
 def analysis_yield(
     postcode: list[str] = typer.Argument(..., help="Postcode (can include spaces)"),
     months: int = typer.Option(24, help="PPD lookback months"),
@@ -1124,6 +1169,7 @@ def analysis_yield(
 
 
 @analysis.command("rental")
+@_ppd_errors
 def analysis_rental(
     postcode: list[str] = typer.Argument(..., help="Postcode (can include spaces)"),
     radius: float = typer.Option(0.5, help="Search radius (miles)"),
@@ -1254,6 +1300,7 @@ app.add_typer(report, name="report")
 
 
 @report.command("generate")
+@_ppd_errors
 def report_generate(
     address: list[str] = typer.Argument(..., help="Address with postcode, e.g. '10 Downing Street SW1A 2AA'"),
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Output file path"),

--- a/property_core/__init__.py
+++ b/property_core/__init__.py
@@ -15,15 +15,18 @@ from property_core.interpret import (
 )
 from property_core.companies_house_client import CompaniesHouseClient
 from property_core.config import ppd_snapshot_enabled
+from property_core.attribution import HMLR_LICENCE_URL, hmlr_attribution
 from property_core.exceptions import (
     InvalidPostcodeError,
     PPDCoverageError,
     PPDError,
+    SnapshotFailure,
     SnapshotUnavailableError,
     TransactionNotFoundError,
     UpstreamShapeError,
     UpstreamUnavailableError,
 )
+from property_core.ppd_source import CoveragePolicy
 from property_core.provenance import (
     ATTRIBUTION_REF,
     CompletenessBasis,
@@ -87,15 +90,19 @@ __all__ = [
     "fetch_listing",
     "fetch_listings",
     "generate_insights",
+    "hmlr_attribution",
     "match_epc_address",
     "ppd_snapshot_enabled",
-    # Provenance and typed errors (PR 1 foundations; not yet wired to responses)
+    # Provenance, attribution and typed errors
     "ATTRIBUTION_REF",
     "CompletenessBasis",
+    "CoveragePolicy",
+    "HMLR_LICENCE_URL",
     "InvalidPostcodeError",
     "PPDCoverageError",
     "PPDError",
     "PPDProvenance",
+    "SnapshotFailure",
     "SnapshotUnavailableError",
     "SourceKind",
     "TransactionNotFoundError",

--- a/property_core/__init__.py
+++ b/property_core/__init__.py
@@ -15,7 +15,11 @@ from property_core.interpret import (
 )
 from property_core.companies_house_client import CompaniesHouseClient
 from property_core.config import ppd_snapshot_enabled
-from property_core.attribution import HMLR_LICENCE_URL, hmlr_attribution
+from property_core.attribution import (
+    HMLR_ATTRIBUTION,
+    HMLR_LICENCE_URL,
+    hmlr_attribution,
+)
 from property_core.exceptions import (
     InvalidPostcodeError,
     PPDCoverageError,
@@ -97,6 +101,7 @@ __all__ = [
     "ATTRIBUTION_REF",
     "CompletenessBasis",
     "CoveragePolicy",
+    "HMLR_ATTRIBUTION",
     "HMLR_LICENCE_URL",
     "InvalidPostcodeError",
     "PPDCoverageError",

--- a/property_core/__init__.py
+++ b/property_core/__init__.py
@@ -21,6 +21,7 @@ from property_core.attribution import (
     hmlr_attribution,
 )
 from property_core.exceptions import (
+    InvalidDateRangeError,
     InvalidPostcodeError,
     PPDCoverageError,
     PPDError,
@@ -103,6 +104,7 @@ __all__ = [
     "CoveragePolicy",
     "HMLR_ATTRIBUTION",
     "HMLR_LICENCE_URL",
+    "InvalidDateRangeError",
     "InvalidPostcodeError",
     "PPDCoverageError",
     "PPDError",

--- a/property_core/attribution.py
+++ b/property_core/attribution.py
@@ -1,0 +1,33 @@
+"""HM Land Registry attribution -- the one place the required text lives.
+
+Price Paid Data is published under the Open Government Licence v3.0, which
+requires the statement below wherever the data is used. Responses carry a
+compact `attribution_ref` pointing here rather than the prose itself: a
+paragraph of licence text repeated on every transaction would be noise in an
+LLM's context and adds nothing a reference does not.
+
+The year in the statement is the year of the data being used, so it is derived
+from the current date rather than pinned -- a hardcoded 2024 in a 2026 response
+misstates the copyright period.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+HMLR_LICENCE_URL = (
+    "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+)
+
+
+def hmlr_attribution(year: int | None = None) -> str:
+    """The exact required statement for `year` (default: the current year)."""
+    return (
+        f"Contains HM Land Registry data © Crown copyright and database right "
+        f"{year or date.today().year}. This data is licensed under the Open "
+        f"Government Licence v3.0."
+    )
+
+# Deliberately no module-level constant holding the rendered string: a
+# long-running process that imported it in December would keep serving last
+# year's statement in January. Call the function.

--- a/property_core/attribution.py
+++ b/property_core/attribution.py
@@ -6,28 +6,35 @@ compact `attribution_ref` pointing here rather than the prose itself: a
 paragraph of licence text repeated on every transaction would be noise in an
 LLM's context and adds nothing a reference does not.
 
-The year in the statement is the year of the data being used, so it is derived
-from the current date rather than pinned -- a hardcoded 2024 in a 2026 response
-misstates the copyright period.
+**The year is part of the prescribed statement, not a copyright notice we
+render for the current year.** HM Land Registry publishes this exact sentence,
+2021 included, on the Price Paid Data downloads page
+(https://www.gov.uk/government/statistical-data-sets/price-paid-data-downloads,
+checked 2026-08-28), and the frozen specification quotes it verbatim in section
+6. An earlier version of this module substituted `date.today().year` and emitted
+"2021" as "2026", which is not the statement the licence asks for. Nothing here
+may consult the calendar.
 """
 
 from __future__ import annotations
-
-from datetime import date
 
 HMLR_LICENCE_URL = (
     "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 )
 
+#: Verbatim, character for character. Changing it means HM Land Registry changed
+#: the prescribed wording -- check the source above and update the frozen
+#: specification's section 6 in the same commit.
+HMLR_ATTRIBUTION = (
+    "Contains HM Land Registry data © Crown copyright and database right 2021. "
+    "This data is licensed under the Open Government Licence v3.0."
+)
 
-def hmlr_attribution(year: int | None = None) -> str:
-    """The exact required statement for `year` (default: the current year)."""
-    return (
-        f"Contains HM Land Registry data © Crown copyright and database right "
-        f"{year or date.today().year}. This data is licensed under the Open "
-        f"Government Licence v3.0."
-    )
 
-# Deliberately no module-level constant holding the rendered string: a
-# long-running process that imported it in December would keep serving last
-# year's statement in January. Call the function.
+def hmlr_attribution() -> str:
+    """The exact required statement.
+
+    Takes no arguments on purpose: there is no per-year variant to select, and a
+    year parameter would invite the same substitution this replaced.
+    """
+    return HMLR_ATTRIBUTION

--- a/property_core/block_service.py
+++ b/property_core/block_service.py
@@ -11,6 +11,7 @@ from statistics import mean
 
 from property_core.models.block import BlockAnalysisResponse, BlockBuilding, BlockUnit
 from property_core.ppd_service import PPDService
+from property_core.ppd_source import CoveragePolicy
 
 
 def analyze_blocks(
@@ -51,6 +52,10 @@ def analyze_blocks(
         transaction_category=None,
         filter_outliers=False,
         auto_escalate=False,
+        # `months` has no upper bound on this surface, so a caller can name a
+        # window the snapshot cannot cover. Refused with both ranges rather than
+        # silently clamped: a clamped answer looks like a complete one.
+        coverage_policy=CoveragePolicy.EXPLICIT,
     )
 
     # Group transactions by building: (paon, street, postcode)

--- a/property_core/exceptions.py
+++ b/property_core/exceptions.py
@@ -47,6 +47,7 @@ class PPDCoverageError(PPDError):
         requested_to: Optional[str] = None,
         source_release: Optional[str] = None,
         detail: str = "requested range precedes available coverage",
+        remedy: Optional[str] = None,
     ):
         if not coverage_from or not coverage_to:
             raise ValueError(
@@ -58,6 +59,13 @@ class PPDCoverageError(PPDError):
         self.requested_from = requested_from
         self.requested_to = requested_to
         self.source_release = source_release
+        # The remedy differs by which boundary was crossed. Telling a caller who
+        # asked for next month to "set from_date >= 2016-01-01" is advice that
+        # cannot work, and advice that cannot work is worse than none.
+        self.remedy = remedy or (
+            f"set from_date >= {coverage_from}, or look up a known transaction "
+            f"by its id"
+        )
         super().__init__(detail)
 
     def to_dict(self) -> dict[str, Any]:
@@ -71,10 +79,7 @@ class PPDCoverageError(PPDError):
             },
             "source_release": self.source_release,
             "retryable": self.retryable,
-            "remedy": (
-                f"set from_date >= {self.coverage_from}, or look up a known "
-                f"transaction by its id"
-            ),
+            "remedy": self.remedy,
         }
 
 

--- a/property_core/exceptions.py
+++ b/property_core/exceptions.py
@@ -115,6 +115,52 @@ class InvalidPostcodeError(PPDError):
         }
 
 
+class InvalidDateRangeError(PPDError):
+    """Caller supplied a date, or a pair of dates, that cannot mean anything.
+
+    Two distinct mistakes share this type because they share a remedy -- fix the
+    input -- but ``field`` says which one:
+
+    * an unparseable date. Coverage decisions compare ISO strings lexically,
+      which is only meaningful for well-formed ones: ``"nonsense"`` sorts after
+      ``"2026-06-30"``, so a garbage ``to_date`` read as "beyond coverage" and
+      was silently clamped to it.
+    * ``from_date`` after ``to_date``. The window is empty by construction, so
+      it passed both coverage-bound checks, matched nothing, and -- being
+      nominally inside coverage -- was reported as a COMPLETE empty result.
+
+    Raised **before either source is queried**, because it is the caller's
+    input that is wrong and neither source can improve on that answer.
+    """
+
+    code = "invalid_date_range"
+    retryable = False
+
+    def __init__(
+        self,
+        detail: str,
+        *,
+        field: str = "",
+        value: Optional[str] = None,
+        from_date: Optional[str] = None,
+        to_date: Optional[str] = None,
+    ):
+        self.field = field
+        self.value = value
+        self.from_date = from_date
+        self.to_date = to_date
+        super().__init__(detail)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "field": self.field,
+            "value": self.value,
+            "requested": {"from_date": self.from_date, "to_date": self.to_date},
+            "expected": "ISO dates (YYYY-MM-DD) with from_date <= to_date",
+        }
+
+
 class TransactionNotFoundError(PPDError):
     """No such transaction upstream. Distinct from a failed lookup."""
 

--- a/property_core/exceptions.py
+++ b/property_core/exceptions.py
@@ -124,7 +124,28 @@ class TransactionNotFoundError(PPDError):
         return {**super().to_dict(), "transaction_id": self.transaction_id}
 
 
-class SnapshotUnavailableError(PPDError):
+class SnapshotFailure(PPDError):
+    """The snapshot path could not serve this request.
+
+    **This type is the fallback contract.** A caller that sees it uses the live
+    source and says so; it never returns empty data. Routing catches this base
+    class rather than an enumeration of known subclasses, so a failure mode added
+    later falls back correctly without anyone remembering to extend a tuple.
+
+    Deliberately disjoint from `UpstreamUnavailableError`: the live source is
+    what the fallback falls back *to*, so a live failure that also read as a
+    snapshot failure would send routing round the loop again.
+
+    Caller errors (`InvalidPostcodeError`) and coverage refusals
+    (`PPDCoverageError`) are NOT snapshot failures. Retrying either against the
+    live source would hide the very fact the caller needs.
+    """
+
+    code = "snapshot_failure"
+    retryable = True
+
+
+class SnapshotUnavailableError(SnapshotFailure):
     """No verified snapshot is open. Distinct from 'no rows matched'."""
 
     code = "snapshot_unavailable"

--- a/property_core/models/ppd.py
+++ b/property_core/models/ppd.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
+from property_core.provenance import PPDProvenance
+
 # --- URI-to-code reverse mappings ---
 
 _PROPERTY_TYPE_BY_URI: Dict[str, str] = {
@@ -162,6 +164,11 @@ class SubjectProperty(BaseModel):
     last_sale: Optional[PPDTransaction] = None
     transaction_count: int = 0
     transaction_history: List[PPDTransaction] = Field(default_factory=list)
+    #: Its own provenance, because it does not share the comparables' source.
+    #: Subject-property history is frequently older than snapshot coverage, so
+    #: it is always answered live -- and a mixed-source response that presented
+    #: both under one label would be making a claim about neither.
+    provenance: Optional[PPDProvenance] = None
 
     @model_validator(mode="after")
     def _history_must_be_one_property(self) -> SubjectProperty:
@@ -227,6 +234,9 @@ class PPDCompsResponse(BaseModel):
     subject_vs_median_pct: Optional[float] = None
     transactions: List[PPDTransaction] = Field(default_factory=list)
     subject_property: Optional[SubjectProperty] = None
+    #: Where these comparables came from and how much of the source was seen.
+    #: Additive and nullable: a caller that never looked at it sees no change.
+    provenance: Optional[PPDProvenance] = None
 
 
 class PPDTransactionRecord(BaseModel):

--- a/property_core/models/report.py
+++ b/property_core/models/report.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
+from property_core.provenance import PPDProvenance
 
 
 class SaleRecord(BaseModel):
@@ -102,6 +103,10 @@ class YieldAnalysis(BaseModel):
     """
 
     warnings: tuple[str, ...] = ()
+    #: The sale side's provenance, carried through from the comps this yield
+    #: divides by. The rental side is Rightmove and has no PPD provenance, so
+    #: this describes the denominator, not the whole figure.
+    sale_provenance: Optional[PPDProvenance] = None
     postcode: str
     median_sale_price: Optional[int] = None
     sale_count: int = 0

--- a/property_core/ppd_client.py
+++ b/property_core/ppd_client.py
@@ -93,6 +93,18 @@ class UnsupportedRecordStatusFilterError(ValueError):
     by. Rejecting is a scope decision, not an ontology unknown.
     """
 
+#: The single wording for the record_status rejection. Raised from the client on
+#: the live path and from the service before routing, so the snapshot path gives
+#: the caller exactly the same explanation and the same remedy.
+RECORD_STATUS_UNSUPPORTED = (
+    "record_status filtering is not supported on SPARQL search: results are "
+    "PPDTransaction rows, which do not carry a record status. The predicate "
+    "does exist upstream (lrppi:recordStatus), but is not yet supported under "
+    "this search's verified binding and performance contract. Use "
+    "PricePaidDataClient.get_transaction_record(transaction_id) / "
+    "PPDService.transaction_record() to read record_status for a known transaction."
+)
+
 # The Land Registry site currently splits some recent years into two files.
 YEARS_WITH_PARTS = {2018, 2019, 2020, 2021, 2022, 2023}
 
@@ -140,7 +152,12 @@ class PricePaidDataClient:
     linked_data_base: str = LINKED_DATA_BASE
     sparql_endpoint: str = SPARQL_ENDPOINT
     user_agent: str = "ppd-wrapper/0.1"
-    timeout: int = 120
+    timeout: float = 120
+    #: Attempts for a SPARQL request, retries included. The bounded existence
+    #: probe (property_core.ppd_probe) sets this to 1: a retried probe is no
+    #: longer bounded, and the probe's whole contract is that it costs at most
+    #: one short request.
+    retry_attempts: int = SPARQL_RETRY_ATTEMPTS
 
     # --------
     # Download URLs
@@ -284,14 +301,7 @@ class PricePaidDataClient:
             UnsupportedRecordStatusFilterError: If record_status is not None.
         """
         if record_status is not None:
-            raise UnsupportedRecordStatusFilterError(
-                "record_status filtering is not supported on SPARQL search: results are "
-                "PPDTransaction rows, which do not carry a record status. The predicate "
-                "does exist upstream (lrppi:recordStatus), but is not yet supported under "
-                "this search's verified binding and performance contract. Use "
-                "PricePaidDataClient.get_transaction_record(transaction_id) / "
-                "PPDService.transaction_record() to read record_status for a known transaction."
-            )
+            raise UnsupportedRecordStatusFilterError(RECORD_STATUS_UNSUPPORTED)
 
         values_clauses = []
         filters = []
@@ -486,7 +496,8 @@ class PricePaidDataClient:
 
     def _fetch_sparql(self, encoded_query: bytes) -> Dict:
         last_exc: Exception | None = None
-        for attempt in range(1, SPARQL_RETRY_ATTEMPTS + 1):
+        attempts = max(1, int(self.retry_attempts))
+        for attempt in range(1, attempts + 1):
             req = urllib.request.Request(
                 self.sparql_endpoint,
                 data=encoded_query,
@@ -502,7 +513,7 @@ class PricePaidDataClient:
             except (TimeoutError, urllib.error.URLError) as exc:
                 last_exc = exc
 
-            if attempt < SPARQL_RETRY_ATTEMPTS:
+            if attempt < attempts:
                 backoff = SPARQL_RETRY_BACKOFF_SECONDS * (2 ** (attempt - 1))
                 time.sleep(backoff)
 

--- a/property_core/ppd_probe.py
+++ b/property_core/ppd_probe.py
@@ -1,0 +1,77 @@
+"""The bounded existence probe -- spec section 2.4, decision O1.
+
+`ppd_transactions` and CLI `ppd search` take no date, so each currently means
+"latest ever". Against a snapshot the same call means "latest within coverage",
+and a postcode last sold in 2009 comes back empty -- which an LLM reads as
+"never sold". That is a confident false claim produced by a tool that was only
+ever asked a narrower question.
+
+The probe answers exactly one question, against the **live** source (the
+snapshot cannot answer it: by construction it holds nothing before
+`coverage_from`): does any record exist at this geography before coverage
+begins?
+
+The constraints are all about not letting the probe become a second data path:
+
+* `LIMIT 1` existence, never `COUNT` -- we need one bit, not a number;
+* a **3-second** timeout;
+* **no retries**;
+* any failure yields `None`, never `False`. `False` is a positive assertion that
+  nothing older exists, and only a probe that actually completed may make it.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Optional
+
+from property_core.ppd_client import PricePaidDataClient
+
+#: One query, bounded. Long enough for a healthy endpoint, short enough that an
+#: unhealthy one costs an empty result its warning rather than the whole request.
+PROBE_TIMEOUT_SECONDS = 3.0
+#: One attempt. A retried probe is no longer bounded.
+PROBE_RETRY_ATTEMPTS = 1
+
+
+def build_probe_client() -> PricePaidDataClient:
+    """A client configured for one bounded attempt and nothing else."""
+    return PricePaidDataClient(timeout=PROBE_TIMEOUT_SECONDS,
+                               retry_attempts=PROBE_RETRY_ATTEMPTS)
+
+
+def day_before(iso_date: str) -> str:
+    """The last day outside coverage. `coverage_from` itself is inside it."""
+    return (date.fromisoformat(iso_date) - timedelta(days=1)).isoformat()
+
+
+class ExistenceProbe:
+    """Answers 'do older records exist?' as `True` / `False` / `None`."""
+
+    def __init__(self, client: Optional[PricePaidDataClient] = None):
+        self.client = client or build_probe_client()
+
+    def older_records_exist(
+        self,
+        *,
+        postcode: Optional[str],
+        postcode_prefix: Optional[str],
+        coverage_from: str,
+    ) -> Optional[bool]:
+        """`True` / `False` / `None` (probe did not complete).
+
+        Every failure path returns `None`. There is deliberately no branch that
+        turns an exception into `False`: the difference between "nothing older
+        exists" and "we could not find out" is the whole point of this function.
+        """
+        try:
+            page = self.client.search_with_evidence(
+                postcode=postcode,
+                postcode_prefix=postcode_prefix,
+                to_date=day_before(coverage_from),
+                limit=1,
+                order_desc=True,
+            )
+        except Exception:  # noqa: BLE001 -- any failure is "unknown", never "no"
+            return None
+        return bool(page.transactions)

--- a/property_core/ppd_service.py
+++ b/property_core/ppd_service.py
@@ -26,6 +26,7 @@ from property_core.ppd_source import (
     live_provenance,
     resolve_coverage,
     snapshot_provenance,
+    validate_date_range,
 )
 from property_core.provenance import SourceKind
 
@@ -119,6 +120,11 @@ class PPDService:
         confident false claim.
         """
         warnings: List[str] = []
+
+        # Before routing, so neither source is queried on input that cannot mean
+        # anything -- and so the same bad input gets the same typed answer
+        # whichever source would have served it.
+        validate_date_range(from_date, to_date)
 
         if limit <= 0:
             limit = DEFAULT_LIMIT

--- a/property_core/ppd_service.py
+++ b/property_core/ppd_service.py
@@ -11,7 +11,7 @@ from datetime import date, timedelta
 from statistics import mean, median, quantiles
 from typing import Any, Dict, List, Optional
 
-from property_core.exceptions import InvalidPostcodeError
+from property_core.exceptions import InvalidPostcodeError, SnapshotFailure
 from property_core.models.ppd import (
     PPDCompsQuery,
     PPDCompsResponse,
@@ -19,6 +19,15 @@ from property_core.models.ppd import (
     SubjectProperty,
 )
 from property_core.ppd_client import PricePaidDataClient
+from property_core.ppd_source import (
+    CoveragePolicy,
+    active_adapter,
+    fallback_warning,
+    live_provenance,
+    resolve_coverage,
+    snapshot_provenance,
+)
+from property_core.provenance import SourceKind
 
 DEFAULT_LIMIT = 50
 MAX_LIMIT = 200
@@ -40,8 +49,19 @@ class PPDService:
     guardrails, stats computation, and subject-property matching.
     All methods are synchronous.
     """
-    def __init__(self, client: Optional[PricePaidDataClient] = None):
+    def __init__(self, client: Optional[PricePaidDataClient] = None,
+                 adapter: Optional[Any] = None):
         self.client = client or PricePaidDataClient()
+        #: An explicit adapter overrides process state; `None` means "ask the
+        #: process at call time". Resolved per call rather than per instance
+        #: because the routers construct one service at import, long before boot.
+        self._adapter_override = adapter
+
+    def _active_adapter(self) -> Optional[Any]:
+        """The snapshot adapter to route to, or None for the live source."""
+        if self._adapter_override is not None:
+            return self._adapter_override
+        return active_adapter()
 
     def download_url(
         self,
@@ -82,9 +102,21 @@ class PPDService:
         order_desc: bool = True,
         include_raw: bool = False,
     ) -> Dict[str, Any]:
-        """Search PPD via SPARQL with guardrails on limit/offset.
+        """Search PPD transactions, from the snapshot when one is routable.
 
-        Returns a dict with keys: count, limit, offset, results, warnings, raw.
+        Returns a dict with keys: count, limit, offset, results, warnings, raw,
+        provenance.
+
+        This surface takes explicit dates, so it uses the EXPLICIT coverage
+        policy: a `from_date` before `coverage_from` is refused with
+        `PPDCoverageError` rather than answered partially. An absent `from_date`
+        means "all time" on the live source and "coverage" here, so it is
+        narrowed with a warning rather than silently.
+
+        When the window was narrowed and the result is empty, one bounded
+        existence probe runs against the live source (spec 2.4): an empty list
+        from a dateless call otherwise reads as "never sold", which is a
+        confident false claim.
         """
         warnings: List[str] = []
 
@@ -102,7 +134,71 @@ class PPDService:
                 "or omit rows across pages"
             )
 
-        results = self.client.sparql_search(
+        if record_status is not None:
+            # Rejected before any routing decision, so the snapshot path has
+            # exactly the live path's behaviour (spec test 19). Raised by the
+            # client normally; done here because the snapshot path never calls it.
+            from property_core.ppd_client import (
+                RECORD_STATUS_UNSUPPORTED,
+                UnsupportedRecordStatusFilterError,
+            )
+
+            raise UnsupportedRecordStatusFilterError(RECORD_STATUS_UNSUPPORTED)
+
+        adapter = self._active_adapter()
+        if adapter is not None:
+            # A coverage refusal and a caller error both propagate: neither is a
+            # snapshot failure, and retrying either against live would hide the
+            # fact the caller needs.
+            decision = resolve_coverage(
+                adapter, from_date=from_date, to_date=to_date,
+                policy=CoveragePolicy.EXPLICIT)
+            try:
+                page = adapter.search(
+                    postcode=postcode,
+                    postcode_prefix=postcode_prefix,
+                    from_date=decision.from_date,
+                    to_date=decision.to_date,
+                    min_price=min_price,
+                    max_price=max_price,
+                    property_types={property_type} if property_type else None,
+                    estate_type=estate_type,
+                    transaction_category=transaction_category,
+                    new_build=new_build,
+                    limit=limit,
+                    order_desc=order_desc,
+                )
+            except SnapshotFailure as exc:
+                warnings.append(fallback_warning(exc))
+            else:
+                results = page.transactions
+                warnings.extend(decision.warnings)
+                older = None
+                if not results and decision.narrowed and adapter.coverage_from:
+                    # No probe when there ARE rows: the question is already
+                    # answered, and a probe would be a second upstream call
+                    # for nothing (spec test 13).
+                    older = self._probe_older_records(
+                        postcode=postcode, postcode_prefix=postcode_prefix,
+                        coverage_from=adapter.coverage_from)
+                    warnings.extend(_older_records_warnings(
+                        older, adapter.coverage_from, adapter.coverage_to))
+
+                return {
+                    "count": len(results),
+                    "limit": limit,
+                    "offset": offset,
+                    "results": results,
+                    "warnings": warnings,
+                    "raw": [t.raw for t in results] if include_raw else None,
+                    "provenance": snapshot_provenance(
+                        adapter, decision=decision, sample_count=len(results),
+                        sample_limit=limit,
+                        completeness_basis=page.completeness_basis,
+                        older_records_exist=older, warnings=tuple(warnings)),
+                }
+
+        page = self.client.search_with_evidence(
             postcode=postcode,
             postcode_prefix=postcode_prefix,
             from_date=from_date,
@@ -112,12 +208,12 @@ class PPDService:
             property_type=property_type,
             estate_type=estate_type,
             transaction_category=transaction_category,
-            record_status=record_status,
             new_build=new_build,
             limit=limit,
             offset=offset,
             order_desc=order_desc,
         )
+        results = page.transactions
 
         return {
             "count": len(results),
@@ -126,7 +222,20 @@ class PPDService:
             "results": results,
             "warnings": warnings,
             "raw": [t.raw for t in results] if include_raw else None,
+            "provenance": live_provenance(
+                evidence=page.evidence, sample_count=len(results),
+                sample_limit=limit, warnings=tuple(warnings)),
         }
+
+    def _probe_older_records(self, *, postcode: Optional[str],
+                             postcode_prefix: Optional[str],
+                             coverage_from: str) -> Optional[bool]:
+        """One bounded probe. Any failure is None -- never False."""
+        from property_core.ppd_probe import ExistenceProbe
+
+        return ExistenceProbe().older_records_exist(
+            postcode=postcode, postcode_prefix=postcode_prefix,
+            coverage_from=coverage_from)
 
     def address_search(
         self,
@@ -143,9 +252,10 @@ class PPDService:
         limit: int = 25,
         include_raw: bool = False,
     ) -> Dict[str, Any]:
-        """Address-form search with strict limits.
+        """Address-form search with strict limits. Always the live source.
 
-        Returns a dict with keys: count, limit, offset, results, warnings, raw.
+        Returns a dict with keys: count, limit, offset, results, warnings, raw,
+        provenance.
         """
         warnings: List[str] = []
         if limit <= 0:
@@ -190,6 +300,12 @@ class PPDService:
             "results": results,
             "warnings": warnings,
             "raw": [t.raw for t in results] if include_raw else None,
+            # Always live (spec 2.6). This search takes no dates and means "this
+            # property's history", which is routinely older than snapshot
+            # coverage; bounding it would turn a real history into a partial one.
+            "provenance": live_provenance(
+                sample_count=len(results), sample_limit=limit,
+                warnings=tuple(warnings)),
         }
 
     def comps(
@@ -205,6 +321,7 @@ class PPDService:
         address: Optional[str] = None,
         auto_escalate: bool = True,
         thin_market_threshold: int = 5,
+        coverage_policy: CoveragePolicy = CoveragePolicy.GUARANTEED,
     ) -> PPDCompsResponse:
         """Return comparable sales and summary stats for a postcode.
 
@@ -269,44 +386,21 @@ class PPDService:
             sparql_property_type = property_type
             apply_residential_filter = False
 
-        # 3. Fetch transactions via SPARQL (client handles post-fetch filtering)
+        # 3. Fetch transactions, from the snapshot when one is routable.
         from_date = (date.today() - timedelta(days=months * 30)).isoformat()
-
-        page = self.client.search_with_evidence(
-            postcode=exact_postcode,
-            postcode_prefix=prefix,
-            from_date=from_date,
-            property_type=sparql_property_type,
-            transaction_category=transaction_category,
-            limit=limit,
-            order_desc=True,
-        )
-        transactions = page.transactions
         warnings: list[str] = []
 
-        # Completeness. `source_exhausted` is tri-state; only True proves the
-        # upstream window was not truncated. It is derived from a fetch limit
-        # that itself scales with the caller's presentation limit, so it is
-        # reported but never used to widen geography on the live path.
-        # Containment and exhaustion are independent facts and are reported
-        # separately. An earlier version reported containment only inside the
-        # exhausted branch while calling the page "saturated" -- a contradiction
-        # that meant the message could never appear when it was true.
-        if page.contained_out:
-            warnings.append(
-                f"{page.contained_out} out-of-area row(s) returned by the upstream "
-                "were removed by geography containment"
-            )
-        if page.evidence.source_exhausted is not True:
-            warnings.append(
-                "result may be incomplete: the upstream window was not exhausted, "
-                "so thin_market reflects the returned sample rather than the market"
-            )
-
-        # 4. Apply residential post-filter when property_type=None.
-        # transaction_category filtering happens server-side via SPARQL above.
-        if apply_residential_filter:
-            transactions = [t for t in transactions if t.property_type in _RESIDENTIAL_TYPES]
+        transactions, provenance_for, from_snapshot = self._fetch_comps(
+            exact_postcode=exact_postcode,
+            prefix=prefix,
+            from_date=from_date,
+            sparql_property_type=sparql_property_type,
+            apply_residential_filter=apply_residential_filter,
+            transaction_category=transaction_category,
+            limit=limit,
+            coverage_policy=coverage_policy,
+            warnings=warnings,
+        )
 
         # 5. Subject property matching
         subject_property = None
@@ -381,8 +475,42 @@ class PPDService:
             address=address,
         )
 
-        response = PPDCompsResponse(
+        thin_market = count < thin_market_threshold
+
+        # Auto-escalation stays DISABLED, on both sources.
+        #
+        # On the live path (PR 2) the only exhaustion evidence is
+        # `raw_bindings_returned < fetch_limit`, and `fetch_limit` derives from
+        # the caller's presentation limit -- so the evidence, and therefore the
+        # geography, would move with page size. The snapshot adapter does supply
+        # limit-independent evidence, which would make widening defensible, but
+        # changing which area a caller's request covers is a behaviour change of
+        # its own and is not in this PR's scope. Both paths return the requested
+        # area and say why.
+        if auto_escalate and thin_market:
+            next_level = {"postcode": "sector", "sector": "district"}.get(search_level)
+            if next_level:
+                # Source-specific, because the reason differs. Saying
+                # "live-source completeness" over a snapshot answer would be
+                # false: the snapshot DOES establish completeness, and what
+                # stops it widening is scope, not evidence.
+                warnings.append(
+                    f"auto-escalation not applied: the snapshot could establish "
+                    f"safe escalation from {search_level} to {next_level}, but "
+                    f"widening is not enabled; returning the requested area"
+                    if from_snapshot else
+                    "auto-escalation not applied: live-source completeness cannot "
+                    f"establish safe escalation from {search_level} to "
+                    f"{next_level}; returning the requested area")
+
+        # Provenance is built ONCE, here, from evidence that is now complete --
+        # the counts are final and every warning has been gathered. The block is
+        # frozen, so a block built earlier and patched afterwards is not
+        # available, and pydantic's validation-bypassing copy hatch is
+        # prohibited for it.
+        return PPDCompsResponse(
             query=query,
+            provenance=provenance_for(count, tuple(warnings)),
             count=count,
             median=computed_median,
             mean=computed_mean,
@@ -390,7 +518,7 @@ class PPDService:
             percentile_75=p75,
             min=min(prices) if prices else None,
             max=max(prices) if prices else None,
-            thin_market=count < thin_market_threshold,
+            thin_market=thin_market,
             warnings=tuple(warnings),
             transactions=transactions,
             subject_property=subject_property,
@@ -398,25 +526,104 @@ class PPDService:
             subject_vs_median_pct=subject_vs_median_pct,
         )
 
-        # Auto-escalation is DISABLED on the live path (PR 2).
-        #
-        # Widening sector -> district needs proof that the narrower search was
-        # exhausted. The only available evidence is `raw_bindings_returned <
-        # fetch_limit`, and `fetch_limit` is derived from the caller's
-        # presentation limit -- so the evidence, and therefore the geography,
-        # would still change with page size. That is the defect being contained,
-        # not a fix for it. Snapshot routing may re-enable escalation in PR 4
-        # using limit-independent deterministic evidence.
-        if auto_escalate and response.thin_market:
-            next_level = {"postcode": "sector", "sector": "district"}.get(search_level)
-            if next_level:
-                response.warnings = response.warnings + (
-                    "auto-escalation not applied: live-source completeness cannot "
-                    f"establish safe escalation from {search_level} to {next_level}; "
-                    "returning the requested area",
-                )
+    def _fetch_comps(
+        self,
+        *,
+        exact_postcode: Optional[str],
+        prefix: Optional[str],
+        from_date: str,
+        sparql_property_type: Optional[str],
+        apply_residential_filter: bool,
+        transaction_category: Optional[str],
+        limit: int,
+        coverage_policy: CoveragePolicy,
+        warnings: List[str],
+    ) -> tuple[List[PPDTransaction], Any, bool]:
+        """Fetch comparables from the snapshot if routable, else live.
 
-        return response
+        Returns the rows, a callable that builds the provenance block once the
+        final count and the complete warning list are known, and whether the
+        snapshot answered -- the block is
+        frozen and must be constructed atomically, so it cannot be built here
+        and refined later. Patching one through pydantic's validation-bypassing
+        copy hatch is prohibited for provenance.
+
+        Appends to `warnings` in place: coverage narrowing, provisional-period
+        and fallback notices all belong to the same list the response carries.
+        """
+        adapter = self._active_adapter()
+        if adapter is not None:
+            decision = resolve_coverage(
+                adapter, from_date=from_date, to_date=None, policy=coverage_policy)
+            try:
+                page = adapter.search(
+                    postcode=exact_postcode,
+                    postcode_prefix=prefix,
+                    from_date=decision.from_date,
+                    # Type filtering is pushed into the query rather than applied
+                    # afterwards. That is what makes limit+1 mean what it says:
+                    # a short answer proves the SOURCE was exhausted, not merely
+                    # that our own post-filter discarded most of a full page.
+                    property_types=(
+                        set(_RESIDENTIAL_TYPES) if apply_residential_filter
+                        else ({sparql_property_type} if sparql_property_type else None)
+                    ),
+                    transaction_category=transaction_category,
+                    limit=limit,
+                    order_desc=True,
+                )
+            except SnapshotFailure as exc:
+                warnings.append(fallback_warning(exc))
+            else:
+                warnings.extend(decision.warnings)
+
+                def _provenance(count: int, gathered: tuple[str, ...]):
+                    return snapshot_provenance(
+                        adapter, decision=decision, sample_count=count,
+                        sample_limit=limit,
+                        completeness_basis=page.completeness_basis,
+                        warnings=gathered)
+
+                return list(page.transactions), _provenance, True
+
+        live = self.client.search_with_evidence(
+            postcode=exact_postcode,
+            postcode_prefix=prefix,
+            from_date=from_date,
+            property_type=sparql_property_type,
+            transaction_category=transaction_category,
+            limit=limit,
+            order_desc=True,
+        )
+        transactions = live.transactions
+
+        # Containment and exhaustion are independent facts, reported separately.
+        # An earlier version reported containment only inside the exhausted
+        # branch while calling the page "saturated" -- a contradiction that meant
+        # the message could never appear when it was true.
+        if live.contained_out:
+            warnings.append(
+                f"{live.contained_out} out-of-area row(s) returned by the upstream "
+                "were removed by geography containment"
+            )
+        if live.evidence.source_exhausted is not True:
+            warnings.append(
+                "result may be incomplete: the upstream window was not exhausted, "
+                "so thin_market reflects the returned sample rather than the market"
+            )
+
+        # The live path cannot push the residential set down, so it filters here
+        # -- which is exactly why its completeness evidence is untrustworthy.
+        if apply_residential_filter:
+            transactions = [t for t in transactions
+                            if t.property_type in _RESIDENTIAL_TYPES]
+
+        def _live_provenance(count: int, gathered: tuple[str, ...]):
+            return live_provenance(
+                evidence=live.evidence, sample_count=count, sample_limit=limit,
+                warnings=gathered)
+
+        return transactions, _live_provenance, False
 
     def _subject_property_lookup(
         self, postcode: str, address: str
@@ -484,6 +691,11 @@ class PPDService:
             last_sale=first,
             transaction_count=len(transactions),
             transaction_history=transactions,
+            # Its own block. A property's history routinely predates snapshot
+            # coverage, so this is always live -- and a mixed-source response
+            # that labelled both halves `snapshot` would misstate one of them.
+            provenance=live_provenance(sample_count=len(transactions),
+                                       sample_limit=50),
         )
 
     @staticmethod
@@ -526,7 +738,42 @@ class PPDService:
     ) -> Dict[str, Any]:
         """Fetch a single transaction record and normalize the result.
 
-        Returns dict with keys: record (PPDTransactionRecord), raw (optional).
+        Returns dict with keys: record (PPDTransactionRecord), raw (optional),
+        provenance.
+
+        **Always Linked Data, never the snapshot.** An exact id is a request for
+        one specific transaction, which is frequently older than snapshot
+        coverage; routing it to a bounded source would turn "here it is" into
+        "not found" for every pre-coverage sale. This is also the remedy the
+        coverage error points callers at, so it has to keep working.
         """
         record = self.client.get_transaction_record(transaction_id, view=view)
-        return {"record": record, "raw": record.raw if include_raw else None}
+        return {
+            "record": record,
+            "raw": record.raw if include_raw else None,
+            # One record, fetched by id: the sample is the record, and the
+            # lookup is exhaustive by construction.
+            "provenance": live_provenance(
+                source=SourceKind.LINKED_DATA, sample_count=1, sample_limit=1),
+        }
+
+
+def _older_records_warnings(older: Optional[bool], coverage_from: Optional[str],
+                            coverage_to: Optional[str]) -> tuple[str, ...]:
+    """What an empty in-coverage result is allowed to say (spec 2.4).
+
+    Asymmetric on purpose. `False` is the only value that licenses a bare empty
+    result, because it is the only one backed by a probe that completed. `True`
+    and `None` both warn, and neither response may read as "never sold".
+    """
+    if older is True:
+        return (
+            f"no sales within coverage {coverage_from}..{coverage_to}; earlier "
+            f"records exist outside coverage",
+        )
+    if older is None:
+        return (
+            "coverage probe unavailable; cannot determine whether earlier "
+            "records exist outside coverage",
+        )
+    return ()

--- a/property_core/ppd_service.py
+++ b/property_core/ppd_service.py
@@ -147,13 +147,16 @@ class PPDService:
 
         adapter = self._active_adapter()
         if adapter is not None:
-            # A coverage refusal and a caller error both propagate: neither is a
-            # snapshot failure, and retrying either against live would hide the
-            # fact the caller needs.
-            decision = resolve_coverage(
-                adapter, from_date=from_date, to_date=to_date,
-                policy=CoveragePolicy.EXPLICIT)
             try:
+                # Inside the try on purpose. `resolve_coverage` can raise a
+                # SnapshotCoverageGapError, which belongs to the fallback
+                # taxonomy; PPDCoverageError and InvalidPostcodeError do not
+                # subclass SnapshotFailure and so still reach the caller, which
+                # is the point -- retrying either against live would hide the
+                # fact the caller needs.
+                decision = resolve_coverage(
+                    adapter, from_date=from_date, to_date=to_date,
+                    policy=CoveragePolicy.EXPLICIT)
                 page = adapter.search(
                     postcode=postcode,
                     postcode_prefix=postcode_prefix,
@@ -166,6 +169,7 @@ class PPDService:
                     transaction_category=transaction_category,
                     new_build=new_build,
                     limit=limit,
+                    offset=offset,
                     order_desc=order_desc,
                 )
             except SnapshotFailure as exc:
@@ -174,7 +178,13 @@ class PPDService:
                 results = page.transactions
                 warnings.extend(decision.warnings)
                 older = None
-                if not results and decision.narrowed and adapter.coverage_from:
+                # `from_narrowed`, NOT `narrowed`: the probe asks whether
+                # anything exists BEFORE coverage begins, which is only a
+                # question for a caller who did not choose the lower bound. A
+                # caller who named `from_date` already excluded that period
+                # deliberately, and an upstream request to tell them so is noise.
+                if (not results and decision.from_narrowed and offset == 0
+                        and adapter.coverage_from):
                     # No probe when there ARE rows: the question is already
                     # answered, and a probe would be a second upstream call
                     # for nothing (spec test 13).
@@ -193,7 +203,7 @@ class PPDService:
                     "raw": [t.raw for t in results] if include_raw else None,
                     "provenance": snapshot_provenance(
                         adapter, decision=decision, sample_count=len(results),
-                        sample_limit=limit,
+                        sample_limit=limit, offset=offset,
                         completeness_basis=page.completeness_basis,
                         older_records_exist=older, warnings=tuple(warnings)),
                 }
@@ -553,9 +563,13 @@ class PPDService:
         """
         adapter = self._active_adapter()
         if adapter is not None:
-            decision = resolve_coverage(
-                adapter, from_date=from_date, to_date=None, policy=coverage_policy)
             try:
+                # Inside the try: a window the snapshot cannot reach raises
+                # SnapshotCoverageGapError, and comps must still answer -- from
+                # the live source, with a warning, like any snapshot failure.
+                decision = resolve_coverage(
+                    adapter, from_date=from_date, to_date=None,
+                    policy=coverage_policy)
                 page = adapter.search(
                     postcode=exact_postcode,
                     postcode_prefix=prefix,

--- a/property_core/ppd_source.py
+++ b/property_core/ppd_source.py
@@ -33,7 +33,7 @@ from enum import Enum
 from typing import Any, Iterable, Optional
 
 from property_core.config import ppd_snapshot_enabled
-from property_core.exceptions import PPDCoverageError
+from property_core.exceptions import InvalidDateRangeError, PPDCoverageError
 from property_core.provenance import (
     CompletenessBasis,
     PPDProvenance,
@@ -103,6 +103,58 @@ def _today() -> date:
     return date.today()
 
 
+def validate_date_range(from_date: Optional[str],
+                        to_date: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Both dates parse as ISO, and `from_date <= to_date`. Or a typed error.
+
+    **Everything downstream compares these as strings.** That is deliberate and
+    fine for well-formed ISO dates, whose lexical and chronological orders agree
+    -- and meaningless for anything else. Unvalidated, `"nonsense"` sorted after
+    `"2026-06-30"` and a garbage `to_date` was read as "beyond coverage" and
+    quietly clamped to it.
+
+    An inverted range is rejected rather than answered. It describes an empty
+    window, so it passed both coverage-bound checks, returned nothing, and was
+    reported complete: a confident "no such sales exist" for a period no source
+    was ever asked about.
+
+    Called before any routing decision, so it protects the live path as well --
+    where an unparseable date previously surfaced as an upstream failure rather
+    than a caller error.
+    """
+    def _parsed(value: Optional[str], field: str) -> Optional[date]:
+        if value is None:
+            return None
+        try:
+            parsed = date.fromisoformat(value)
+        except (TypeError, ValueError) as exc:
+            raise InvalidDateRangeError(
+                f"{field} {value!r} is not an ISO date (YYYY-MM-DD)",
+                field=field, value=value,
+                from_date=from_date, to_date=to_date,
+            ) from exc
+        # `date.fromisoformat` accepts a few non-canonical spellings; requiring
+        # the round trip keeps one spelling reaching the comparisons.
+        if parsed.isoformat() != value:
+            raise InvalidDateRangeError(
+                f"{field} {value!r} is not a canonical ISO date (YYYY-MM-DD)",
+                field=field, value=value,
+                from_date=from_date, to_date=to_date,
+            )
+        return parsed
+
+    start = _parsed(from_date, "from_date")
+    end = _parsed(to_date, "to_date")
+    if start is not None and end is not None and start > end:
+        raise InvalidDateRangeError(
+            f"from_date {from_date} is after to_date {to_date}; the window is "
+            f"empty, and an empty window is not an answer",
+            field="from_date", value=from_date,
+            from_date=from_date, to_date=to_date,
+        )
+    return from_date, to_date
+
+
 def freshness_days(coverage_to: Optional[str]) -> Optional[int]:
     if not coverage_to:
         return None
@@ -147,9 +199,15 @@ def resolve_coverage(
        naming what was excluded, and record that the interval was NOT fully
        contained, which forbids any completeness claim.
 
-    Raises `PPDCoverageError` or `SnapshotCoverageGapError`.
+    Raises `InvalidDateRangeError`, `PPDCoverageError` or
+    `SnapshotCoverageGapError`.
     """
     from property_core.snapshot.errors import SnapshotCoverageGapError
+
+    # Defence in depth. The service validates before routing, so both sources
+    # are protected; this function owns the lexical comparisons, so it must not
+    # depend on a caller having checked first.
+    validate_date_range(from_date, to_date)
 
     coverage_from = adapter.coverage_from
     coverage_to = adapter.coverage_to

--- a/property_core/ppd_source.py
+++ b/property_core/ppd_source.py
@@ -62,8 +62,26 @@ class CoverageDecision:
     from_date: Optional[str]
     to_date: Optional[str]
     warnings: tuple[str, ...]
-    narrowed: bool
+    #: The caller gave no `from_date`, so the lower bound became `coverage_from`.
+    #: Kept separate from `to_clamped` because only this one licenses the
+    #: existence probe: the probe asks whether records exist BEFORE coverage,
+    #: which is a question only a caller who did not choose the lower bound is
+    #: asking. Conflating the two fired a probe -- an upstream request -- on
+    #: every request that merely ran up to the present.
+    from_narrowed: bool
+    #: The requested window reached past `coverage_to` and was clamped to it.
+    to_clamped: bool
     recent_period_provisional: bool
+    #: Whether the caller's ENTIRE requested interval lies inside coverage.
+    #: `sample_complete` may only be true when this is -- see
+    #: `snapshot_provenance`. An interval that reaches past either bound was
+    #: only partly answered, however exhaustively the overlap was searched.
+    fully_contained: bool = False
+
+    @property
+    def narrowed(self) -> bool:
+        """Whether the queried window differs from the requested one, either end."""
+        return self.from_narrowed or self.to_clamped
 
 
 def active_adapter() -> Optional[Any]:
@@ -103,20 +121,78 @@ def resolve_coverage(
     to_date: Optional[str],
     policy: CoveragePolicy,
 ) -> CoverageDecision:
-    """Decide the queried window, or refuse. Raises `PPDCoverageError`."""
+    """Decide the queried window over the COMPLETE interval, or refuse.
+
+    Both bounds are checked. Testing only the lower one let a request for a
+    period entirely *after* `coverage_to` -- next month, say -- run against the
+    snapshot, match nothing, and come back as an empty result marked complete:
+    a confident statement that no such sales exist, made by a source that could
+    not have known.
+
+    Four cases, in order:
+
+    1. **Disjoint** -- the interval and coverage do not overlap at all. Under
+       EXPLICIT this is a typed refusal naming the boundary that was crossed;
+       under GUARANTEED it is a `SnapshotCoverageGapError`, so the live source
+       answers. The difference is who chose the dates: an EXPLICIT caller can
+       act on a refusal, while a GUARANTEED caller never named a window and
+       would just be blamed for a stale snapshot.
+    2. **Starts before coverage** -- refuse (EXPLICIT) or narrow and warn
+       (GUARANTEED, whose `months` is bounded and whose snapshot is sized for
+       the maximum).
+    3. **No `from_date`** -- narrow to `coverage_from` and warn. Silently
+       turning "all time" into eleven years is the lie this exists to prevent.
+    4. **Extends past `coverage_to`** (including every request with no
+       `to_date`, since that means "up to now") -- clamp to `coverage_to`, warn
+       naming what was excluded, and record that the interval was NOT fully
+       contained, which forbids any completeness claim.
+
+    Raises `PPDCoverageError` or `SnapshotCoverageGapError`.
+    """
+    from property_core.snapshot.errors import SnapshotCoverageGapError
+
     coverage_from = adapter.coverage_from
     coverage_to = adapter.coverage_to
     warnings: list[str] = []
-    narrowed = False
+    from_narrowed = False
+    to_clamped = False
     resolved_from = from_date
+    resolved_to = to_date
 
+    # The adapter's metadata gate guarantees both bounds are present, ordered
+    # ISO dates before it will route, so there is no "unknown coverage" branch
+    # here. If that gate is ever loosened, this falls back to serving the window
+    # verbatim rather than inventing bounds.
     if coverage_from and coverage_to:
+        starts_after_coverage = from_date is not None and from_date > coverage_to
+        ends_before_coverage = to_date is not None and to_date < coverage_from
+
+        if starts_after_coverage or ends_before_coverage:
+            side = "follows" if starts_after_coverage else "precedes"
+            if policy is CoveragePolicy.EXPLICIT:
+                raise PPDCoverageError(
+                    coverage_from=coverage_from,
+                    coverage_to=coverage_to,
+                    requested_from=from_date,
+                    requested_to=to_date,
+                    source_release=adapter.version,
+                    detail=f"requested range {side} available coverage entirely",
+                    remedy=(
+                        f"request a range within {coverage_from}..{coverage_to}; "
+                        f"sales after {coverage_to} are not yet in this release"
+                        if starts_after_coverage else
+                        f"request a range within {coverage_from}..{coverage_to}, "
+                        f"or look up a known transaction by its id"
+                    ),
+                )
+            raise SnapshotCoverageGapError(
+                f"snapshot coverage {coverage_from}..{coverage_to} does not "
+                f"overlap the requested window {from_date}..{to_date}"
+            )
+
         if from_date is None:
-            # "No start date" means "all time" on the live source and "coverage"
-            # here. Narrowing silently would turn 31 years into 11 without
-            # telling anyone.
             resolved_from = coverage_from
-            narrowed = True
+            from_narrowed = True
             warnings.append(
                 f"unbounded from_date narrowed to snapshot coverage "
                 f"{coverage_from}")
@@ -130,10 +206,18 @@ def resolve_coverage(
                     source_release=adapter.version,
                 )
             resolved_from = coverage_from
-            narrowed = True
+            from_narrowed = True
             warnings.append(
                 f"requested window starts {from_date}, before snapshot coverage; "
                 f"narrowed to {coverage_from}")
+
+        if to_date is None or to_date > coverage_to:
+            resolved_to = coverage_to
+            to_clamped = True
+            warnings.append(
+                f"requested window extends to "
+                f"{to_date or 'the present'}, beyond snapshot coverage "
+                f"{coverage_to}; sales after {coverage_to} are not included")
 
         age = freshness_days(coverage_to)
         if age is not None and age > FRESHNESS_WARNING_DAYS:
@@ -141,8 +225,14 @@ def resolve_coverage(
                 f"snapshot is {age} days behind its coverage end {coverage_to}; "
                 f"recent sales may be missing")
 
+    fully_contained = bool(
+        coverage_from and coverage_to
+        and from_date is not None and from_date >= coverage_from
+        and to_date is not None and to_date <= coverage_to
+    )
+
     provisional = _intersects_provisional(
-        adapter, from_date=resolved_from, to_date=to_date)
+        adapter, from_date=resolved_from, to_date=resolved_to)
     if provisional:
         warnings.append(
             f"the window overlaps the provisional period from "
@@ -151,10 +241,12 @@ def resolve_coverage(
 
     return CoverageDecision(
         from_date=resolved_from,
-        to_date=to_date,
+        to_date=resolved_to,
         warnings=tuple(warnings),
-        narrowed=narrowed,
+        from_narrowed=from_narrowed,
+        to_clamped=to_clamped,
         recent_period_provisional=provisional,
+        fully_contained=fully_contained,
     )
 
 
@@ -182,6 +274,7 @@ def snapshot_provenance(
     sample_count: int,
     sample_limit: int,
     completeness_basis: Optional[CompletenessBasis],
+    offset: int = 0,
     older_records_exist: Optional[bool] = None,
     warnings: Iterable[str] = (),
 ) -> PPDProvenance:
@@ -190,7 +283,21 @@ def snapshot_provenance(
     `sample_complete` is derived from `completeness_basis` rather than passed
     alongside it, so the pair cannot disagree: a basis means complete, no basis
     means not complete, and there is no third spelling.
+
+    **Two things withdraw the basis here, centrally, so no call site can forget
+    them.** The adapter's `limit + 1` evidence is a fact about the page it
+    fetched, and a page is not the sample when either holds:
+
+    * the requested interval was not fully inside coverage -- part of what was
+      asked for was never searched, so exhausting the rest proves nothing about
+      it;
+    * `offset > 0` -- a short final page says the page ended, not that the pages
+      skipped over were seen.
     """
+    basis = completeness_basis
+    if basis is not None and (not decision.fully_contained or offset > 0):
+        basis = None
+    completeness_basis = basis
     return PPDProvenance(
         source=SourceKind.SNAPSHOT,
         source_release=adapter.version,

--- a/property_core/ppd_source.py
+++ b/property_core/ppd_source.py
@@ -1,0 +1,245 @@
+"""Source routing: which source answers, over what window, and what we say so.
+
+Three jobs, all of them about the difference between a fact and an absence.
+
+**Coverage.** A request whose range starts before `coverage_from` is
+unsatisfiable as stated. Two policies decide what that means:
+
+* ``GUARANTEED`` -- the surface bounds `months` (comps at 60/120, yield, report)
+  and the snapshot is sized to cover the maximum. A window reaching past coverage
+  therefore means a *stale snapshot*, not an impossible request, so it is
+  narrowed to `coverage_from` and warned.
+* ``EXPLICIT`` -- the caller named dates, or `months` has no upper bound
+  (`/v1/ppd/transactions`, `/v1/ppd/blocks`). Refused with `PPDCoverageError`
+  carrying both ranges as structured fields. Never a partial 200: a truncated
+  result is indistinguishable from a complete one.
+
+**Fallback.** Every `SnapshotFailure` hands off to the live source and says so
+in a warning. A `PPDCoverageError` and an `InvalidPostcodeError` do not: the
+first is the answer, the second is the caller's mistake, and routing either to
+live would hide exactly the fact the caller needs.
+
+**Provenance.** One validated block, built once from already-gathered evidence.
+`PPDProvenance` is frozen precisely so it cannot be built early and refined by
+assignment, and `model_copy(update=...)` -- which bypasses validation by design
+-- is prohibited here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+from typing import Any, Iterable, Optional
+
+from property_core.config import ppd_snapshot_enabled
+from property_core.exceptions import PPDCoverageError
+from property_core.provenance import (
+    CompletenessBasis,
+    PPDProvenance,
+    SourceKind,
+    TransportEvidence,
+)
+
+#: Freshness beyond which a response says so. Staleness is a warning, never an
+#: outage: a stale verified snapshot always beats going unready (spec 4.9).
+FRESHNESS_WARNING_DAYS = 45
+
+
+class CoveragePolicy(str, Enum):
+    """How a surface reacts to a window reaching past `coverage_from`."""
+
+    #: Bounded `months`; narrow and warn.
+    GUARANTEED = "guaranteed"
+    #: Caller-supplied or unbounded dates; refuse, typed, with both ranges.
+    EXPLICIT = "explicit"
+
+
+@dataclass(frozen=True)
+class CoverageDecision:
+    """The window actually queried, and what had to be said about it."""
+
+    from_date: Optional[str]
+    to_date: Optional[str]
+    warnings: tuple[str, ...]
+    narrowed: bool
+    recent_period_provisional: bool
+
+
+def active_adapter() -> Optional[Any]:
+    """The process's snapshot adapter, or `None` for the live source.
+
+    The flag is checked BEFORE the import, so with the feature off a request
+    path never so much as imports `property_core.snapshot` -- let alone DuckDB.
+    The same check is repeated inside `state.active_adapter()`; that redundancy
+    is deliberate, because either call site alone must fail closed.
+    """
+    if not ppd_snapshot_enabled():
+        return None
+    from property_core.snapshot import state
+
+    return state.active_adapter()
+
+
+def _today() -> date:
+    return date.today()
+
+
+def freshness_days(coverage_to: Optional[str]) -> Optional[int]:
+    if not coverage_to:
+        return None
+    try:
+        # Never negative: a coverage_to in the future would otherwise report a
+        # negative age, which the model rejects and which means nothing anyway.
+        return max(0, (_today() - date.fromisoformat(coverage_to)).days)
+    except ValueError:
+        return None
+
+
+def resolve_coverage(
+    adapter: Any,
+    *,
+    from_date: Optional[str],
+    to_date: Optional[str],
+    policy: CoveragePolicy,
+) -> CoverageDecision:
+    """Decide the queried window, or refuse. Raises `PPDCoverageError`."""
+    coverage_from = adapter.coverage_from
+    coverage_to = adapter.coverage_to
+    warnings: list[str] = []
+    narrowed = False
+    resolved_from = from_date
+
+    if coverage_from and coverage_to:
+        if from_date is None:
+            # "No start date" means "all time" on the live source and "coverage"
+            # here. Narrowing silently would turn 31 years into 11 without
+            # telling anyone.
+            resolved_from = coverage_from
+            narrowed = True
+            warnings.append(
+                f"unbounded from_date narrowed to snapshot coverage "
+                f"{coverage_from}")
+        elif from_date < coverage_from:
+            if policy is CoveragePolicy.EXPLICIT:
+                raise PPDCoverageError(
+                    coverage_from=coverage_from,
+                    coverage_to=coverage_to,
+                    requested_from=from_date,
+                    requested_to=to_date,
+                    source_release=adapter.version,
+                )
+            resolved_from = coverage_from
+            narrowed = True
+            warnings.append(
+                f"requested window starts {from_date}, before snapshot coverage; "
+                f"narrowed to {coverage_from}")
+
+        age = freshness_days(coverage_to)
+        if age is not None and age > FRESHNESS_WARNING_DAYS:
+            warnings.append(
+                f"snapshot is {age} days behind its coverage end {coverage_to}; "
+                f"recent sales may be missing")
+
+    provisional = _intersects_provisional(
+        adapter, from_date=resolved_from, to_date=to_date)
+    if provisional:
+        warnings.append(
+            f"the window overlaps the provisional period from "
+            f"{adapter.provisional_from}; HM Land Registry revises recent "
+            f"months, so those figures may change")
+
+    return CoverageDecision(
+        from_date=resolved_from,
+        to_date=to_date,
+        warnings=tuple(warnings),
+        narrowed=narrowed,
+        recent_period_provisional=provisional,
+    )
+
+
+def _intersects_provisional(adapter: Any, *, from_date: Optional[str],
+                            to_date: Optional[str]) -> bool:
+    """Whether the queried window touches `[provisional_from, coverage_to]`.
+
+    `provisional_from` is *published in the manifest*, never inferred at query
+    time: how far back HMLR's incremental publication is still moving is a
+    property of the release, not something a query can work out.
+    """
+    provisional_from = adapter.provisional_from
+    coverage_to = adapter.coverage_to
+    if not provisional_from or not coverage_to:
+        return False
+    window_end = to_date or coverage_to
+    window_start = from_date or adapter.coverage_from or provisional_from
+    return not (window_end < provisional_from or window_start > coverage_to)
+
+
+def snapshot_provenance(
+    adapter: Any,
+    *,
+    decision: CoverageDecision,
+    sample_count: int,
+    sample_limit: int,
+    completeness_basis: Optional[CompletenessBasis],
+    older_records_exist: Optional[bool] = None,
+    warnings: Iterable[str] = (),
+) -> PPDProvenance:
+    """One validated block, built once from evidence already gathered.
+
+    `sample_complete` is derived from `completeness_basis` rather than passed
+    alongside it, so the pair cannot disagree: a basis means complete, no basis
+    means not complete, and there is no third spelling.
+    """
+    return PPDProvenance(
+        source=SourceKind.SNAPSHOT,
+        source_release=adapter.version,
+        snapshot_imported_at=adapter.imported_at,
+        coverage_from=adapter.coverage_from,
+        coverage_to=adapter.coverage_to,
+        freshness_days=freshness_days(adapter.coverage_to),
+        recent_period_provisional=decision.recent_period_provisional,
+        older_records_exist=older_records_exist,
+        sample_count=sample_count,
+        sample_limit=sample_limit,
+        sample_complete=completeness_basis is not None,
+        completeness_basis=completeness_basis,
+        warnings=tuple(warnings),
+    )
+
+
+def live_provenance(
+    *,
+    source: SourceKind = SourceKind.SPARQL,
+    evidence: Optional[TransportEvidence] = None,
+    sample_count: int = 0,
+    sample_limit: int = 0,
+    warnings: Iterable[str] = (),
+) -> PPDProvenance:
+    """Provenance for a live answer. Completeness stays false unless proven.
+
+    The live path may only claim completeness through `SOURCE_EXHAUSTED`, and
+    only when the transport actually observed it. Counts alone establish
+    nothing: the upstream window is bounded *before* client-side filtering, so a
+    short list is equally consistent with "the window was truncated and most
+    rows were discarded".
+
+    Snapshot fields are null, not zero or empty -- a live answer has no coverage
+    bounds to state.
+    """
+    exhausted = evidence.source_exhausted if evidence is not None else None
+    basis = CompletenessBasis.SOURCE_EXHAUSTED if exhausted is True else None
+    return PPDProvenance(
+        source=source,
+        sample_count=sample_count,
+        sample_limit=sample_limit,
+        sample_complete=basis is not None,
+        completeness_basis=basis,
+        warnings=tuple(warnings),
+    )
+
+
+def fallback_warning(exc: Exception) -> str:
+    """The one sentence a caller needs when the snapshot stepped aside."""
+    return (f"snapshot source unavailable ({type(exc).__name__}: "
+            f"{str(exc)[:160]}); answered from the live source instead")

--- a/property_core/snapshot/__init__.py
+++ b/property_core/snapshot/__init__.py
@@ -1,14 +1,21 @@
-"""Snapshot boot runtime.
+"""Snapshot boot runtime and query adapter.
 
-Fetches, verifies and activates a PPD snapshot bundle at process start. It does
-NOT query the snapshot, route any request, or change any response: reading data
-from an activated snapshot is a later piece of work.
+Two layers with deliberately different claims:
+
+* the **boot runtime** fetches, verifies and activates a bundle at process
+  start, establishing *structural* facts only -- digest, member safety, file
+  inventory. It never opens the snapshot;
+* the **adapter** turns that into a routable source, and only after it has
+  checked the schema, the row count, and an executed query. That gap is the
+  point: a well-formed archive can still be unusable, and reporting the weaker
+  claim as the stronger one would serve nonsense.
 
 Disabled by default -- see `property_core.config.ppd_snapshot_enabled`.
 """
 
 from __future__ import annotations
 
+from property_core.snapshot.adapter import SnapshotAdapter, SnapshotPage
 from property_core.snapshot.archive import ExtractionLimits, ExtractionStats, safe_extract
 from property_core.snapshot.errors import (
     ArchiveRejected,
@@ -16,6 +23,10 @@ from property_core.snapshot.errors import (
     DownloadDeadlineExceeded,
     InsufficientDiskSpaceError,
     SnapshotExtraMissingError,
+    SnapshotNotQueryableError,
+    SnapshotQueryError,
+    SnapshotRowCountError,
+    SnapshotSchemaError,
 )
 from property_core.snapshot.fetch import DownloadResult, download_verified
 from property_core.snapshot.lock import LockTimeout, single_flight
@@ -46,8 +57,14 @@ __all__ = [
     "LockTimeout",
     "ObjectSource",
     "Readiness",
+    "SnapshotAdapter",
     "SnapshotExtraMissingError",
     "SnapshotManifest",
+    "SnapshotNotQueryableError",
+    "SnapshotPage",
+    "SnapshotQueryError",
+    "SnapshotRowCountError",
+    "SnapshotSchemaError",
     "SnapshotStore",
     "VerificationRecord",
     "download_verified",

--- a/property_core/snapshot/adapter.py
+++ b/property_core/snapshot/adapter.py
@@ -65,10 +65,14 @@ _CATEGORIES = frozenset({"A", "B"})
 class SnapshotPage:
     """One page of snapshot rows plus the evidence that judges completeness.
 
-    `exhausted` is *positive* evidence: the adapter asked for one row more than
-    the caller wanted and did not get it, so every matching row inside coverage
-    was examined. `completeness_basis` records how that was established, because
-    a claim of completeness with no stated basis is not a claim anyone can check.
+    The two fields say different things, and the difference is the whole point:
+
+    * `exhausted` is scoped to the PAGE -- the adapter asked for one row more
+      than the caller wanted and did not get it, so this page ran out;
+    * `completeness_basis` is scoped to the whole matching set. It is set only
+      when the page ran out *and* it was the only page (`offset == 0`), because
+      rows skipped over by an offset were never examined. A claim of
+      completeness with no stated basis is not a claim anyone can check.
     """
 
     transactions: list[PPDTransaction]
@@ -454,10 +458,18 @@ class SnapshotAdapter:
                 ) from exc
 
         exhausted = len(rows) <= limit
+        # A basis is a claim that every matching row was examined, so it needs
+        # BOTH facts: the page ended, and it was the only page. At an offset the
+        # rows skipped over were never looked at, however short the final page
+        # is. The provenance builder withdraws a basis at an offset as well;
+        # that stays, but this type is exported and its evidence must be true on
+        # its own terms rather than relying on a later caller to correct it.
+        basis = (CompletenessBasis.LIMIT_PLUS_ONE
+                 if exhausted and offset == 0 else None)
         return SnapshotPage(
             transactions=[_row_to_transaction(r) for r in rows[:limit]],
             exhausted=exhausted,
             fetch_limit=fetch_limit,
             offset=offset,
-            completeness_basis=CompletenessBasis.LIMIT_PLUS_ONE if exhausted else None,
+            completeness_basis=basis,
         )

--- a/property_core/snapshot/adapter.py
+++ b/property_core/snapshot/adapter.py
@@ -1,0 +1,379 @@
+"""DuckDB adapter over a materialized snapshot.
+
+**This is where READY becomes permission to route.** The boot runtime proves
+structural facts -- the bundle matched its digest, every archive member was safe,
+the unpacked inventory is exactly what was written. None of that says the Parquet
+files parse, carry the columns a query needs, or hold the rows the record claims.
+`SnapshotAdapter.open` establishes those three before it will answer anything,
+and refuses with a typed `SnapshotFailure` otherwise -- which routing turns into
+a live fallback, never into an empty result set.
+
+Two properties this adapter has that the live path cannot:
+
+* **Exact geography.** Membership is `outcode = ?` / `sector = ?` against
+  materialized columns, so `B5` cannot match `B50` by construction.
+* **Limit-independent completeness.** It asks for `limit + 1` rows; a short
+  answer is positive proof that nothing was truncated. That is real evidence,
+  unlike the live path's `raw_bindings < fetch_limit`, which moves with the
+  caller's page size.
+
+Deliberately absent: any notion of widening the search. Escalation is a caller
+decision made on evidence, never something a query does on its own.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+
+from property_core.models.ppd import PPDTransaction
+from property_core.postcode_rules import (
+    is_sector,
+    normalise_postcode,
+    normalise_prefix,
+)
+from property_core.provenance import CompletenessBasis
+from property_core.snapshot.duckdb_support import require_duckdb
+from property_core.snapshot.errors import (
+    SnapshotNotQueryableError,
+    SnapshotQueryError,
+    SnapshotRowCountError,
+    SnapshotSchemaError,
+)
+from property_core.snapshot.models import VerificationRecord
+from property_core.snapshot.schema import (
+    PROJECTION,
+    REQUIRED_COLUMNS,
+    normalise_type,
+)
+
+#: The relation name the adapter registers its Parquet files under.
+VIEW = "ppd"
+
+#: Reverse of the CSV codes carried through the build. Kept explicit rather than
+#: trusting whatever string the column happens to hold.
+_ESTATE_TYPES = frozenset({"F", "L"})
+_PROPERTY_TYPES = frozenset({"D", "S", "T", "F", "O"})
+_CATEGORIES = frozenset({"A", "B"})
+
+
+@dataclass(frozen=True)
+class SnapshotPage:
+    """One page of snapshot rows plus the evidence that judges completeness.
+
+    `exhausted` is *positive* evidence: the adapter asked for one row more than
+    the caller wanted and did not get it, so every matching row inside coverage
+    was examined. `completeness_basis` records how that was established, because
+    a claim of completeness with no stated basis is not a claim anyone can check.
+    """
+
+    transactions: list[PPDTransaction]
+    exhausted: bool
+    fetch_limit: int
+    completeness_basis: Optional[CompletenessBasis] = None
+
+
+def _row_to_transaction(row: Sequence[Any]) -> PPDTransaction:
+    """Map one projected row onto the shared transaction model.
+
+    Codes are validated rather than passed through: a snapshot column holding
+    something outside the known set becomes `None`, which reads as "not stated",
+    instead of an invented code that a consumer would filter or display.
+    """
+    (transaction_id, price, transfer_date, postcode, property_type, duration,
+     ppd_category, new_build, paon, saon, street, locality, town, district,
+     county) = row
+
+    def _code(value: Any, allowed: frozenset[str]) -> Optional[str]:
+        if not isinstance(value, str):
+            return None
+        text = value.strip().upper()
+        return text if text in allowed else None
+
+    return PPDTransaction(
+        # The bulk CSV wraps ids in braces; the Linked Data and SPARQL paths do
+        # not. Stripped here so an id means the same thing on every source.
+        transaction_id=(transaction_id or "").strip("{} ") or None,
+        price=int(price) if price is not None else None,
+        date=transfer_date.isoformat() if hasattr(transfer_date, "isoformat")
+        else (str(transfer_date) if transfer_date is not None else None),
+        postcode=postcode,
+        property_type=_code(property_type, _PROPERTY_TYPES),
+        estate_type=_code(duration, _ESTATE_TYPES),
+        transaction_category=_code(ppd_category, _CATEGORIES),
+        new_build=bool(new_build) if new_build is not None else None,
+        paon=paon, saon=saon, street=street, locality=locality,
+        town=town, district=district, county=county,
+    )
+
+
+@dataclass
+class SnapshotAdapter:
+    """A validated, queryable view over one materialized snapshot.
+
+    Constructed through `open`, which is the only path that runs validation. A
+    directly constructed instance is not routable, and nothing in this package
+    constructs one.
+    """
+
+    directory: Path
+    record: VerificationRecord
+    _connection: Any = None
+    _files: tuple[str, ...] = ()
+    #: DuckDB connections are not safe to share across threads. The service layer
+    #: runs sync calls in a thread pool, so every query holds this.
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _closed: bool = False
+
+    # -- lifecycle ------------------------------------------------------
+    @classmethod
+    def open(cls, directory: Path | str, record: VerificationRecord) -> "SnapshotAdapter":
+        """Connect, validate, and return a routable adapter -- or raise.
+
+        On any validation failure the connection is closed before the error
+        leaves this method: a rejected snapshot must not leak a DuckDB handle
+        into a process that is about to serve from the live source for hours.
+        """
+        adapter = cls(directory=Path(directory), record=record)
+        try:
+            adapter._connect()
+            adapter._validate()
+        except Exception:
+            adapter.close()
+            raise
+        return adapter
+
+    def close(self) -> None:
+        with self._lock:
+            if self._connection is not None:
+                try:
+                    self._connection.close()
+                finally:
+                    self._connection = None
+            self._closed = True
+
+    def __enter__(self) -> "SnapshotAdapter":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    # -- coverage -------------------------------------------------------
+    @property
+    def version(self) -> str:
+        return self.record.version
+
+    @property
+    def coverage_from(self) -> Optional[str]:
+        return self.record.coverage_from
+
+    @property
+    def coverage_to(self) -> Optional[str]:
+        return self.record.coverage_to
+
+    @property
+    def provisional_from(self) -> Optional[str]:
+        return self.record.provisional_from
+
+    @property
+    def imported_at(self) -> Optional[str]:
+        return self.record.verified_at
+
+    # -- validation -----------------------------------------------------
+    def _connect(self) -> None:
+        duckdb = require_duckdb("the PPD snapshot adapter")
+        files = sorted(str(p) for p in self.directory.rglob("*.parquet"))
+        if not files:
+            raise SnapshotNotQueryableError(
+                f"no parquet files under {self.directory}")
+        self._files = tuple(files)
+        self._connection = duckdb.connect()
+        # `hive_partitioning=false`: the build lays partitions out as
+        # `year=<YYYY>/`, and letting DuckDB synthesise a `year` column from the
+        # directory name would collide with the real column the build projects.
+        # `union_by_name` so an added column in one partition cannot fail the
+        # scan -- the schema gate is what decides whether the shape is usable.
+        # DDL cannot take a prepared parameter, so the file list is inlined.
+        # These paths come from our own rglob over the verified directory, never
+        # from a caller; single quotes are still escaped so an odd filename on
+        # disk cannot break out of the literal.
+        listed = ", ".join("'" + f.replace("'", "''") + "'" for f in self._files)
+        try:
+            self._execute(
+                f"CREATE VIEW {VIEW} AS SELECT * FROM read_parquet([{listed}], "
+                f"hive_partitioning=false, union_by_name=true)"
+            )
+        except Exception as exc:
+            # DuckDB reads Parquet footers here, so a truncated or corrupt file
+            # surfaces at view creation. Translated so a caller handles one
+            # taxonomy rather than a bare `_duckdb.InvalidInputException`.
+            raise SnapshotNotQueryableError(
+                f"snapshot parquet files are not readable: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+
+    def _validate(self) -> None:
+        self._validate_schema()
+        self._validate_row_count()
+        self._validate_queryable()
+
+    def _validate_schema(self) -> None:
+        try:
+            described = self._execute(f"DESCRIBE SELECT * FROM {VIEW}").fetchall()
+        except Exception as exc:
+            raise SnapshotNotQueryableError(
+                f"snapshot could not be described: {type(exc).__name__}: {exc}"
+            ) from exc
+
+        found = {str(row[0]): normalise_type(str(row[1])) for row in described}
+        for column, accepted in REQUIRED_COLUMNS.items():
+            if column not in found:
+                raise SnapshotSchemaError(
+                    f"snapshot is missing required column {column!r}; routing "
+                    f"cannot answer a query it has no column for",
+                    column=column,
+                )
+            if found[column] not in accepted:
+                raise SnapshotSchemaError(
+                    f"column {column!r} has type {found[column]}, expected one "
+                    f"of {sorted(accepted)}",
+                    column=column,
+                )
+
+    def _validate_row_count(self) -> None:
+        # count(*) over Parquet is answered from row-group metadata. Never
+        # count(DISTINCT filename) -- Phase 3 found that scans every row.
+        try:
+            found = int(self._execute(f"SELECT count(*) FROM {VIEW}").fetchone()[0])
+        except Exception as exc:
+            raise SnapshotNotQueryableError(
+                f"snapshot row count failed: {type(exc).__name__}: {exc}"
+            ) from exc
+        if found != self.record.rows:
+            raise SnapshotRowCountError(expected=self.record.rows, found=found)
+
+    def _validate_queryable(self) -> None:
+        """Run the shape a request will run. Metadata parsing is not enough."""
+        sql = (f"SELECT {', '.join(PROJECTION)} FROM {VIEW} "
+               f"WHERE transfer_date IS NOT NULL "
+               f"ORDER BY transfer_date DESC, transaction_id ASC LIMIT 1")
+        try:
+            rows = self._execute(sql).fetchall()
+        except Exception as exc:
+            raise SnapshotNotQueryableError(
+                f"snapshot did not answer a probe query: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+        if rows:
+            try:
+                _row_to_transaction(rows[0])
+            except Exception as exc:
+                raise SnapshotSchemaError(
+                    f"snapshot row does not map onto the transaction model: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
+
+    # -- queries --------------------------------------------------------
+    def _execute(self, sql: str, params: Sequence[Any] = ()) -> Any:
+        if self._connection is None:
+            raise SnapshotNotQueryableError("adapter has no open connection")
+        return self._connection.execute(sql, list(params))
+
+    def search(
+        self,
+        *,
+        postcode: Optional[str] = None,
+        postcode_prefix: Optional[str] = None,
+        from_date: Optional[str] = None,
+        to_date: Optional[str] = None,
+        min_price: Optional[int] = None,
+        max_price: Optional[int] = None,
+        property_types: Optional[Iterable[str]] = None,
+        estate_type: Optional[str] = None,
+        transaction_category: Optional[str] = None,
+        new_build: Optional[bool] = None,
+        limit: int = 20,
+        order_desc: bool = True,
+    ) -> SnapshotPage:
+        """Rows matching the filters, plus completeness evidence.
+
+        Every filter is pushed into SQL. Nothing is filtered client-side, which
+        is what makes `limit + 1` mean what it says: a short answer proves the
+        source was exhausted, not merely that our own post-filter discarded a
+        lot.
+        """
+        where: list[str] = []
+        params: list[Any] = []
+
+        # Geography by parsed column, never by text prefix. `normalise_*` raises
+        # InvalidPostcodeError, which is a caller error and must NOT be caught
+        # into a live fallback.
+        if postcode is not None:
+            where.append("postcode = ?")
+            params.append(normalise_postcode(postcode))
+        if postcode_prefix is not None:
+            prefix = normalise_prefix(postcode_prefix)
+            where.append("sector = ?" if is_sector(prefix) else "outcode = ?")
+            params.append(prefix)
+
+        if from_date:
+            where.append("transfer_date >= CAST(? AS DATE)")
+            params.append(from_date)
+        if to_date:
+            where.append("transfer_date <= CAST(? AS DATE)")
+            params.append(to_date)
+        if min_price is not None:
+            where.append("price >= ?")
+            params.append(int(min_price))
+        if max_price is not None:
+            where.append("price <= ?")
+            params.append(int(max_price))
+
+        types = sorted({t.strip().upper() for t in property_types}) if property_types else None
+        if types:
+            where.append(f"property_type IN ({', '.join('?' * len(types))})")
+            params.extend(types)
+        if estate_type:
+            where.append("duration = ?")
+            params.append(estate_type.strip().upper())
+        if transaction_category:
+            where.append("ppd_category = ?")
+            params.append(transaction_category.strip().upper())
+        if new_build is not None:
+            where.append("new_build = ?")
+            params.append(bool(new_build))
+
+        limit = max(1, int(limit))
+        # One more than asked for. The extra row is evidence, never data.
+        fetch_limit = limit + 1
+        direction = "DESC" if order_desc else "ASC"
+        sql = (
+            f"SELECT {', '.join(PROJECTION)} FROM {VIEW}"
+            + (f" WHERE {' AND '.join(where)}" if where else "")
+            # transaction_id breaks same-date ties, so the order is total and
+            # repeating a query cannot repeat or omit a row.
+            + f" ORDER BY transfer_date {direction}, transaction_id ASC"
+            + f" LIMIT {fetch_limit}"
+        )
+
+        with self._lock:
+            try:
+                rows = self._execute(sql, params).fetchall()
+            except Exception as exc:
+                raise SnapshotQueryError(
+                    f"snapshot query failed: {type(exc).__name__}: {exc}"
+                ) from exc
+
+        exhausted = len(rows) <= limit
+        return SnapshotPage(
+            transactions=[_row_to_transaction(r) for r in rows[:limit]],
+            exhausted=exhausted,
+            fetch_limit=fetch_limit,
+            completeness_basis=CompletenessBasis.LIMIT_PLUS_ONE if exhausted else None,
+        )

--- a/property_core/snapshot/adapter.py
+++ b/property_core/snapshot/adapter.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
+from datetime import date
 from typing import Any, Iterable, Optional, Sequence
 
 from property_core.models.ppd import PPDTransaction
@@ -37,6 +38,7 @@ from property_core.postcode_rules import (
 from property_core.provenance import CompletenessBasis
 from property_core.snapshot.duckdb_support import require_duckdb
 from property_core.snapshot.errors import (
+    SnapshotMetadataError,
     SnapshotNotQueryableError,
     SnapshotQueryError,
     SnapshotRowCountError,
@@ -72,6 +74,9 @@ class SnapshotPage:
     transactions: list[PPDTransaction]
     exhausted: bool
     fetch_limit: int
+    #: The offset this page started at. `exhausted` is scoped to the page, so a
+    #: non-zero offset means it cannot speak for the whole matching set.
+    offset: int = 0
     completeness_basis: Optional[CompletenessBasis] = None
 
 
@@ -186,6 +191,16 @@ class SnapshotAdapter:
         return self.record.verified_at
 
     # -- validation -----------------------------------------------------
+    @staticmethod
+    def _quote(path: str) -> str:
+        """A SQL string literal for a path we produced ourselves.
+
+        These come from our own rglob over the verified directory, never from a
+        caller. Quotes are still escaped so an odd filename on disk cannot break
+        out of the literal.
+        """
+        return "'" + path.replace("'", "''") + "'"
+
     def _connect(self) -> None:
         duckdb = require_duckdb("the PPD snapshot adapter")
         files = sorted(str(p) for p in self.directory.rglob("*.parquet"))
@@ -194,16 +209,21 @@ class SnapshotAdapter:
                 f"no parquet files under {self.directory}")
         self._files = tuple(files)
         self._connection = duckdb.connect()
+
+    def _create_view(self) -> None:
         # `hive_partitioning=false`: the build lays partitions out as
         # `year=<YYYY>/`, and letting DuckDB synthesise a `year` column from the
         # directory name would collide with the real column the build projects.
-        # `union_by_name` so an added column in one partition cannot fail the
-        # scan -- the schema gate is what decides whether the shape is usable.
-        # DDL cannot take a prepared parameter, so the file list is inlined.
-        # These paths come from our own rglob over the verified directory, never
-        # from a caller; single quotes are still escaped so an odd filename on
-        # disk cannot break out of the literal.
-        listed = ", ".join("'" + f.replace("'", "''") + "'" for f in self._files)
+        #
+        # `union_by_name=true` is safe ONLY because every partition has already
+        # been validated individually. On its own it is actively dangerous: it
+        # fills a column one partition lacks with NULLs, so a partition missing
+        # `outcode` passes a check over the combined view, silently contributes
+        # no rows to any outcode search, and the short result is then reported
+        # as exhaustive. A whole year of sales disappears and the response says
+        # nothing is missing. With the per-file gate ahead of it, all it now
+        # tolerates is a partition carrying EXTRA columns.
+        listed = ", ".join(self._quote(f) for f in self._files)
         try:
             self._execute(
                 f"CREATE VIEW {VIEW} AS SELECT * FROM read_parquet([{listed}], "
@@ -219,30 +239,84 @@ class SnapshotAdapter:
             ) from exc
 
     def _validate(self) -> None:
-        self._validate_schema()
+        # Order matters. Every partition is checked on its own BEFORE the union
+        # exists, because the union is what hides a partition-level defect.
+        self._validate_coverage()
+        for path in self._files:
+            self._validate_partition(path)
+        self._create_view()
+        self._validate_schema(f"SELECT * FROM {VIEW}", source="the combined view")
         self._validate_row_count()
         self._validate_queryable()
 
-    def _validate_schema(self) -> None:
+    def _validate_coverage(self) -> None:
+        """Coverage metadata must be sound before it can decide anything.
+
+        Routing answers every coverage question from these three fields -- what
+        to refuse, what to narrow, what a warning says. Absent or contradictory
+        bounds do not degrade those decisions, they remove them silently, so an
+        unusable record is a typed failure and the caller uses the live source.
+        """
+        def _parsed(value: Optional[str], field: str) -> date:
+            if value is None:
+                raise SnapshotMetadataError(
+                    f"snapshot declares no {field}; routing cannot state what "
+                    f"coverage it is answering within",
+                    field=field,
+                )
+            try:
+                return date.fromisoformat(value)
+            except (TypeError, ValueError) as exc:
+                raise SnapshotMetadataError(
+                    f"snapshot {field} {value!r} is not an ISO date", field=field
+                ) from exc
+
+        coverage_from = _parsed(self.record.coverage_from, "coverage_from")
+        coverage_to = _parsed(self.record.coverage_to, "coverage_to")
+        if coverage_from > coverage_to:
+            raise SnapshotMetadataError(
+                f"snapshot coverage is inverted: coverage_from "
+                f"{self.record.coverage_from} is after coverage_to "
+                f"{self.record.coverage_to}",
+                field="coverage_from",
+            )
+
+        provisional = self.record.provisional_from
+        if provisional is not None:
+            boundary = _parsed(provisional, "provisional_from")
+            if not (coverage_from <= boundary <= coverage_to):
+                raise SnapshotMetadataError(
+                    f"snapshot provisional_from {provisional} is outside coverage "
+                    f"{self.record.coverage_from}..{self.record.coverage_to}; a "
+                    f"provisional tail that is not inside the data marks nothing",
+                    field="provisional_from",
+                )
+
+    def _validate_partition(self, path: str) -> None:
+        """One Parquet file, on its own terms. See `_create_view` for why."""
+        self._validate_schema(f"SELECT * FROM read_parquet({self._quote(path)})",
+                              source=path)
+
+    def _validate_schema(self, relation: str, *, source: str) -> None:
         try:
-            described = self._execute(f"DESCRIBE SELECT * FROM {VIEW}").fetchall()
+            described = self._execute(f"DESCRIBE {relation}").fetchall()
         except Exception as exc:
             raise SnapshotNotQueryableError(
-                f"snapshot could not be described: {type(exc).__name__}: {exc}"
+                f"{source} could not be described: {type(exc).__name__}: {exc}"
             ) from exc
 
         found = {str(row[0]): normalise_type(str(row[1])) for row in described}
         for column, accepted in REQUIRED_COLUMNS.items():
             if column not in found:
                 raise SnapshotSchemaError(
-                    f"snapshot is missing required column {column!r}; routing "
+                    f"{source} is missing required column {column!r}; routing "
                     f"cannot answer a query it has no column for",
                     column=column,
                 )
             if found[column] not in accepted:
                 raise SnapshotSchemaError(
-                    f"column {column!r} has type {found[column]}, expected one "
-                    f"of {sorted(accepted)}",
+                    f"{source}: column {column!r} has type {found[column]}, "
+                    f"expected one of {sorted(accepted)}",
                     column=column,
                 )
 
@@ -299,6 +373,7 @@ class SnapshotAdapter:
         transaction_category: Optional[str] = None,
         new_build: Optional[bool] = None,
         limit: int = 20,
+        offset: int = 0,
         order_desc: bool = True,
     ) -> SnapshotPage:
         """Rows matching the filters, plus completeness evidence.
@@ -307,6 +382,13 @@ class SnapshotAdapter:
         is what makes `limit + 1` mean what it says: a short answer proves the
         source was exhausted, not merely that our own post-filter discarded a
         lot.
+
+        `offset` is honoured. Unlike the live path, paging here is exact: the
+        ORDER BY is total (date, then transaction id), so successive pages
+        neither repeat nor omit a row. `exhausted` still describes only the page
+        that was fetched -- a short final page says nothing about the pages
+        skipped over, so the caller must not read it as whole-sample
+        completeness.
         """
         where: list[str] = []
         params: list[Any] = []
@@ -350,6 +432,7 @@ class SnapshotAdapter:
             params.append(bool(new_build))
 
         limit = max(1, int(limit))
+        offset = max(0, int(offset))
         # One more than asked for. The extra row is evidence, never data.
         fetch_limit = limit + 1
         direction = "DESC" if order_desc else "ASC"
@@ -359,7 +442,7 @@ class SnapshotAdapter:
             # transaction_id breaks same-date ties, so the order is total and
             # repeating a query cannot repeat or omit a row.
             + f" ORDER BY transfer_date {direction}, transaction_id ASC"
-            + f" LIMIT {fetch_limit}"
+            + f" LIMIT {fetch_limit} OFFSET {offset}"
         )
 
         with self._lock:
@@ -375,5 +458,6 @@ class SnapshotAdapter:
             transactions=[_row_to_transaction(r) for r in rows[:limit]],
             exhausted=exhausted,
             fetch_limit=fetch_limit,
+            offset=offset,
             completeness_basis=CompletenessBasis.LIMIT_PLUS_ONE if exhausted else None,
         )

--- a/property_core/snapshot/bootstrap.py
+++ b/property_core/snapshot/bootstrap.py
@@ -1,0 +1,187 @@
+"""Boot the snapshot once per server process, through the FastMCP lifespan.
+
+Spec section 4.10, which fixes this before PR 4 rather than leaving it to be
+discovered:
+
+* **Once per process, at startup.** A lazy first-use boot would put a twenty
+  second download in the path of whichever request happened to arrive first.
+* **Combined lifespans where the MCP app is mounted alongside FastAPI.**
+  Mounting does not chain lifespans; a lifespan that is never awaited is a boot
+  that never happens. `app/main.py` awaits the FastMCP lifespan explicitly.
+* **Process-scoped state** -- see `property_core.snapshot.state`.
+* **The filesystem single-flight lock is retained.** Lifespan wiring coordinates
+  nothing between the worker processes sharing a Machine; `flock` does.
+* **A startup failure leaves the server up on the live source.** UNREADY is a
+  normal outcome, not a startup error, so nothing here is allowed to raise into
+  the ASGI startup sequence.
+
+Everything is off unless `PPD_SNAPSHOT_ENABLED` is set. With it unset this module
+imports nothing from DuckDB and touches no filesystem.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, AsyncIterator, Optional
+
+from property_core.config import ppd_snapshot_enabled
+from property_core.snapshot import state
+
+log = logging.getLogger("property_core.snapshot.boot")
+
+#: Where the bundle is published. A local directory is supported so the whole
+#: path can be exercised without any network or cloud resource.
+SNAPSHOT_URL_ENV = "PPD_SNAPSHOT_URL"
+SNAPSHOT_DIR_ENV = "PPD_SNAPSHOT_DIR"
+#: Where it is materialized. Ephemeral: Fly's default rootfs, wiped on restart.
+SNAPSHOT_CACHE_ENV = "PPD_SNAPSHOT_CACHE_DIR"
+DEFAULT_CACHE_DIR = "/tmp/ppd-snapshot"
+
+#: Set once the boot has been attempted in this process. Idempotence is by
+#: attempt, not by success: a failed boot must not be retried by every worker
+#: thread that happens to call the lifespan again.
+_booted = False
+
+
+def _build_source() -> Any:
+    from property_core.snapshot.source import HttpObjectSource, LocalDirectorySource
+
+    directory = os.getenv(SNAPSHOT_DIR_ENV)
+    if directory:
+        return LocalDirectorySource(Path(directory))
+    url = os.getenv(SNAPSHOT_URL_ENV)
+    if not url:
+        raise RuntimeError(
+            f"{SNAPSHOT_URL_ENV} or {SNAPSHOT_DIR_ENV} must be set when "
+            f"PPD_SNAPSHOT_ENABLED is on"
+        )
+    return HttpObjectSource(url)
+
+
+def _materialize() -> None:
+    """Fetch, verify, validate and install. Raises; the caller degrades.
+
+    Split out as its own function so the lifespan's failure policy is visible in
+    one place, and so tests can substitute a materialization without standing up
+    an object store.
+    """
+    from property_core.snapshot.adapter import SnapshotAdapter
+    from property_core.snapshot.runtime import SnapshotRuntime
+    from property_core.snapshot.store import SnapshotStore
+
+    store = SnapshotStore(os.getenv(SNAPSHOT_CACHE_ENV, DEFAULT_CACHE_DIR))
+    runtime = SnapshotRuntime(source=_build_source(), store=store)
+    report = runtime.boot()
+
+    if not report.ready or not report.snapshot_dir or not report.version:
+        log.warning("snapshot boot did not produce a snapshot; using the live "
+                    "source (%s)", report.source_error)
+        return
+
+    record = store.verified_record(report.version)
+    if record is None:
+        log.warning("snapshot %s has no readable verification record; using the "
+                    "live source", report.version)
+        return
+
+    # READY is structural. This is where it becomes permission to route:
+    # schema, row count and an executed query, all before anything is served.
+    adapter = SnapshotAdapter.open(Path(report.snapshot_dir), record)
+    state.install(adapter, report)
+    log.info("snapshot %s validated and routable (coverage %s..%s)",
+             adapter.version, adapter.coverage_from, adapter.coverage_to)
+
+
+def boot_once() -> None:
+    """Attempt the boot at most once per process. Never raises."""
+    global _booted
+    if _booted:
+        return
+    _booted = True
+    if not ppd_snapshot_enabled():
+        return
+    try:
+        _materialize()
+    except Exception as exc:  # noqa: BLE001
+        # The server must come up. A snapshot that cannot be materialized or
+        # validated means the live source answers, which is the documented
+        # steady state after every restart anyway.
+        log.warning("snapshot boot failed (%s: %s); serving from the live source",
+                    type(exc).__name__, exc)
+
+
+def reset_for_tests() -> None:
+    """Forget that a boot was attempted. Test-only."""
+    global _booted
+    _booted = False
+    state.clear()
+
+
+@asynccontextmanager
+async def snapshot_lifespan() -> AsyncIterator[None]:
+    """Startup/shutdown for the snapshot source.
+
+    Installed on both FastMCP servers. `app/main.py` awaits the FastMCP lifespan
+    from inside the FastAPI lifespan, so the mounted deployment boots exactly
+    once too.
+    """
+    import anyio.to_thread
+
+    # The boot does blocking I/O -- network, disk, and a flock wait of up to
+    # LOCK_WAIT_SECONDS. Off the event loop so a co-hosted FastAPI app is not
+    # frozen while a sibling worker holds the single-flight lock.
+    await anyio.to_thread.run_sync(boot_once)
+    try:
+        yield
+    finally:
+        state.clear()
+
+
+def fastmcp_lifespan(server: Any):
+    """The lifespan callable FastMCP expects, ignoring the server argument."""
+    @asynccontextmanager
+    async def _lifespan(_server: Any) -> AsyncIterator[dict]:
+        async with snapshot_lifespan():
+            yield {}
+
+    return _lifespan
+
+
+def lifespan_is_installed(server: Any) -> bool:
+    """Whether `server` runs the snapshot boot lifespan.
+
+    Asserted by test against both MCP servers: one of them silently missing it
+    would mean that deployment never boots a snapshot, and the only symptom
+    would be permanently-live provenance nobody looked at.
+    """
+    return bool(getattr(server, "_ppd_snapshot_lifespan", False))
+
+
+def mark_installed(server: Any) -> Any:
+    """Record that this server carries the boot lifespan."""
+    setattr(server, "_ppd_snapshot_lifespan", True)
+    return server
+
+
+def snapshot_status() -> dict[str, Optional[object]]:
+    """A small, honest summary for health output and diagnostics."""
+    adapter = state.installed_adapter()
+    report = state.boot_report()
+    if adapter is None:
+        return {
+            "enabled": ppd_snapshot_enabled(),
+            "routable": False,
+            "source_error": getattr(report, "source_error", None),
+        }
+    return {
+        "enabled": ppd_snapshot_enabled(),
+        "routable": state.active_adapter() is not None,
+        "version": adapter.version,
+        "coverage_from": adapter.coverage_from,
+        "coverage_to": adapter.coverage_to,
+        "behind_advertised_release": getattr(report, "behind_advertised_release",
+                                             False),
+    }

--- a/property_core/snapshot/errors.py
+++ b/property_core/snapshot/errors.py
@@ -154,3 +154,39 @@ class SnapshotQueryError(SnapshotFailure):
 
     code = "snapshot_query_failed"
     retryable = True
+
+
+class SnapshotMetadataError(SnapshotFailure):
+    """Coverage metadata that routing cannot answer coverage questions from.
+
+    Routing decides what to refuse, what to narrow, and what a warning must say
+    entirely from `coverage_from`/`coverage_to`/`provisional_from`. Missing,
+    unparseable or contradictory bounds do not degrade those decisions -- they
+    silently remove them: a record with no bounds answered a 1995 request from an
+    eleven-year snapshot, reported null coverage, and claimed the sample was
+    complete. Rejected before routing, so the caller gets the live source.
+    """
+
+    code = "snapshot_metadata_invalid"
+    retryable = False
+
+    def __init__(self, detail: str, *, field: str = ""):
+        self.field = field
+        super().__init__(detail)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**super().to_dict(), "field": self.field}
+
+
+class SnapshotCoverageGapError(SnapshotFailure):
+    """The snapshot holds nothing in the window this surface must answer.
+
+    Distinct from `PPDCoverageError`, and the distinction is who the answer is
+    for. A caller who named dates outside coverage gets a refusal they can act
+    on. A caller of a bounded-`months` surface named no dates at all -- the
+    window was derived for them -- so refusing would blame them for a stale
+    snapshot. This is a snapshot failure, and the live source answers.
+    """
+
+    code = "snapshot_coverage_gap"
+    retryable = True

--- a/property_core/snapshot/errors.py
+++ b/property_core/snapshot/errors.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from property_core.exceptions import PPDError
+from property_core.exceptions import PPDError, SnapshotFailure
 
 
-class SnapshotExtraMissingError(PPDError):
+class SnapshotExtraMissingError(SnapshotFailure):
     """A snapshot feature was used without the optional dependency installed.
 
     Actionable by construction: the message names the extra to install, because
@@ -37,14 +37,14 @@ class SnapshotExtraMissingError(PPDError):
         return {**super().to_dict(), "extra": self.extra, "package": self.package}
 
 
-class BundleVerificationError(PPDError):
+class BundleVerificationError(SnapshotFailure):
     """A bundle failed size or digest verification, or the transfer was short."""
 
     code = "snapshot_bundle_verification_failed"
     retryable = True
 
 
-class InsufficientDiskSpaceError(PPDError):
+class InsufficientDiskSpaceError(SnapshotFailure):
     """Not enough free space to download and unpack the bundle.
 
     Checked BEFORE the transfer starts: filling the filesystem is worse than not
@@ -66,14 +66,14 @@ class InsufficientDiskSpaceError(PPDError):
                 "available_bytes": self.available}
 
 
-class DownloadDeadlineExceeded(PPDError):
+class DownloadDeadlineExceeded(SnapshotFailure):
     """The transfer exceeded its total budget or stalled."""
 
     code = "snapshot_download_deadline"
     retryable = True
 
 
-class ArchiveRejected(PPDError):
+class ArchiveRejected(SnapshotFailure):
     """An archive member violated a safety rule. Fail closed.
 
     ``rule`` names the violated invariant so a caller can tell a hostile archive
@@ -93,3 +93,64 @@ class ArchiveRejected(PPDError):
 
     def to_dict(self) -> dict[str, Any]:
         return {**super().to_dict(), "rule": self.rule, "member": self.member}
+
+
+class SnapshotSchemaError(SnapshotFailure):
+    """The materialized snapshot does not carry the columns routing needs.
+
+    A missing or mistyped column is not a query that returns nothing -- it is a
+    query that cannot be asked. Caught here so it becomes a live fallback rather
+    than an empty result set that reads as "no sales here".
+    """
+
+    code = "snapshot_schema_invalid"
+    retryable = False
+
+    def __init__(self, detail: str, *, column: str = ""):
+        self.column = column
+        super().__init__(detail)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**super().to_dict(), "column": self.column}
+
+
+class SnapshotRowCountError(SnapshotFailure):
+    """The snapshot holds a different number of rows than its record declares.
+
+    The verification record is written from the build's own count. A disagreement
+    means the directory is not the snapshot that was verified, whatever the file
+    inventory says.
+    """
+
+    code = "snapshot_row_count_mismatch"
+    retryable = False
+
+    def __init__(self, expected: int, found: int):
+        self.expected, self.found = expected, found
+        super().__init__(
+            f"snapshot holds {found} row(s); the verification record declares "
+            f"{expected}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**super().to_dict(), "expected_rows": self.expected,
+                "found_rows": self.found}
+
+
+class SnapshotNotQueryableError(SnapshotFailure):
+    """Structurally verified bytes that DuckDB cannot actually read.
+
+    Boot proves the archive was safe and the inventory exact. Neither implies the
+    Parquet files parse, so this is checked before the adapter is allowed to
+    serve anything.
+    """
+
+    code = "snapshot_not_queryable"
+    retryable = False
+
+
+class SnapshotQueryError(SnapshotFailure):
+    """A query against an already-validated snapshot failed at request time."""
+
+    code = "snapshot_query_failed"
+    retryable = True

--- a/property_core/snapshot/schema.py
+++ b/property_core/snapshot/schema.py
@@ -1,0 +1,64 @@
+"""The Parquet column contract a routable snapshot must satisfy.
+
+This is the interface between the build pipeline and the routing layer, and it
+is checked before a single request is served from a snapshot: a missing column
+is not a query returning nothing, it is a query that cannot be asked, and
+finding that out at request time would surface as an empty result -- the one
+thing an empty result must never mean.
+
+Two design points worth stating.
+
+**Geography is stored derived, not derived at query time.** `outcode` and
+`sector` are materialized columns, so an outcode search is `outcode = 'B5'`.
+There is no text-prefix comparison anywhere in the query path, which is why the
+`STRSTARTS("B5")` class of bug -- matching `B50`, twenty miles away -- cannot be
+expressed against this schema at all.
+
+**Types are checked, not just names.** `transfer_date` stored as VARCHAR would
+still answer a range filter, lexically, and return the wrong rows silently.
+
+The contract is "at least these columns, with these types". Extra columns are
+tolerated: a later build that adds one must not take the snapshot path down.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+#: Column -> the DuckDB type names accepted for it. A set rather than one name
+#: because more than one width is genuinely equivalent for our use (`price` as
+#: INTEGER or BIGINT), while VARCHAR for a date is not.
+REQUIRED_COLUMNS: Mapping[str, frozenset[str]] = {
+    "transaction_id": frozenset({"VARCHAR"}),
+    "price": frozenset({"BIGINT", "INTEGER", "HUGEINT"}),
+    "transfer_date": frozenset({"DATE"}),
+    "postcode": frozenset({"VARCHAR"}),
+    #: Derived geography. The reason outcode/sector membership is exact.
+    "outcode": frozenset({"VARCHAR"}),
+    "sector": frozenset({"VARCHAR"}),
+    "property_type": frozenset({"VARCHAR"}),
+    #: PPD's `duration` column; the API calls it `estate_type` (F/L).
+    "duration": frozenset({"VARCHAR"}),
+    #: PPD's `ppd_category` column; the API calls it `transaction_category` (A/B).
+    "ppd_category": frozenset({"VARCHAR"}),
+    "new_build": frozenset({"BOOLEAN"}),
+    "paon": frozenset({"VARCHAR"}),
+    "saon": frozenset({"VARCHAR"}),
+    "street": frozenset({"VARCHAR"}),
+    "locality": frozenset({"VARCHAR"}),
+    "town": frozenset({"VARCHAR"}),
+    "district": frozenset({"VARCHAR"}),
+    "county": frozenset({"VARCHAR"}),
+}
+
+#: Columns the adapter projects, in the order the row mapper reads them.
+PROJECTION: tuple[str, ...] = (
+    "transaction_id", "price", "transfer_date", "postcode", "property_type",
+    "duration", "ppd_category", "new_build", "paon", "saon", "street",
+    "locality", "town", "district", "county",
+)
+
+
+def normalise_type(duckdb_type: str) -> str:
+    """DuckDB reports e.g. `DECIMAL(18,3)`; compare on the base name."""
+    return duckdb_type.strip().upper().split("(", 1)[0]

--- a/property_core/snapshot/state.py
+++ b/property_core/snapshot/state.py
@@ -1,0 +1,78 @@
+"""Process-scoped snapshot state.
+
+**Process-scoped, deliberately.** The materialization belongs to the process and
+the Machine it runs on, not to any client. Holding it in MCP session state --
+the obvious-looking alternative -- would re-boot for every client that connects,
+leak one client's adapter into another's reconnect, and tie a filesystem
+resource to a lifetime that has nothing to do with it. There is no session
+anything in this module and there must never be.
+
+The state is a module global because a process has exactly one of these, the
+same way it has one working directory. Guarded by a lock because uvicorn serves
+concurrently and boot happens while requests may already be arriving.
+
+Nothing here decides *whether* to use a snapshot beyond the flag: installing is
+the boot layer's job, and `active_adapter()` returning `None` is the normal,
+expected state -- it means the caller uses the live source.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Optional
+
+from property_core.config import ppd_snapshot_enabled
+
+_lock = threading.Lock()
+_adapter: Any = None
+_boot_report: Any = None
+
+
+def install(adapter: Any, report: Any = None) -> None:
+    """Make a validated adapter the process's snapshot source.
+
+    Only a validated adapter reaches here: `SnapshotAdapter.open` raises rather
+    than returning an unusable one, so there is no half-installed state.
+    """
+    global _adapter, _boot_report
+    with _lock:
+        _adapter = adapter
+        _boot_report = report
+
+
+def active_adapter() -> Optional[Any]:
+    """The adapter to route to, or `None` to use the live source.
+
+    The flag is consulted on every call, not once at import. `PPD_SNAPSHOT_ENABLED=0`
+    plus a restart is the documented rollback, and reading the flag here means an
+    installed adapter cannot outlive the flag that authorised it.
+    """
+    if not ppd_snapshot_enabled():
+        return None
+    with _lock:
+        return _adapter
+
+
+def installed_adapter() -> Optional[Any]:
+    """What is installed, regardless of the flag. For diagnostics and shutdown."""
+    with _lock:
+        return _adapter
+
+
+def boot_report() -> Optional[Any]:
+    with _lock:
+        return _boot_report
+
+
+def clear() -> None:
+    """Drop the adapter and close it. Safe to call when nothing is installed."""
+    global _adapter, _boot_report
+    with _lock:
+        adapter, _adapter, _boot_report = _adapter, None, None
+    if adapter is not None:
+        close = getattr(adapter, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:  # noqa: BLE001 -- shutdown must not raise
+                pass

--- a/property_core/yield_service.py
+++ b/property_core/yield_service.py
@@ -69,6 +69,7 @@ async def calculate_yield(
         return YieldAnalysis(
             postcode=postcode,
             warnings=tuple(comps.warnings),
+            sale_provenance=comps.provenance,
             median_sale_price=comps.median,
             sale_count=comps.count,
             thin_market=comps.thin_market,
@@ -115,6 +116,7 @@ async def calculate_yield(
         return YieldAnalysis(
             postcode=postcode,
             warnings=tuple(comps.warnings),
+            sale_provenance=comps.provenance,
             median_sale_price=comps.median,
             sale_count=comps.count,
             thin_market=comps.thin_market,
@@ -133,6 +135,7 @@ async def calculate_yield(
         # The yield divides rent by the comps median, so an incomplete sales
         # window makes this figure equally uncertain. The caveat travels with it.
         warnings=tuple(comps.warnings),
+        sale_provenance=comps.provenance,
         median_sale_price=comps.median,
         sale_count=comps.count,
         median_monthly_rent=median_rent,

--- a/tests/fixtures/ppd/response_contract_golden.json
+++ b/tests/fixtures/ppd/response_contract_golden.json
@@ -1,7 +1,7 @@
 {
   "cli.ppd_comps": {
     "exit_code": 0,
-    "stdout": "{\n  \"query\": {\n    \"postcode\": \"B5 4BX\",\n    \"property_type\": null,\n    \"months\": 24,\n    \"search_level\": \"sector\",\n    \"address\": null\n  },\n  \"count\": 3,\n  \"median\": 250000,\n  \"mean\": 250000,\n  \"percentile_25\": null,\n  \"percentile_75\": null,\n  \"min\": 190000,\n  \"max\": 310000,\n  \"thin_market\": true,\n  \"warnings\": [\n    \"auto-escalation not applied: live-source completeness cannot establish safe\nescalation from sector to district; returning the requested area\"\n  ],\n  \"escalated_from\": null,\n  \"escalated_to\": null,\n  \"median_price_per_sqft\": null,\n  \"epc_match_rate\": null,\n  \"subject_price_percentile\": null,\n  \"subject_vs_median_pct\": null,\n  \"transactions\": [\n    {\n      \"transaction_id\": \"{AAAAAAAA-0000-0000-0000-000000000001}\",\n      \"price\": 250000,\n      \"date\": \"2025-06-01\",\n      \"postcode\": \"B5 4BX\",\n      \"property_type\": \"F\",\n      \"estate_type\": \"L\",\n      \"transaction_category\": \"A\",\n      \"new_build\": false,\n      \"paon\": \"33\",\n      \"saon\": \"APARTMENT 1\",\n      \"street\": \"ESSEX STREET\",\n      \"town\": \"BIRMINGHAM\",\n      \"county\": \"WEST MIDLANDS\",\n      \"locality\": \"\",\n      \"district\": \"BIRMINGHAM\",\n      \"epc_match\": null,\n      \"epc_match_score\": null,\n      \"epc_match_method\": null,\n      \"epc_floor_area_sqm\": null,\n      \"epc_floor_area_sqft\": null,\n      \"price_per_sqm\": null,\n      \"price_per_sqft\": null,\n      \"epc_rating\": null,\n      \"epc_score\": null,\n      \"epc_construction_age\": null,\n      \"epc_built_form\": null\n    },\n    {\n      \"transaction_id\": \"{AAAAAAAA-0000-0000-0000-000000000002}\",\n      \"price\": 310000,\n      \"date\": \"2025-03-14\",\n      \"postcode\": \"B5 4BX\",\n      \"property_type\": \"T\",\n      \"estate_type\": \"F\",\n      \"transaction_category\": \"A\",\n      \"new_build\": false,\n      \"paon\": \"35\",\n      \"saon\": \"\",\n      \"street\": \"ESSEX STREET\",\n      \"town\": \"BIRMINGHAM\",\n      \"county\": \"WEST MIDLANDS\",\n      \"locality\": \"\",\n      \"district\": \"BIRMINGHAM\",\n      \"epc_match\": null,\n      \"epc_match_score\": null,\n      \"epc_match_method\": null,\n      \"epc_floor_area_sqm\": null,\n      \"epc_floor_area_sqft\": null,\n      \"price_per_sqm\": null,\n      \"price_per_sqft\": null,\n      \"epc_rating\": null,\n      \"epc_score\": null,\n      \"epc_construction_age\": null,\n      \"epc_built_form\": null\n    },\n    {\n      \"transaction_id\": \"{AAAAAAAA-0000-0000-0000-000000000003}\",\n      \"price\": 190000,\n      \"date\": \"2024-11-02\",\n      \"postcode\": \"B5 4BY\",\n      \"property_type\": \"F\",\n      \"estate_type\": \"L\",\n      \"transaction_category\": \"A\",\n      \"new_build\": true,\n      \"paon\": \"12\",\n      \"saon\": \"\",\n      \"street\": \"GOOCH STREET\",\n      \"town\": \"BIRMINGHAM\",\n      \"county\": \"WEST MIDLANDS\",\n      \"locality\": \"\",\n      \"district\": \"BIRMINGHAM\",\n      \"epc_match\": null,\n      \"epc_match_score\": null,\n      \"epc_match_method\": null,\n      \"epc_floor_area_sqm\": null,\n      \"epc_floor_area_sqft\": null,\n      \"price_per_sqm\": null,\n      \"price_per_sqft\": null,\n      \"epc_rating\": null,\n      \"epc_score\": null,\n      \"epc_construction_age\": null,\n      \"epc_built_form\": null\n    }\n  ],\n  \"subject_property\": null\n}\n"
+    "stdout": "{\n  \"query\": {\n    \"postcode\": \"B5 4BX\",\n    \"property_type\": null,\n    \"months\": 24,\n    \"search_level\": \"sector\",\n    \"address\": null\n  },\n  \"count\": 3,\n  \"median\": 250000,\n  \"mean\": 250000,\n  \"percentile_25\": null,\n  \"percentile_75\": null,\n  \"min\": 190000,\n  \"max\": 310000,\n  \"thin_market\": true,\n  \"warnings\": [\n    \"auto-escalation not applied: live-source completeness cannot establish safe escalation from sector to district; returning the requested area\"\n  ],\n  \"escalated_from\": null,\n  \"escalated_to\": null,\n  \"median_price_per_sqft\": null,\n  \"epc_match_rate\": null,\n  \"subject_price_percentile\": null,\n  \"subject_vs_median_pct\": null,\n  \"transactions\": [\n    {\n      \"transaction_id\": \"{AAAAAAAA-0000-0000-0000-000000000001}\",\n      \"price\": 250000,\n      \"date\": \"2025-06-01\",\n      \"postcode\": \"B5 4BX\",\n      \"property_type\": \"F\",\n      \"estate_type\": \"L\",\n      \"transaction_category\": \"A\",\n      \"new_build\": false,\n      \"paon\": \"33\",\n      \"saon\": \"APARTMENT 1\",\n      \"street\": \"ESSEX STREET\",\n      \"town\": \"BIRMINGHAM\",\n      \"county\": \"WEST MIDLANDS\",\n      \"locality\": \"\",\n      \"district\": \"BIRMINGHAM\",\n      \"epc_match\": null,\n      \"epc_match_score\": null,\n      \"epc_match_method\": null,\n      \"epc_floor_area_sqm\": null,\n      \"epc_floor_area_sqft\": null,\n      \"price_per_sqm\": null,\n      \"price_per_sqft\": null,\n      \"epc_rating\": null,\n      \"epc_score\": null,\n      \"epc_construction_age\": null,\n      \"epc_built_form\": null\n    },\n    {\n      \"transaction_id\": \"{AAAAAAAA-0000-0000-0000-000000000002}\",\n      \"price\": 310000,\n      \"date\": \"2025-03-14\",\n      \"postcode\": \"B5 4BX\",\n      \"property_type\": \"T\",\n      \"estate_type\": \"F\",\n      \"transaction_category\": \"A\",\n      \"new_build\": false,\n      \"paon\": \"35\",\n      \"saon\": \"\",\n      \"street\": \"ESSEX STREET\",\n      \"town\": \"BIRMINGHAM\",\n      \"county\": \"WEST MIDLANDS\",\n      \"locality\": \"\",\n      \"district\": \"BIRMINGHAM\",\n      \"epc_match\": null,\n      \"epc_match_score\": null,\n      \"epc_match_method\": null,\n      \"epc_floor_area_sqm\": null,\n      \"epc_floor_area_sqft\": null,\n      \"price_per_sqm\": null,\n      \"price_per_sqft\": null,\n      \"epc_rating\": null,\n      \"epc_score\": null,\n      \"epc_construction_age\": null,\n      \"epc_built_form\": null\n    },\n    {\n      \"transaction_id\": \"{AAAAAAAA-0000-0000-0000-000000000003}\",\n      \"price\": 190000,\n      \"date\": \"2024-11-02\",\n      \"postcode\": \"B5 4BY\",\n      \"property_type\": \"F\",\n      \"estate_type\": \"L\",\n      \"transaction_category\": \"A\",\n      \"new_build\": true,\n      \"paon\": \"12\",\n      \"saon\": \"\",\n      \"street\": \"GOOCH STREET\",\n      \"town\": \"BIRMINGHAM\",\n      \"county\": \"WEST MIDLANDS\",\n      \"locality\": \"\",\n      \"district\": \"BIRMINGHAM\",\n      \"epc_match\": null,\n      \"epc_match_score\": null,\n      \"epc_match_method\": null,\n      \"epc_floor_area_sqm\": null,\n      \"epc_floor_area_sqft\": null,\n      \"price_per_sqm\": null,\n      \"price_per_sqft\": null,\n      \"epc_rating\": null,\n      \"epc_score\": null,\n      \"epc_construction_age\": null,\n      \"epc_built_form\": null\n    }\n  ],\n  \"subject_property\": null,\n  \"provenance\": {\n    \"source\": \"sparql\",\n    \"source_release\": null,\n    \"snapshot_imported_at\": null,\n    \"coverage_from\": null,\n    \"coverage_to\": null,\n    \"freshness_days\": null,\n    \"recent_period_provisional\": false,\n    \"older_records_exist\": null,\n    \"sample_count\": 3,\n    \"sample_limit\": 50,\n    \"sample_complete\": true,\n    \"completeness_basis\": \"source_exhausted\",\n    \"attribution_ref\": \"/v1/meta#attribution\",\n    \"warnings\": [\n      \"auto-escalation not applied: live-source completeness cannot establish safe escalation from sector to district; returning the requested area\"\n    ]\n  }\n}\n"
   },
   "core.comps": {
     "count": 3,
@@ -15,6 +15,22 @@
     "min": 190000,
     "percentile_25": null,
     "percentile_75": null,
+    "provenance": {
+      "attribution_ref": "/v1/meta#attribution",
+      "completeness_basis": "source_exhausted",
+      "coverage_from": null,
+      "coverage_to": null,
+      "freshness_days": null,
+      "older_records_exist": null,
+      "recent_period_provisional": false,
+      "sample_complete": true,
+      "sample_count": 3,
+      "sample_limit": 50,
+      "snapshot_imported_at": null,
+      "source": "sparql",
+      "source_release": null,
+      "warnings": []
+    },
     "query": {
       "address": null,
       "months": 24,
@@ -118,6 +134,22 @@
     "count": 3,
     "limit": 10,
     "offset": 0,
+    "provenance": {
+      "attribution_ref": "/v1/meta#attribution",
+      "completeness_basis": "source_exhausted",
+      "coverage_from": null,
+      "coverage_to": null,
+      "freshness_days": null,
+      "older_records_exist": null,
+      "recent_period_provisional": false,
+      "sample_complete": true,
+      "sample_count": 3,
+      "sample_limit": 10,
+      "snapshot_imported_at": null,
+      "source": "sparql",
+      "source_release": null,
+      "warnings": []
+    },
     "raw": null,
     "results": [
       {
@@ -178,6 +210,22 @@
     "count": 3,
     "limit": 10,
     "offset": 0,
+    "provenance": {
+      "attribution_ref": "/v1/meta#attribution",
+      "completeness_basis": "source_exhausted",
+      "coverage_from": null,
+      "coverage_to": null,
+      "freshness_days": null,
+      "older_records_exist": null,
+      "recent_period_provisional": false,
+      "sample_complete": true,
+      "sample_count": 3,
+      "sample_limit": 10,
+      "snapshot_imported_at": null,
+      "source": "sparql",
+      "source_release": null,
+      "warnings": []
+    },
     "raw": null,
     "results": [
       {
@@ -238,6 +286,22 @@
     "count": 3,
     "limit": 10,
     "offset": 0,
+    "provenance": {
+      "attribution_ref": "/v1/meta#attribution",
+      "completeness_basis": "source_exhausted",
+      "coverage_from": null,
+      "coverage_to": null,
+      "freshness_days": null,
+      "older_records_exist": null,
+      "recent_period_provisional": false,
+      "sample_complete": true,
+      "sample_count": 3,
+      "sample_limit": 10,
+      "snapshot_imported_at": null,
+      "source": "sparql",
+      "source_release": null,
+      "warnings": []
+    },
     "results": [
       {
         "county": "WEST MIDLANDS",
@@ -306,6 +370,24 @@
       "min": 190000,
       "percentile_25": null,
       "percentile_75": null,
+      "provenance": {
+        "attribution_ref": "/v1/meta#attribution",
+        "completeness_basis": "source_exhausted",
+        "coverage_from": null,
+        "coverage_to": null,
+        "freshness_days": null,
+        "older_records_exist": null,
+        "recent_period_provisional": false,
+        "sample_complete": true,
+        "sample_count": 3,
+        "sample_limit": 50,
+        "snapshot_imported_at": null,
+        "source": "sparql",
+        "source_release": null,
+        "warnings": [
+          "auto-escalation not applied: live-source completeness cannot establish safe escalation from sector to district; returning the requested area"
+        ]
+      },
       "query": {
         "address": null,
         "months": 24,
@@ -434,6 +516,22 @@
       "count": 3,
       "limit": 10,
       "offset": 0,
+      "provenance": {
+        "attribution_ref": "/v1/meta#attribution",
+        "completeness_basis": "source_exhausted",
+        "coverage_from": null,
+        "coverage_to": null,
+        "freshness_days": null,
+        "older_records_exist": null,
+        "recent_period_provisional": false,
+        "sample_complete": true,
+        "sample_count": 3,
+        "sample_limit": 10,
+        "snapshot_imported_at": null,
+        "source": "sparql",
+        "source_release": null,
+        "warnings": []
+      },
       "raw": null,
       "results": [
         {

--- a/tests/ppd_golden_harness.py
+++ b/tests/ppd_golden_harness.py
@@ -92,10 +92,15 @@ def _bindings():
 #: suite, where other tests clear these vars.
 AMBIENT_CREDENTIAL_VARS = ("EPC_API_TOKEN", "EPC_API_EMAIL", "EPC_API_KEY")
 
+#: Also cleared. The golden captures the LIVE-path contract; a developer with
+#: the snapshot flag set in their shell would otherwise capture a different one,
+#: and the same run would then fail for everyone else.
+AMBIENT_FLAG_VARS = ("PPD_SNAPSHOT_ENABLED",)
+
 
 @contextmanager
 def deterministic_ppd():
-    """Patch the transport seam, neutralise ambient credentials, block sockets."""
+    """Patch the transport seam, neutralise the ambient environment, block sockets."""
     import os
     import socket
 
@@ -110,7 +115,7 @@ def deterministic_ppd():
         "property_core.ppd_client.PricePaidDataClient._fetch_sparql",
         return_value=payload,
     ), patch.object(socket.socket, "connect", _no_network):
-        for var in AMBIENT_CREDENTIAL_VARS:
+        for var in AMBIENT_CREDENTIAL_VARS + AMBIENT_FLAG_VARS:
             os.environ.pop(var, None)
         yield
 
@@ -134,9 +139,15 @@ def capture() -> dict:
         search = svc.search_transactions(postcode="B5 4BX", postcode_prefix=None, limit=10)
         out["core.search_transactions"] = _sortable(
             {
-                **{k: v for k, v in search.items() if k != "results"},
+                **{k: v for k, v in search.items()
+                   if k not in ("results", "provenance")},
                 "results": [t.model_dump(mode="json", exclude_none=True)
                             for t in search["results"]],
+                # Dumped like `results`: the core service returns models, and
+                # comparing their repr() would lock the repr rather than the
+                # response contract.
+                "provenance": (search["provenance"].model_dump(mode="json")
+                               if search.get("provenance") else None),
             }
         )
 

--- a/tests/snapshot/conftest.py
+++ b/tests/snapshot/conftest.py
@@ -34,3 +34,177 @@ def manifest_for():
 @pytest.fixture
 def store_root(tmp_path: Path) -> Path:
     return tmp_path / "snapshots"
+
+
+# ---------------------------------------------------------------------------
+# Source-routing fixtures (PR 4)
+#
+# Two mutually exclusive worlds, chosen per test by fixture name:
+#
+#   snapshot_routing -- a validated adapter installed in process-scoped state,
+#                       with PPD_SNAPSHOT_ENABLED on;
+#   live_only        -- nothing installed, flag off.
+#
+# The flag is set through the real environment variable rather than by patching
+# the accessor, so these also prove the flag genuinely gates routing.
+# ---------------------------------------------------------------------------
+
+from dataclasses import dataclass, field  # noqa: E402
+from typing import Any, Optional  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch):
+    """No test in this package may reach the network.
+
+    A routing test that accidentally falls through to the real SPARQL endpoint
+    does not fail -- it hangs, or worse, passes for the wrong reason against
+    whatever the upstream happens to hold today. Blocked at the PPD client's own
+    fetch seams rather than at `urlopen`, so the boot-runtime tests that stand up
+    a loopback HTTP server on purpose keep working.
+    """
+    from property_core.ppd_client import PricePaidDataClient
+
+    def _blocked(*args, **kwargs):
+        raise AssertionError(
+            "a snapshot test attempted a real Land Registry call; patch the "
+            "transport seam (fake_live / recording_sparql) instead")
+
+    monkeypatch.setattr(PricePaidDataClient, "_fetch_sparql", _blocked)
+    monkeypatch.setattr(PricePaidDataClient, "_fetch_json", _blocked)
+
+
+@pytest.fixture
+def live_only(monkeypatch):
+    from property_core.snapshot import state
+
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "0")
+    state.clear()
+    yield
+    state.clear()
+
+
+@dataclass
+class _Routing:
+    version: str
+    adapter: Any
+    directory: Path
+
+
+@pytest.fixture
+def snapshot_routing(tmp_path, monkeypatch):
+    pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+    from property_core.snapshot import state
+    from property_core.snapshot.adapter import SnapshotAdapter
+    from tests.snapshot.snapshot_fixtures import build_snapshot, default_rows
+
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    directory, record = build_snapshot(tmp_path / "store", default_rows())
+    adapter = SnapshotAdapter.open(directory, record)
+    state.clear()
+    state.install(adapter)
+    try:
+        yield _Routing(version=record.version, adapter=adapter, directory=directory)
+    finally:
+        state.clear()
+
+
+@dataclass
+class _FakeLive:
+    """Stands in for the live SPARQL transport at the client seam."""
+
+    rows: list = field(default_factory=list)
+    calls: int = 0
+    raises: Optional[BaseException] = None
+    queries: list = field(default_factory=list)
+    #: Override to model a page with NO exhaustion observation. Left None, the
+    #: fake reports what a real short page would report.
+    evidence: Any = None
+
+
+@pytest.fixture
+def fake_live(monkeypatch):
+    """Patch `search_with_evidence` so no test ever reaches the network."""
+    from property_core.models.ppd import PPDTransaction
+    from property_core.ppd_client import PricePaidDataClient, SearchPage
+    from property_core.provenance import TransportEvidence
+
+    spy = _FakeLive(rows=[
+        PPDTransaction(transaction_id="LIVE-1", price=190_000, date="2013-04-01",
+                       postcode="B5 7AA", property_type="F", estate_type="L",
+                       transaction_category="A", new_build=False,
+                       paon="1", street="HIGH STREET", town="BIRMINGHAM"),
+    ])
+
+    def _fake(self, **kwargs):
+        spy.calls += 1
+        spy.queries.append(kwargs)
+        if spy.raises is not None:
+            raise spy.raises
+        rows = list(spy.rows)[: kwargs.get("limit", 20)]
+        evidence = spy.evidence
+        if evidence is None:
+            evidence = TransportEvidence(
+                raw_bindings_returned=len(rows),
+                fetch_limit=max(kwargs.get("limit", 20), 1))
+        return SearchPage(transactions=rows, evidence=evidence)
+
+    monkeypatch.setattr(PricePaidDataClient, "search_with_evidence", _fake)
+    return spy
+
+
+@dataclass
+class _ProbeSpy:
+    calls: list = field(default_factory=list)
+    result: Optional[bool] = None
+    raises: Optional[BaseException] = None
+
+
+@pytest.fixture
+def probe_spy(monkeypatch):
+    """Observe the existence probe without issuing one."""
+    from property_core.ppd_probe import ExistenceProbe
+
+    spy = _ProbeSpy()
+
+    def _fake(self, *, postcode, postcode_prefix, coverage_from):
+        spy.calls.append({"postcode": postcode, "postcode_prefix": postcode_prefix,
+                          "coverage_from": coverage_from})
+        if spy.raises is not None:
+            return None
+        return spy.result
+
+    monkeypatch.setattr(ExistenceProbe, "older_records_exist", _fake)
+    return spy
+
+
+@dataclass
+class _RecordingSparql:
+    client: Any = None
+    queries: list = field(default_factory=list)
+    raise_on_call: Optional[BaseException] = None
+
+
+@pytest.fixture
+def recording_sparql(monkeypatch):
+    """A real probe client whose HTTP seam records the query and answers empty."""
+    import urllib.parse
+
+    from property_core.ppd_client import PricePaidDataClient
+
+    recorder = _RecordingSparql()
+
+    def _fake_fetch(self, encoded_query: bytes):
+        query = urllib.parse.parse_qs(encoded_query.decode())["query"][0]
+        recorder.queries.append(query)
+        if recorder.raise_on_call is not None:
+            raise recorder.raise_on_call
+        return {"results": {"bindings": []}}
+
+    monkeypatch.setattr(PricePaidDataClient, "_fetch_sparql", _fake_fetch)
+
+    from property_core.ppd_probe import build_probe_client
+
+    recorder.client = build_probe_client()
+    return recorder

--- a/tests/snapshot/snapshot_fixtures.py
+++ b/tests/snapshot/snapshot_fixtures.py
@@ -1,0 +1,201 @@
+"""Tiny synthetic Parquet snapshots. Nothing large or real is ever committed.
+
+Every snapshot built here is a handful of rows written by the same DuckDB the
+adapter reads with, laid out exactly as the build pipeline will lay one out:
+one directory per year partition, one Parquet file inside it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from property_core.snapshot.models import VerificationRecord
+from property_core.snapshot.store import VERIFIED_RECORD, SnapshotStore
+
+#: Column order the fixture writes. The adapter's contract is by NAME, not
+#: position; this is only the order the fixture happens to emit.
+COLUMNS = (
+    "transaction_id", "price", "transfer_date", "postcode", "outcode", "sector",
+    "property_type", "duration", "ppd_category", "new_build",
+    "paon", "saon", "street", "locality", "town", "district", "county",
+    "area", "year",
+)
+
+
+def row(
+    transaction_id: str,
+    postcode: str,
+    transfer_date: str,
+    price: int = 250_000,
+    *,
+    property_type: str = "F",
+    duration: str = "L",
+    ppd_category: str = "A",
+    new_build: bool = False,
+    paon: Optional[str] = "1",
+    saon: Optional[str] = None,
+    street: Optional[str] = "HIGH STREET",
+    locality: Optional[str] = None,
+    town: Optional[str] = "BIRMINGHAM",
+    district: Optional[str] = "BIRMINGHAM",
+    county: Optional[str] = "WEST MIDLANDS",
+) -> dict[str, Any]:
+    """One snapshot row with outcode/sector/area/year derived as the build does."""
+    pc = postcode.strip().upper()
+    head, _, tail = pc.partition(" ")
+    return {
+        "transaction_id": transaction_id,
+        "price": price,
+        "transfer_date": transfer_date,
+        "postcode": pc,
+        "outcode": head or None,
+        "sector": f"{head} {tail[0]}" if tail else None,
+        "property_type": property_type,
+        "duration": duration,
+        "ppd_category": ppd_category,
+        "new_build": new_build,
+        "paon": paon,
+        "saon": saon,
+        "street": street,
+        "locality": locality,
+        "town": town,
+        "district": district,
+        "county": county,
+        "area": "".join(c for c in head if c.isalpha()) or "UNKNOWN",
+        "year": int(transfer_date[:4]),
+    }
+
+
+def _sql_literal(value: Any) -> str:
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, int):
+        return str(value)
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+#: DuckDB type for each column. Overridable so a test can write a snapshot with
+#: the wrong type for one column and prove the schema gate rejects it.
+DEFAULT_TYPES = {
+    "transaction_id": "VARCHAR", "price": "BIGINT", "transfer_date": "DATE",
+    "postcode": "VARCHAR", "outcode": "VARCHAR", "sector": "VARCHAR",
+    "property_type": "VARCHAR", "duration": "VARCHAR", "ppd_category": "VARCHAR",
+    "new_build": "BOOLEAN", "paon": "VARCHAR", "saon": "VARCHAR",
+    "street": "VARCHAR", "locality": "VARCHAR", "town": "VARCHAR",
+    "district": "VARCHAR", "county": "VARCHAR", "area": "VARCHAR", "year": "INTEGER",
+}
+
+
+def write_parquet_snapshot(
+    directory: Path,
+    rows: Iterable[dict[str, Any]],
+    *,
+    types: Optional[dict[str, str]] = None,
+    drop_columns: Iterable[str] = (),
+) -> int:
+    """Write rows into `directory` as year=<YYYY>/data.parquet. Returns file count."""
+    import duckdb
+
+    types = {**DEFAULT_TYPES, **(types or {})}
+    keep = [c for c in COLUMNS if c not in set(drop_columns)]
+    rows = list(rows)
+    directory.mkdir(parents=True, exist_ok=True)
+
+    con = duckdb.connect()
+    try:
+        projection = ", ".join(f"CAST(c{i} AS {types[name]}) AS {name}"
+                               for i, name in enumerate(keep))
+        if rows:
+            values = ", ".join(
+                "(" + ", ".join(_sql_literal(r.get(name)) for name in keep) + ")"
+                for r in rows
+            )
+            con.execute(
+                f"CREATE TABLE src AS SELECT {projection} FROM (VALUES {values}) "
+                f"AS t({', '.join(f'c{i}' for i in range(len(keep)))})"
+            )
+        else:
+            empty = ", ".join(f"CAST(NULL AS {types[name]}) AS {name}" for name in keep)
+            con.execute(f"CREATE TABLE src AS SELECT {empty} WHERE 1=0")
+
+        years = sorted({r["year"] for r in rows}) or [1970]
+        for year in years:
+            part = directory / f"year={year}"
+            part.mkdir(parents=True, exist_ok=True)
+            con.execute(
+                f"COPY (SELECT * FROM src WHERE year = {year}) "
+                f"TO '{part / 'data.parquet'}' (FORMAT parquet)"
+            )
+        return len(years)
+    finally:
+        con.close()
+
+
+def build_snapshot(
+    root: Path,
+    rows: Iterable[dict[str, Any]],
+    *,
+    version: str = "v20260101T000000Z",
+    coverage_from: str = "2016-01-01",
+    coverage_to: str = "2026-06-30",
+    provisional_from: Optional[str] = "2026-04-01",
+    declared_rows: Optional[int] = None,
+    types: Optional[dict[str, str]] = None,
+    drop_columns: Iterable[str] = (),
+) -> tuple[Path, VerificationRecord]:
+    """A materialized snapshot directory plus the record the store would hold.
+
+    `declared_rows` defaults to the real count; pass a different value to prove
+    the row-count gate rejects a snapshot that does not hold what it claims.
+    """
+    rows = list(rows)
+    store = SnapshotStore(root)
+    directory = store.snapshots_dir / version
+    files = write_parquet_snapshot(directory, rows, types=types,
+                                   drop_columns=drop_columns)
+
+    record = VerificationRecord(
+        version=version,
+        bundle_sha256="0" * 64,
+        bundle_bytes=1024,
+        bundle_object=f"snapshot-{version}.tar",
+        parquet_files=files,
+        rows=len(rows) if declared_rows is None else declared_rows,
+        verified_at="2026-01-01T00:00:00Z",
+        coverage_from=coverage_from,
+        coverage_to=coverage_to,
+        provisional_from=provisional_from,
+        layout="year",
+        duckdb_version="1.5.5",
+        inventory=SnapshotStore.inventory(directory),
+    )
+    (directory / VERIFIED_RECORD).write_text(record.model_dump_json(indent=2))
+    store.set_current(version)
+    return directory, record
+
+
+def default_rows() -> list[dict[str, Any]]:
+    """A small corpus with the geography traps the spec names.
+
+    `B5` and `B50` are different places ~20 miles apart; `B5 6` and `B5 7` are
+    different sectors. Same-date ties exist so ordering can be asserted.
+    """
+    return [
+        row("T-B57-2024", "B5 7AA", "2024-03-01", 200_000),
+        row("T-B57-2023", "B5 7AB", "2023-06-15", 210_000, property_type="T"),
+        row("T-B56-2024", "B5 6QQ", "2024-03-01", 300_000),
+        row("T-B50-2024", "B50 4AA", "2024-05-01", 400_000),
+        row("T-B50-2022", "B50 4AB", "2022-05-01", 380_000),
+        row("T-M37-2024", "M3 7AA", "2024-01-10", 250_000, town="MANCHESTER"),
+        row("T-M38-2024", "M3 8AA", "2024-01-10", 260_000, town="MANCHESTER"),
+        row("T-B57-CATB", "B5 7AC", "2024-02-01", 999_000, ppd_category="B"),
+        row("T-B57-OTHER", "B5 7AD", "2024-02-02", 111_000, property_type="O"),
+    ]
+
+
+def read_verified(directory: Path) -> VerificationRecord:
+    return VerificationRecord(**json.loads((directory / VERIFIED_RECORD).read_text()))

--- a/tests/snapshot/test_adapter_queries.py
+++ b/tests/snapshot/test_adapter_queries.py
@@ -1,0 +1,148 @@
+"""Adapter query semantics: geography, filters, ordering, completeness.
+
+Spec section 7.1 tests 1-4 and 20/21b, asserted against the snapshot adapter.
+Geography is the load-bearing one: `B5` and `B50` are ~20 miles apart, and a
+text-prefix match conflates them. The adapter filters on the *derived* outcode
+and sector columns, so the class of bug that produced `STRSTARTS("B5")` cannot
+be expressed here at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+from property_core.provenance import CompletenessBasis  # noqa: E402
+from property_core.snapshot.adapter import SnapshotAdapter  # noqa: E402
+from tests.snapshot.snapshot_fixtures import (  # noqa: E402
+    build_snapshot,
+    default_rows,
+    row,
+)
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    directory, record = build_snapshot(tmp_path, default_rows())
+    with SnapshotAdapter.open(directory, record) as a:
+        yield a
+
+
+def ids(page) -> set[str]:
+    return {t.transaction_id for t in page.transactions}
+
+
+def test_outcode_search_never_matches_a_longer_outcode(adapter):
+    """Spec test 1. B5 must never return B50."""
+    page = adapter.search(postcode_prefix="B5", limit=50)
+    assert ids(page) == {"T-B57-2024", "T-B57-2023", "T-B56-2024",
+                         "T-B57-CATB", "T-B57-OTHER"}
+    assert not any(t.postcode.startswith("B50") for t in page.transactions)
+
+
+def test_sector_search_is_isolated(adapter):
+    """Spec test 2. M3 7 returns only M3 7, never M3 8."""
+    page = adapter.search(postcode_prefix="M3 7", limit=50)
+    assert ids(page) == {"T-M37-2024"}
+
+
+def test_exact_postcode_search(adapter):
+    page = adapter.search(postcode="B5 7AA", limit=50)
+    assert ids(page) == {"T-B57-2024"}
+
+
+def test_property_type_and_category_filters_are_exact(adapter):
+    """Spec test 4. Filters are pushed into the query, not applied afterwards."""
+    page = adapter.search(postcode_prefix="B5", property_types={"F"}, limit=50)
+    assert ids(page) == {"T-B57-2024", "T-B56-2024", "T-B57-CATB"}
+
+    page = adapter.search(postcode_prefix="B5", transaction_category="A", limit=50)
+    assert "T-B57-CATB" not in ids(page)
+
+    page = adapter.search(postcode_prefix="B5", property_types={"F", "D", "S", "T"},
+                          transaction_category="A", limit=50)
+    assert ids(page) == {"T-B57-2024", "T-B57-2023", "T-B56-2024"}
+
+
+def test_date_range_filters(adapter):
+    page = adapter.search(postcode_prefix="B5", from_date="2024-01-01", limit=50)
+    assert "T-B57-2023" not in ids(page)
+    page = adapter.search(postcode_prefix="B5", to_date="2023-12-31", limit=50)
+    assert ids(page) == {"T-B57-2023"}
+
+
+def test_ordering_is_deterministic_across_same_date_ties(tmp_path):
+    """Spec test 3. Ties broken canonically, so paging cannot repeat or omit."""
+    rows = [row(f"T-{i:02d}", "B5 7AA", "2024-03-01", 100_000 + i) for i in range(10)]
+    directory, record = build_snapshot(tmp_path, rows)
+    with SnapshotAdapter.open(directory, record) as a:
+        first = [t.transaction_id for t in a.search(postcode_prefix="B5", limit=10).transactions]
+        second = [t.transaction_id for t in a.search(postcode_prefix="B5", limit=10).transactions]
+    assert first == second
+    assert first == sorted(first)
+
+
+def test_rows_map_onto_the_transaction_model(adapter):
+    page = adapter.search(postcode="B5 7AB", limit=5)
+    t = page.transactions[0]
+    assert t.transaction_id == "T-B57-2023"
+    assert t.price == 210_000
+    assert t.date == "2023-06-15"
+    assert t.postcode == "B5 7AB"
+    assert t.property_type == "T"
+    assert t.estate_type == "L"
+    assert t.transaction_category == "A"
+    assert t.new_build is False
+    assert t.street == "HIGH STREET"
+    assert t.town == "BIRMINGHAM"
+
+
+def test_result_below_limit_is_proven_complete(adapter):
+    """Spec test 21b. limit+1 came back short, so nothing was truncated."""
+    page = adapter.search(postcode_prefix="M3 7", limit=10)
+    assert page.exhausted is True
+    assert page.completeness_basis is CompletenessBasis.LIMIT_PLUS_ONE
+
+
+def test_result_at_the_limit_is_not_complete(adapter):
+    """Spec test 20. A full page proves nothing about what was left behind."""
+    page = adapter.search(postcode_prefix="B5", limit=2)
+    assert len(page.transactions) == 2
+    assert page.exhausted is False
+    assert page.completeness_basis is None
+
+
+def test_limit_plus_one_row_is_never_returned(adapter):
+    """The probe row is evidence, not data. Returning it would break the limit."""
+    page = adapter.search(postcode_prefix="B5", limit=3)
+    assert len(page.transactions) == 3
+
+
+def test_geography_is_never_widened_by_the_adapter(adapter):
+    """A thin result stays thin. Escalation is a caller decision, never a query one."""
+    page = adapter.search(postcode_prefix="B5 6", limit=50)
+    assert ids(page) == {"T-B56-2024"}
+
+
+def test_malformed_prefix_is_rejected_before_any_query(adapter):
+    from property_core.exceptions import InvalidPostcodeError
+
+    with pytest.raises(InvalidPostcodeError):
+        adapter.search(postcode_prefix="'; DROP TABLE ppd; --", limit=5)
+
+
+def test_geography_arguments_reach_the_query_as_parameters(adapter, monkeypatch):
+    """String interpolation of caller input into SQL is not available here."""
+    captured: list[tuple[str, tuple]] = []
+    original = SnapshotAdapter._execute
+
+    def _record(self, sql, params=()):
+        captured.append((sql, tuple(params)))
+        return original(self, sql, params)
+
+    monkeypatch.setattr(SnapshotAdapter, "_execute", _record)
+    adapter.search(postcode_prefix="B5 7", limit=5)
+    sql, params = captured[-1]
+    assert "B5 7" not in sql
+    assert "B5 7" in params

--- a/tests/snapshot/test_adapter_validation.py
+++ b/tests/snapshot/test_adapter_validation.py
@@ -1,0 +1,142 @@
+"""READY is not permission to route: the adapter must prove queryability first.
+
+Spec section 4.4 / 4.5. The boot runtime establishes *structural* verification --
+the bundle matched its digest, every archive member was safe, the file inventory
+is exactly what was written. That is a strictly weaker claim than "this snapshot
+answers queries correctly", and the routing layer is where the stronger claim has
+to be earned: schema, row count, and an actual executed query.
+
+Every failure here is a SnapshotFailure, which is the caller's signal to use the
+live source -- never to return an empty result set.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+from property_core.exceptions import SnapshotFailure  # noqa: E402
+from property_core.snapshot.adapter import SnapshotAdapter  # noqa: E402
+from property_core.snapshot.errors import (  # noqa: E402
+    SnapshotNotQueryableError,
+    SnapshotRowCountError,
+    SnapshotSchemaError,
+)
+from tests.snapshot.snapshot_fixtures import build_snapshot, default_rows, row  # noqa: E402
+
+
+def test_valid_snapshot_opens_and_reports_its_coverage(tmp_path):
+    directory, record = build_snapshot(tmp_path, default_rows())
+    with SnapshotAdapter.open(directory, record) as adapter:
+        assert adapter.version == record.version
+        assert adapter.coverage_from == "2016-01-01"
+        assert adapter.coverage_to == "2026-06-30"
+        assert adapter.provisional_from == "2026-04-01"
+
+
+def test_missing_required_column_is_rejected(tmp_path):
+    """A snapshot without `sector` cannot answer a sector query at all.
+
+    Discovering that on the first request would surface as an empty result --
+    the one thing an empty result must never mean.
+    """
+    directory, record = build_snapshot(tmp_path, default_rows(),
+                                       drop_columns=["sector"])
+    with pytest.raises(SnapshotSchemaError) as exc:
+        SnapshotAdapter.open(directory, record)
+    assert "sector" in str(exc.value)
+    assert isinstance(exc.value, SnapshotFailure)
+
+
+def test_wrong_column_type_is_rejected(tmp_path):
+    """`transfer_date` as VARCHAR compares lexically, not chronologically.
+
+    A date range filter would still "work" and silently return the wrong rows.
+    """
+    directory, record = build_snapshot(tmp_path, default_rows(),
+                                       types={"transfer_date": "VARCHAR"})
+    with pytest.raises(SnapshotSchemaError) as exc:
+        SnapshotAdapter.open(directory, record)
+    assert "transfer_date" in str(exc.value)
+
+
+def test_row_count_mismatch_is_rejected(tmp_path):
+    """The record says how many rows were built. Fewer means a partial snapshot."""
+    rows = default_rows()
+    directory, record = build_snapshot(tmp_path, rows,
+                                       declared_rows=len(rows) + 5)
+    with pytest.raises(SnapshotRowCountError) as exc:
+        SnapshotAdapter.open(directory, record)
+    assert str(len(rows)) in str(exc.value)
+    assert str(len(rows) + 5) in str(exc.value)
+
+
+def test_unreadable_parquet_is_rejected_as_not_queryable(tmp_path):
+    """Structurally verified bytes can still be an unreadable Parquet file."""
+    directory, record = build_snapshot(tmp_path, default_rows())
+    target = next(directory.rglob("*.parquet"))
+    target.write_bytes(b"PAR1" + b"\x00" * 64)
+    with pytest.raises(SnapshotFailure) as exc:
+        SnapshotAdapter.open(directory, record)
+    assert isinstance(exc.value, (SnapshotNotQueryableError, SnapshotSchemaError))
+
+
+def test_snapshot_with_no_parquet_files_is_rejected(tmp_path):
+    directory, record = build_snapshot(tmp_path, default_rows())
+    for parquet in directory.rglob("*.parquet"):
+        parquet.unlink()
+    with pytest.raises(SnapshotFailure):
+        SnapshotAdapter.open(directory, record)
+
+
+def test_row_count_uses_metadata_not_a_full_scan(tmp_path, monkeypatch):
+    """count(*) over Parquet reads row-group metadata; nothing may scan values.
+
+    Phase 3 found a readiness probe using `count(DISTINCT filename)`, which reads
+    every row. Asserted by inspecting the statements the adapter issues.
+    """
+    directory, record = build_snapshot(tmp_path, default_rows())
+    seen: list[str] = []
+    original = SnapshotAdapter._execute
+
+    def _record(self, sql, params=()):
+        seen.append(sql)
+        return original(self, sql, params)
+
+    monkeypatch.setattr(SnapshotAdapter, "_execute", _record)
+    with SnapshotAdapter.open(directory, record):
+        pass
+
+    counts = [s for s in seen if "count(" in s.lower()]
+    assert counts, "expected a row-count statement during validation"
+    assert not any("distinct" in s.lower() for s in counts)
+
+
+def test_validation_failure_leaves_no_open_connection(tmp_path):
+    """A rejected snapshot must not leak a DuckDB connection into the process."""
+    directory, record = build_snapshot(tmp_path, default_rows(),
+                                       drop_columns=["sector"])
+    with pytest.raises(SnapshotSchemaError) as exc:
+        SnapshotAdapter.open(directory, record)
+    assert getattr(exc.value, "connection", None) is None
+
+
+def test_extra_columns_are_tolerated(tmp_path):
+    """The contract is 'these columns, these types', not 'exactly these columns'.
+
+    A future build adding a column must not take the snapshot path down.
+    """
+    directory, record = build_snapshot(tmp_path, [row("T-1", "B5 7AA", "2024-01-01")])
+    import duckdb as _duckdb
+
+    parquet = next(directory.rglob("*.parquet"))
+    con = _duckdb.connect()
+    con.execute(
+        f"COPY (SELECT *, 'extra' AS future_column FROM read_parquet('{parquet}')) "
+        f"TO '{parquet}' (FORMAT parquet)"
+    )
+    con.close()
+    record = record.model_copy(update={"inventory": dict(record.inventory)})
+    with SnapshotAdapter.open(directory, record) as adapter:
+        assert adapter.version == record.version

--- a/tests/snapshot/test_attribution_and_derived_surfaces.py
+++ b/tests/snapshot/test_attribution_and_derived_surfaces.py
@@ -1,0 +1,93 @@
+"""Attribution, and provenance on the surfaces derived from comps.
+
+Spec section 6 and 3.1. Two things being pinned:
+
+* **The attribution reference resolves.** Every PPD response carries
+  `attribution_ref` rather than licence prose, which is only honest if the thing
+  it points at actually exists and says the required words. The expected string
+  is pinned literally in this file, not imported -- a test that derived it from
+  the same constant the runtime uses would pass even if that constant were
+  corrupted.
+* **Derived figures inherit their source's provenance.** A yield divides rent by
+  the comps median, so an incomplete or coverage-bounded sales window makes the
+  yield equally bounded. The caveat has to travel with the number.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+from property_core.provenance import SourceKind  # noqa: E402
+
+#: Pinned literally. See the module docstring.
+REQUIRED_ATTRIBUTION = (
+    "Contains HM Land Registry data © Crown copyright and database right "
+    "2026. This data is licensed under the Open Government Licence v3.0."
+)
+
+
+def test_cli_meta_states_the_attribution(snapshot_routing):
+    import json
+
+    typer_testing = pytest.importorskip("typer.testing")
+
+    from property_cli.main import app
+
+    result = typer_testing.CliRunner().invoke(app, ["meta"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["attribution"] == REQUIRED_ATTRIBUTION
+    assert payload["ppd_snapshot"]["version"] == snapshot_routing.version
+
+
+def test_both_mcp_instructions_state_the_licence_and_the_bound():
+    """The instructions string is the first thing an LLM reads about this server."""
+    from app.mcp.server import mcp as plain_server
+    from property_app.server import mcp as app_server
+
+    for server in (plain_server, app_server):
+        instructions = server.instructions or ""
+        assert "Open Government Licence" in instructions, server.name
+        assert "HM Land Registry" in instructions, server.name
+        assert "never sold" in instructions, server.name
+
+
+def test_rest_meta_reports_the_snapshot_state(snapshot_routing):
+    from fastapi.testclient import TestClient
+
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        payload = client.get("/v1/meta").json()
+    assert payload["snapshot"]["routable"] is True
+    assert payload["snapshot"]["coverage_from"] == "2016-01-01"
+
+
+def test_address_search_declares_the_live_source(snapshot_routing, fake_live):
+    """Spec 2.6: address search takes no dates and is never routed to a snapshot."""
+    from property_core.ppd_service import PPDService
+
+    result = PPDService().address_search(postcode="B5 7AA", street="High Street")
+    assert result["provenance"].source is SourceKind.SPARQL
+    assert result["provenance"].coverage_from is None
+
+
+@pytest.mark.anyio
+async def test_yield_inherits_the_sale_side_provenance(snapshot_routing, monkeypatch):
+    """A yield is only as bounded as the sale window it divides by."""
+    from property_core import yield_service
+    from property_core.rightmove_location import RightmoveLocationAPI
+
+    # Both Rightmove seams stubbed: this test is about the sale side, and a real
+    # listings call would make it slow and non-deterministic.
+    monkeypatch.setattr(RightmoveLocationAPI, "build_search_url",
+                        lambda self, *a, **k: "https://example.invalid/rent")
+    monkeypatch.setattr(yield_service, "fetch_listings", lambda *a, **k: [])
+
+    analysis = await yield_service.calculate_yield("B5 7AA", months=24,
+                                                   search_level="district")
+    assert analysis.sale_provenance is not None
+    assert analysis.sale_provenance.source is SourceKind.SNAPSHOT
+    assert analysis.sale_provenance.coverage_from == "2016-01-01"

--- a/tests/snapshot/test_attribution_and_derived_surfaces.py
+++ b/tests/snapshot/test_attribution_and_derived_surfaces.py
@@ -24,7 +24,7 @@ from property_core.provenance import SourceKind  # noqa: E402
 #: Pinned literally. See the module docstring.
 REQUIRED_ATTRIBUTION = (
     "Contains HM Land Registry data © Crown copyright and database right "
-    "2026. This data is licensed under the Open Government Licence v3.0."
+    "2021. This data is licensed under the Open Government Licence v3.0."
 )
 
 

--- a/tests/snapshot/test_coverage_routing.py
+++ b/tests/snapshot/test_coverage_routing.py
@@ -1,0 +1,149 @@
+"""Coverage routing: what happens when the request reaches past the snapshot.
+
+Spec section 2.5 and tests 5-9. The rule the whole design turns on: a request
+whose range starts before `coverage_from` is **unsatisfiable as stated** and is
+refused with both ranges attached. It is never answered partially, because a
+truncated answer is indistinguishable from a complete one.
+
+Two policies, and the difference is whether the caller's window is bounded:
+
+* GUARANTEED -- `months` has an upper bound the snapshot is sized to cover
+  (comps, yield, report). A window reaching past coverage can only happen with a
+  stale snapshot, so it is narrowed and warned rather than refused.
+* EXPLICIT -- the caller named dates, or `months` has no upper bound (blocks,
+  transactions). Refused, typed, with structured ranges.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+from property_core.exceptions import PPDCoverageError  # noqa: E402
+from property_core.ppd_service import PPDService  # noqa: E402
+from property_core.provenance import SourceKind  # noqa: E402
+
+
+def test_explicit_from_date_before_coverage_is_refused(snapshot_routing):
+    """Spec test 5. Never a 200 with partial rows."""
+    svc = PPDService()
+    with pytest.raises(PPDCoverageError) as exc:
+        svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                from_date="2004-01-01", limit=10)
+    payload = exc.value.to_dict()
+    assert payload["error"] == "ppd_coverage_error"
+    assert payload["requested"] == {"from_date": "2004-01-01", "to_date": None}
+    assert payload["available"] == {"coverage_from": "2016-01-01",
+                                    "coverage_to": "2026-06-30"}
+    assert payload["source_release"] == snapshot_routing.version
+    assert "2016-01-01" in payload["remedy"]
+
+
+def test_ranges_are_structured_not_prose(snapshot_routing):
+    """A caller reformulates from fields, never by parsing a sentence."""
+    svc = PPDService()
+    with pytest.raises(PPDCoverageError) as exc:
+        svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                from_date="2004-01-01", to_date="2005-01-01",
+                                limit=10)
+    payload = exc.value.to_dict()
+    assert isinstance(payload["requested"], dict)
+    assert isinstance(payload["available"], dict)
+    assert payload["requested"]["to_date"] == "2005-01-01"
+
+
+def test_from_date_inside_coverage_is_served_from_the_snapshot(snapshot_routing):
+    """Spec test 6."""
+    svc = PPDService()
+    result = svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                     from_date="2020-01-01", limit=10)
+    assert result["provenance"].source is SourceKind.SNAPSHOT
+    assert result["provenance"].source_release == snapshot_routing.version
+    assert result["count"] > 0
+
+
+def test_absent_from_date_is_narrowed_with_a_warning(snapshot_routing):
+    """Spec test 7. 'All time' silently becoming '11 years' is the lie to avoid."""
+    svc = PPDService()
+    result = svc.search_transactions(postcode=None, postcode_prefix="B5", limit=10)
+    provenance = result["provenance"]
+    assert provenance.source is SourceKind.SNAPSHOT
+    assert provenance.coverage_from == "2016-01-01"
+    assert any("narrowed" in w for w in result["warnings"])
+    assert any("narrowed" in w for w in provenance.warnings)
+
+
+def test_blocks_with_an_unbounded_window_is_refused_not_clamped(snapshot_routing):
+    """Spec test 8. `months` has no upper bound on this surface."""
+    from property_core.block_service import analyze_blocks
+
+    with pytest.raises(PPDCoverageError) as exc:
+        analyze_blocks("B5 7AA", months=600)
+    assert exc.value.coverage_from == "2016-01-01"
+    assert exc.value.requested_from is not None
+    assert exc.value.requested_from < "2016-01-01"
+
+
+def test_comps_narrows_rather_than_refusing(snapshot_routing):
+    """comps' `months` is bounded by every surface that exposes it (60 / 120).
+
+    A window reaching past coverage therefore means a stale snapshot, not an
+    unsatisfiable request -- so it is narrowed and warned, never refused.
+    """
+    svc = PPDService()
+    result = svc.comps(postcode="B5 7AA", months=600, search_level="district")
+    assert result.provenance.source is SourceKind.SNAPSHOT
+    assert result.provenance.coverage_from == "2016-01-01"
+    assert any("narrowed" in w for w in result.warnings)
+
+
+def test_comps_inside_coverage_carries_no_narrowing_warning(snapshot_routing):
+    svc = PPDService()
+    result = svc.comps(postcode="B5 7AA", months=24, search_level="district")
+    assert result.provenance.source is SourceKind.SNAPSHOT
+    assert not any("narrowed" in w for w in result.warnings)
+
+
+def test_rest_coverage_error_is_a_422_with_both_ranges(snapshot_routing):
+    from fastapi.testclient import TestClient
+
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        response = client.get("/v1/ppd/transactions",
+                              params={"postcode_prefix": "B5",
+                                      "from_date": "2004-01-01"})
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["error"] == "ppd_coverage_error"
+    assert detail["available"]["coverage_from"] == "2016-01-01"
+    assert detail["requested"]["from_date"] == "2004-01-01"
+
+
+def test_cli_coverage_error_exits_non_zero_and_prints_both_ranges(snapshot_routing):
+    """Spec test 9."""
+    typer_testing = pytest.importorskip("typer.testing")
+
+    from property_cli.main import app
+
+    result = typer_testing.CliRunner().invoke(
+        app, ["ppd", "blocks", "B5 7AA", "--months", "600"])
+    assert result.exit_code != 0
+    assert "2016-01-01" in result.output
+    assert "2026-06-30" in result.output
+    assert "ppd_coverage_error" in result.output
+
+
+def test_provisional_tail_is_flagged_from_the_manifest(snapshot_routing):
+    """Spec section 1.3. Provisional is published, never inferred at query time."""
+    svc = PPDService()
+    intersecting = svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                           from_date="2026-05-01", limit=10)
+    assert intersecting["provenance"].recent_period_provisional is True
+    assert any("provisional" in w for w in intersecting["provenance"].warnings)
+
+    earlier = svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                      from_date="2020-01-01", to_date="2021-01-01",
+                                      limit=10)
+    assert earlier["provenance"].recent_period_provisional is False

--- a/tests/snapshot/test_existence_probe.py
+++ b/tests/snapshot/test_existence_probe.py
@@ -1,0 +1,128 @@
+"""The bounded existence probe: what an empty result is allowed to mean.
+
+Spec section 2.4 and tests 10-14, decision O1.
+
+`ppd_transactions` and CLI `ppd search` take no date. Against a snapshot the
+call means "latest within coverage", so a postcode last sold in 2009 returns an
+empty list -- which an LLM reads as "never sold". That is a confident false
+claim, and the probe exists to make it impossible.
+
+The asymmetry is the point: `true` and `null` both add a warning, `false` is the
+only value that licenses a bare empty result, and `false` may only be set by a
+probe that actually completed.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+from property_core.ppd_service import PPDService  # noqa: E402
+
+
+def test_probe_is_not_issued_when_the_snapshot_returns_rows(snapshot_routing, probe_spy):
+    """Spec test 13. A non-empty result answers the question already."""
+    svc = PPDService()
+    result = svc.search_transactions(postcode=None, postcode_prefix="B5", limit=10)
+    assert result["count"] > 0
+    assert probe_spy.calls == []
+    assert result["provenance"].older_records_exist is None
+    assert not any("earlier records" in w for w in result["provenance"].warnings)
+
+
+def test_empty_with_nothing_older_is_an_honest_empty(snapshot_routing, probe_spy):
+    """Spec test 10. No warning: the absence is real and complete."""
+    probe_spy.result = False
+    svc = PPDService()
+    result = svc.search_transactions(postcode="ZZ9 9ZZ", postcode_prefix=None, limit=10)
+    assert result["count"] == 0
+    assert len(probe_spy.calls) == 1
+    provenance = result["provenance"]
+    assert provenance.older_records_exist is False
+    assert not any("earlier" in w or "cannot determine" in w
+                   for w in provenance.warnings)
+
+
+def test_empty_with_older_records_warns(snapshot_routing, probe_spy):
+    """Spec test 11."""
+    probe_spy.result = True
+    svc = PPDService()
+    result = svc.search_transactions(postcode="ZZ9 9ZZ", postcode_prefix=None, limit=10)
+    provenance = result["provenance"]
+    assert provenance.older_records_exist is True
+    assert any("earlier records exist outside coverage" in w
+               for w in provenance.warnings)
+    assert any("2016-01-01" in w for w in provenance.warnings)
+
+
+def test_probe_failure_is_null_and_never_false(snapshot_routing, probe_spy):
+    """Spec test 12. `false` asserts a fact about the world; a timeout asserts nothing."""
+    probe_spy.raises = TimeoutError("probe timed out")
+    svc = PPDService()
+    result = svc.search_transactions(postcode="ZZ9 9ZZ", postcode_prefix=None, limit=10)
+    provenance = result["provenance"]
+    assert provenance.older_records_exist is None
+    assert provenance.older_records_exist is not False
+    assert any("coverage probe unavailable" in w for w in provenance.warnings)
+
+    payload = str(result) + str(provenance.model_dump(mode="json"))
+    assert "never sold" not in payload.lower()
+
+
+def test_probe_uses_limit_one_existence_and_is_not_retried(snapshot_routing,
+                                                           recording_sparql):
+    """Spec test 14. Never COUNT, never retried, bounded at three seconds."""
+    from property_core.ppd_probe import ExistenceProbe
+
+    probe = ExistenceProbe(client=recording_sparql.client)
+    assert probe.older_records_exist(postcode="ZZ9 9ZZ", postcode_prefix=None,
+                                     coverage_from="2016-01-01") is False
+
+    assert len(recording_sparql.queries) == 1
+    query = recording_sparql.queries[0]
+    assert "LIMIT 1" in query
+    # The aggregate, not the substring: `?county` is a projected column and
+    # legitimately contains "count".
+    assert re.search(r"\bCOUNT\s*\(", query, re.IGNORECASE) is None
+    assert 'FILTER(?transactionDate <= "2015-12-31"^^xsd:date)' in query
+    assert recording_sparql.client.timeout == pytest.approx(3.0)
+    assert recording_sparql.client.retry_attempts == 1
+
+
+def test_probe_failure_is_not_retried(snapshot_routing, recording_sparql):
+    from property_core.ppd_probe import ExistenceProbe
+
+    recording_sparql.raise_on_call = RuntimeError("upstream down")
+    probe = ExistenceProbe(client=recording_sparql.client)
+    assert probe.older_records_exist(postcode="ZZ9 9ZZ", postcode_prefix=None,
+                                     coverage_from="2016-01-01") is None
+    assert len(recording_sparql.queries) == 1
+
+
+def test_probe_is_not_issued_when_the_caller_gave_a_from_date(snapshot_routing,
+                                                              probe_spy):
+    """A caller who named a start date already knows what they excluded."""
+    svc = PPDService()
+    result = svc.search_transactions(postcode="ZZ9 9ZZ", postcode_prefix=None,
+                                     from_date="2020-01-01", limit=10)
+    assert result["count"] == 0
+    assert probe_spy.calls == []
+    assert result["provenance"].older_records_exist is None
+
+
+def test_probe_is_not_issued_on_the_live_path(live_only, fake_live, probe_spy):
+    """Without a snapshot there is no coverage boundary to probe across."""
+    svc = PPDService()
+    svc.search_transactions(postcode="ZZ9 9ZZ", postcode_prefix=None, limit=10)
+    assert probe_spy.calls == []
+
+
+def test_probe_geography_matches_the_request(snapshot_routing, probe_spy):
+    probe_spy.result = False
+    svc = PPDService()
+    svc.search_transactions(postcode=None, postcode_prefix="ZZ9", limit=10)
+    assert probe_spy.calls[0]["postcode_prefix"] == "ZZ9"
+    assert probe_spy.calls[0]["coverage_from"] == "2016-01-01"

--- a/tests/snapshot/test_lifespan_wiring.py
+++ b/tests/snapshot/test_lifespan_wiring.py
@@ -1,0 +1,211 @@
+"""Where the runtime is started -- spec section 4.10, the governing rule for PR 4.
+
+The rules and why each exists:
+
+* **Boot once per server process, through the FastMCP lifespan.** Not per
+  request, not lazily on first use: a lazy boot puts a 20-second download in the
+  path of whichever request happens to arrive first.
+* **Combine the lifespans explicitly where the MCP app is mounted alongside
+  FastAPI.** Mounting does not chain them, and a lifespan that is never awaited
+  is a boot that never happens.
+* **Process-scoped state, never MCP session state.** Session state is client-
+  and session-scoped; the materialization belongs to the Machine. Storing it per
+  session would re-boot per client and leak across reconnects.
+* **A startup failure leaves the server serving from live.** UNREADY is a normal
+  outcome, not a startup error.
+"""
+
+from __future__ import annotations
+
+import anyio
+import pytest
+
+from property_core.snapshot import bootstrap, state
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    bootstrap.reset_for_tests()
+    yield
+    bootstrap.reset_for_tests()
+
+
+def test_flag_off_boots_nothing(monkeypatch):
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+    calls: list[int] = []
+    monkeypatch.setattr(bootstrap, "_materialize", lambda: calls.append(1))
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            pass
+
+    anyio.run(_run)
+    assert calls == []
+    assert state.active_adapter() is None
+
+
+def test_flag_off_imports_no_duckdb(monkeypatch):
+    """Deferred from PR 1 (§7.1): with no adapter installed nothing imports duckdb.
+
+    Run in a clean subprocess with an import blocker: asserting against
+    `sys.modules` in the shared test process passes vacuously as soon as any
+    earlier test has imported DuckDB.
+    """
+    import subprocess
+    import sys
+
+    program = """
+import sys
+
+class Blocker:
+    def find_module(self, name, path=None):
+        return self.find_spec(name, path)
+    def find_spec(self, name, path=None, target=None):
+        if name == "duckdb" or name.startswith("duckdb."):
+            raise ImportError("duckdb import blocked for this test")
+        return None
+
+sys.meta_path.insert(0, Blocker())
+try:
+    import duckdb
+except ImportError:
+    pass
+else:
+    raise SystemExit("blocker is not armed")
+
+import anyio
+from property_core.snapshot import bootstrap
+from property_core.ppd_service import PPDService
+
+async def main():
+    async with bootstrap.snapshot_lifespan():
+        assert PPDService()._active_adapter() is None
+
+anyio.run(main)
+print("OK")
+"""
+    env = {"PATH": "/usr/bin:/bin", "PPD_SNAPSHOT_ENABLED": "0"}
+    proc = subprocess.run([sys.executable, "-c", program], capture_output=True,
+                          text=True, env=env)
+    assert proc.returncode == 0, proc.stderr
+    assert "OK" in proc.stdout
+
+
+def test_flag_off_never_imports_the_snapshot_package_on_a_request_path():
+    """The flag is checked before the import, not after.
+
+    Run in a clean subprocess: `sys.modules` in the shared test process is
+    already full of snapshot modules from other tests, so an in-process
+    assertion would pass vacuously.
+    """
+    import subprocess
+    import sys
+
+    program = """
+import sys
+from property_core.ppd_source import active_adapter
+
+assert active_adapter() is None
+imported = [m for m in sys.modules if m.startswith("property_core.snapshot")]
+assert imported == [], imported
+print("OK")
+"""
+    proc = subprocess.run([sys.executable, "-c", program], capture_output=True,
+                          text=True, env={"PATH": "/usr/bin:/bin",
+                                          "PPD_SNAPSHOT_ENABLED": "0"})
+    assert proc.returncode == 0, proc.stderr
+    assert "OK" in proc.stdout
+
+
+def test_boot_runs_exactly_once_per_process(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    calls: list[int] = []
+    monkeypatch.setattr(bootstrap, "_materialize", lambda: calls.append(1))
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            async with bootstrap.snapshot_lifespan():
+                pass
+
+    anyio.run(_run)
+    assert calls == [1]
+
+
+def test_boot_failure_leaves_the_server_up_on_live(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+
+    def _explode():
+        raise RuntimeError("object store unreachable")
+
+    monkeypatch.setattr(bootstrap, "_materialize", _explode)
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            assert state.active_adapter() is None
+
+    anyio.run(_run)  # must not raise
+
+
+def test_state_is_module_scoped_not_session_scoped():
+    """A session store would re-boot per client and leak across reconnects."""
+    import inspect
+
+    source = inspect.getsource(state)
+    assert "session" not in source.lower() or "never" in source.lower()
+    assert not hasattr(state, "set_session_state")
+
+
+def test_fastmcp_servers_declare_the_boot_lifespan():
+    """Both MCP servers must carry it, or one of them never boots."""
+    from app.mcp.server import mcp as plain_server
+    from property_app.server import mcp as app_server
+
+    for server in (plain_server, app_server):
+        assert bootstrap.lifespan_is_installed(server), (
+            f"{server.name} does not run the snapshot boot lifespan")
+
+
+def test_fastapi_lifespan_explicitly_awaits_the_mcp_lifespan():
+    """Mounting does not chain lifespans; app/main.py must combine them."""
+    import inspect
+
+    from app import main
+
+    source = inspect.getsource(main.lifespan)
+    assert "_mcp_http_app.lifespan" in source
+
+
+def test_asgi_startup_boots_the_snapshot_once(monkeypatch):
+    """The end-to-end assertion: serving the app actually runs the boot."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    calls: list[int] = []
+    monkeypatch.setattr(bootstrap, "_materialize", lambda: calls.append(1))
+
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        assert client.get("/health").status_code == 200
+    assert calls == [1]
+
+
+def test_shutdown_releases_the_adapter(monkeypatch, tmp_path):
+    """A process that stops serving must not hold a DuckDB connection open."""
+    pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+    from property_core.snapshot.adapter import SnapshotAdapter
+    from tests.snapshot.snapshot_fixtures import build_snapshot, default_rows
+
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    directory, record = build_snapshot(tmp_path, default_rows())
+    adapter = SnapshotAdapter.open(directory, record)
+    monkeypatch.setattr(bootstrap, "_materialize", lambda: state.install(adapter))
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            assert state.active_adapter() is adapter
+
+    anyio.run(_run)
+    assert state.active_adapter() is None
+    assert adapter.closed is True

--- a/tests/snapshot/test_optional_extra_and_inertness.py
+++ b/tests/snapshot/test_optional_extra_and_inertness.py
@@ -155,17 +155,37 @@ def test_importing_property_core_does_not_import_the_snapshot_runtime():
 
 
 def test_no_request_path_boots_a_snapshot():
-    """Nothing wires the runtime in yet -- routing arrives later, behind the flag."""
+    """Boot happens at startup only -- never on the path of a request.
+
+    PR 4 added routing, so these modules may now *consult* an already-installed
+    adapter. What none of them may do is construct the boot runtime: that would
+    put a download in the path of whichever request arrived first, which is the
+    exact failure the lifespan rule (spec 4.10) exists to prevent.
+    """
     import inspect
 
     import app.api.v1.ppd as rest
     import app.mcp.server as plain
     import property_core.ppd_service as svc
+    import property_core.ppd_source as routing
 
-    for module in (rest, plain, svc):
+    for module in (rest, plain, svc, routing):
         src = inspect.getsource(module)
-        assert "SnapshotRuntime" not in src, f"{module.__name__} boots a snapshot"
-        assert "property_core.snapshot" not in src, f"{module.__name__} imports it"
+        assert "SnapshotRuntime" not in src, (
+            f"{module.__name__} constructs the boot runtime on a request path")
+
+
+def test_only_the_bootstrap_module_constructs_the_runtime():
+    """One place boots, and it is the one the lifespan calls."""
+    # Walked from disk, not `git grep`: a new caller that has not been staged
+    # yet is exactly the one this needs to catch.
+    callers = sorted(
+        str(path.relative_to(REPO))
+        for package in ("property_core", "app", "property_app", "property_cli")
+        for path in (REPO / package).rglob("*.py")
+        if "SnapshotRuntime(" in path.read_text()
+    )
+    assert callers == ["property_core/snapshot/bootstrap.py"], callers
 
 
 def test_the_snapshot_extra_declares_a_zstd_reader():

--- a/tests/snapshot/test_provenance_propagation.py
+++ b/tests/snapshot/test_provenance_propagation.py
@@ -1,0 +1,258 @@
+"""Provenance reaches every consumer, and completeness is never inferred.
+
+Spec section 3.1 and tests 21c/21d and 22-28c. Four consumers read this library
+-- REST, two MCP servers, and the CLI -- and a provenance block that stops at the
+service layer tells none of them anything. The LLM-facing surfaces matter most:
+`content` is what the model reads, and a median without its caveat is exactly
+the uncaveated figure the caveat exists to prevent.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+from property_core.provenance import (  # noqa: E402
+    ATTRIBUTION_REF,
+    CompletenessBasis,
+    PPDProvenance,
+    SourceKind,
+)
+
+#: Pinned literally, NOT imported from the constant the runtime uses. Deriving
+#: it from the same source would let a corrupted constant pass this test.
+REQUIRED_ATTRIBUTION = (
+    "Contains HM Land Registry data © Crown copyright and database right "
+    "2026. This data is licensed under the Open Government Licence v3.0."
+)
+
+
+def test_provenance_defaults_to_incomplete():
+    """Spec test 21d."""
+    provenance = PPDProvenance(source=SourceKind.SPARQL)
+    assert provenance.sample_complete is False
+    assert provenance.completeness_basis is None
+
+
+def test_live_sparql_leaves_completeness_false(live_only, fake_live):
+    """Spec test 21c. With no exhaustion observation, counts prove nothing.
+
+    `sample_count = 1` against `sample_limit = 50` looks complete and is not:
+    the upstream window is bounded BEFORE client-side filtering, so a short list
+    is equally consistent with "the window was truncated and most rows were
+    discarded". Only an explicit transport-layer observation may establish it.
+    """
+    from property_core.provenance import TransportEvidence
+
+    from property_core.ppd_service import PPDService
+
+    fake_live.rows = fake_live.rows[:1]
+    fake_live.evidence = TransportEvidence()  # nothing observed
+    result = PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                              limit=50)
+    provenance = result["provenance"]
+    assert provenance.sample_count == 1
+    assert provenance.sample_limit == 50
+    assert provenance.sample_complete is False
+    assert provenance.completeness_basis is None
+
+
+def test_live_sparql_may_claim_completeness_only_on_observed_exhaustion(live_only,
+                                                                        fake_live):
+    """The other half of 21c: an observation IS admissible, and is named."""
+    from property_core.ppd_service import PPDService
+
+    result = PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                              limit=50)
+    provenance = result["provenance"]
+    assert provenance.sample_complete is True
+    assert provenance.completeness_basis is CompletenessBasis.SOURCE_EXHAUSTED
+
+
+def test_snapshot_exhaustion_establishes_completeness(snapshot_routing):
+    """Spec test 21b, end to end through the service."""
+    from property_core.ppd_service import PPDService
+
+    result = PPDService().search_transactions(postcode=None, postcode_prefix="M3 7",
+                                              limit=50)
+    provenance = result["provenance"]
+    assert provenance.sample_complete is True
+    assert provenance.completeness_basis is CompletenessBasis.LIMIT_PLUS_ONE
+
+
+def test_snapshot_result_at_the_limit_is_incomplete(snapshot_routing):
+    """Spec test 20."""
+    from property_core.ppd_service import PPDService
+
+    result = PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                              limit=2)
+    assert result["provenance"].sample_complete is False
+
+
+def test_rest_comps_carries_the_provenance_block(snapshot_routing):
+    """Spec test 22."""
+    from fastapi.testclient import TestClient
+
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        response = client.get("/v1/ppd/comps",
+                              params={"postcode": "B5 7AA", "search_level": "district"})
+    assert response.status_code == 200
+    provenance = response.json()["provenance"]
+    assert provenance["source"] == "snapshot"
+    assert provenance["source_release"] == snapshot_routing.version
+    assert provenance["coverage_from"] == "2016-01-01"
+    assert provenance["coverage_to"] == "2026-06-30"
+    assert provenance["attribution_ref"] == ATTRIBUTION_REF
+    assert "sample_complete" in provenance
+    assert isinstance(provenance["freshness_days"], int)
+
+
+def test_rest_transactions_carries_the_provenance_block(snapshot_routing):
+    from fastapi.testclient import TestClient
+
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        response = client.get("/v1/ppd/transactions", params={"postcode_prefix": "B5"})
+    assert response.status_code == 200
+    assert response.json()["provenance"]["source"] == "snapshot"
+
+
+@pytest.mark.anyio
+async def test_plain_mcp_property_comps_carries_provenance(snapshot_routing):
+    """Spec test 23. The tool payload is what a programmatic consumer reads."""
+    from app.mcp.server import property_comps
+
+    result = await property_comps(postcode="B5 7AA", search_level="district")
+    assert result["provenance"]["source"] == "snapshot"
+    assert result["provenance"]["coverage_from"] == "2016-01-01"
+
+
+def test_plain_mcp_ppd_transactions_carries_provenance(snapshot_routing):
+    from app.mcp.server import ppd_transactions
+
+    result = ppd_transactions(postcode="B5 7AA")
+    assert result["provenance"]["source"] == "snapshot"
+    assert result["provenance"]["coverage_to"] == "2026-06-30"
+
+
+def test_mcp_app_search_comps_carries_provenance(snapshot_routing):
+    """Spec test 24."""
+    from property_app.dashboards.comps import _search_comps
+
+    data = _search_comps(postcode="B5 7AA", search_level="district")
+    assert data["provenance"]["source"] == "snapshot"
+
+
+def test_cli_comps_carries_provenance_in_core_mode(snapshot_routing, capsys):
+    """Spec test 25, core half."""
+    typer_testing = pytest.importorskip("typer.testing")
+
+    from property_cli.main import app
+
+    result = typer_testing.CliRunner().invoke(
+        app, ["ppd", "comps", "B5 7AA", "--search-level", "district"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["provenance"]["source"] == "snapshot"
+
+
+def test_mixed_source_comps_declares_both(snapshot_routing, fake_live):
+    """Spec test 26. Subject-property history is live; the comps are not."""
+    from property_core.ppd_service import PPDService
+
+    result = PPDService().comps(postcode="B5 7AA", address="1 High Street",
+                                search_level="district")
+    assert result.provenance.source is SourceKind.SNAPSHOT
+    assert result.subject_property is not None
+    assert result.subject_property.provenance.source is SourceKind.SPARQL
+
+
+def test_subject_property_failure_warns_and_success_does_not(snapshot_routing,
+                                                             fake_live):
+    """Spec test 17. A failed lookup is never rendered as an absent history."""
+    from property_core.ppd_service import PPDService
+
+    fake_live.rows = []
+    genuine = PPDService().comps(postcode="B5 7AA", address="1 High Street",
+                                 search_level="district")
+    assert genuine.subject_property is None
+    assert not any("lookup unavailable" in w for w in genuine.warnings)
+
+    fake_live.raises = RuntimeError("SPARQL down")
+    failed = PPDService().comps(postcode="B5 7AA", address="1 High Street",
+                                search_level="district")
+    assert failed.subject_property is None
+    assert any("lookup unavailable" in w for w in failed.warnings)
+
+
+def test_attribution_ref_resolves_to_the_exact_required_string(snapshot_routing):
+    """Spec tests 28 and 28b. The expected value is pinned in this file."""
+    from fastapi.testclient import TestClient
+
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        meta = client.get("/v1/meta").json()
+    assert meta["attribution"] == REQUIRED_ATTRIBUTION
+
+
+def test_licence_prose_never_appears_in_a_data_payload(snapshot_routing):
+    """Spec test 28c. Responses carry a reference, not the licence."""
+    from fastapi.testclient import TestClient
+
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        body = client.get("/v1/ppd/transactions",
+                          params={"postcode_prefix": "B5"}).text
+    assert "Open Government Licence" not in body
+    assert "Crown copyright" not in body
+    assert ATTRIBUTION_REF in body
+
+
+def test_provenance_is_built_atomically_never_patched():
+    """Spec section 3.1.2.
+
+    `model_copy(update=...)` bypasses validation by design: it can produce and
+    serialise a block `__init__` would reject. Checked over the parsed AST, not
+    the text, so prose explaining the prohibition does not read as a violation
+    of it.
+    """
+    import ast
+    import inspect
+
+    from property_core import ppd_service, ppd_source
+
+    for module in (ppd_service, ppd_source):
+        tree = ast.parse(inspect.getsource(module))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "model_copy"
+                    and any(kw.arg == "update" for kw in node.keywords)):
+                raise AssertionError(
+                    f"{module.__name__} patches a model with model_copy(update=...)")
+
+
+@pytest.mark.anyio
+async def test_ppd_transactions_descriptions_state_coverage_bounded_semantics():
+    """Spec test 29. Read from the REGISTERED tool, not the source docstring.
+
+    These strings are the routing contract an LLM reads, so what matters is what
+    FastMCP actually publishes.
+    """
+    from app.mcp.server import mcp as plain_server
+    from property_app import tools  # noqa: F401 -- registers the app's tools
+    from property_app.server import mcp as app_server
+
+    for server in (plain_server, app_server):
+        tool = await server.get_tool("ppd_transactions")
+        description = (tool.description or "").lower()
+        assert "every recorded transaction" not in description
+        assert "coverage" in description
+        assert "older_records_exist" in description

--- a/tests/snapshot/test_provenance_propagation.py
+++ b/tests/snapshot/test_provenance_propagation.py
@@ -26,7 +26,7 @@ from property_core.provenance import (  # noqa: E402
 #: it from the same source would let a corrupted constant pass this test.
 REQUIRED_ATTRIBUTION = (
     "Contains HM Land Registry data © Crown copyright and database right "
-    "2026. This data is licensed under the Open Government Licence v3.0."
+    "2021. This data is licensed under the Open Government Licence v3.0."
 )
 
 
@@ -73,14 +73,34 @@ def test_live_sparql_may_claim_completeness_only_on_observed_exhaustion(live_onl
 
 
 def test_snapshot_exhaustion_establishes_completeness(snapshot_routing):
-    """Spec test 21b, end to end through the service."""
+    """Spec test 21b, end to end through the service.
+
+    The window is named explicitly and sits inside coverage. That matters: the
+    adapter's `limit + 1` evidence covers what it searched, so it can only
+    establish completeness for an interval that was entirely searchable.
+    """
     from property_core.ppd_service import PPDService
 
     result = PPDService().search_transactions(postcode=None, postcode_prefix="M3 7",
-                                              limit=50)
+                                              from_date="2016-01-01",
+                                              to_date="2026-06-30", limit=50)
     provenance = result["provenance"]
     assert provenance.sample_complete is True
     assert provenance.completeness_basis is CompletenessBasis.LIMIT_PLUS_ONE
+
+
+def test_the_same_query_open_ended_is_not_complete(snapshot_routing):
+    """No `to_date` means "up to now", and now is past `coverage_to`.
+
+    Same postcode, same limit, same exhausted page -- and honestly incomplete,
+    because part of what was asked for lies outside the snapshot entirely.
+    """
+    from property_core.ppd_service import PPDService
+
+    result = PPDService().search_transactions(postcode=None, postcode_prefix="M3 7",
+                                              from_date="2016-01-01", limit=50)
+    assert result["provenance"].sample_complete is False
+    assert result["provenance"].completeness_basis is None
 
 
 def test_snapshot_result_at_the_limit_is_incomplete(snapshot_routing):

--- a/tests/snapshot/test_review_blockers_pr4.py
+++ b/tests/snapshot/test_review_blockers_pr4.py
@@ -357,3 +357,168 @@ def test_the_runtime_statement_matches_the_frozen_specification():
         line.lstrip("> ") for line in spec.read_text().splitlines()
     )
     assert " ".join(hmlr_attribution().split()) in " ".join(body.split())
+
+
+# ---------------------------------------------------------------------------
+# 6. Date inputs are validated before anything compares them
+# ---------------------------------------------------------------------------
+#
+# `resolve_coverage` compares date strings lexically, which is only meaningful
+# for well-formed ISO dates. Fed anything else it produced confident nonsense:
+# "nonsense" sorts after "2026-06-30", so a garbage `to_date` was read as
+# "beyond coverage" and silently clamped; an inverted range passed both bound
+# checks, queried `date >= 2025-01-01 AND date <= 2024-01-01`, matched nothing,
+# and -- being entirely "inside" coverage -- was reported COMPLETE.
+#
+# The live path shares the defect from the other side: a garbage date reached
+# SPARQL's own validator and surfaced as an upstream failure rather than a
+# caller error, and an inverted range returned an empty 200. Validation
+# therefore belongs before routing, where it covers both sources.
+
+
+@pytest.mark.parametrize("bad", ["nonsense", "2026-13-01", "2026-02-30", "", "20260101"])
+def test_a_malformed_date_is_a_caller_error_not_a_clamp(snapshot_routing, bad):
+    from property_core.exceptions import InvalidDateRangeError
+
+    with pytest.raises(InvalidDateRangeError) as exc:
+        PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                         to_date=bad, limit=10)
+    payload = exc.value.to_dict()
+    assert payload["error"] == "invalid_date_range"
+    assert payload["field"] == "to_date"
+    assert payload["value"] == bad
+
+
+def test_a_malformed_from_date_names_that_field(snapshot_routing):
+    from property_core.exceptions import InvalidDateRangeError
+
+    with pytest.raises(InvalidDateRangeError) as exc:
+        PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                         from_date="not-a-date", limit=10)
+    assert exc.value.to_dict()["field"] == "from_date"
+
+
+def test_an_inverted_range_is_refused_rather_than_answered_completely(snapshot_routing):
+    """The worst of the two: an empty result asserted to be complete."""
+    from property_core.exceptions import InvalidDateRangeError
+
+    with pytest.raises(InvalidDateRangeError) as exc:
+        PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                         from_date="2025-01-01", to_date="2024-01-01",
+                                         limit=10)
+    payload = exc.value.to_dict()
+    assert payload["requested"] == {"from_date": "2025-01-01", "to_date": "2024-01-01"}
+
+
+def test_an_equal_range_is_valid(snapshot_routing):
+    """A single day is a legitimate window; only from > to is not."""
+    result = PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                              from_date="2024-03-01",
+                                              to_date="2024-03-01", limit=10)
+    assert result["count"] >= 1
+
+
+def test_bad_dates_are_rejected_on_the_live_path_too(live_only, fake_live):
+    """Same defect, other source: SPARQL reported a caller error as an outage."""
+    from property_core.exceptions import InvalidDateRangeError
+
+    with pytest.raises(InvalidDateRangeError):
+        PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                         to_date="nonsense", limit=10)
+    with pytest.raises(InvalidDateRangeError):
+        PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                         from_date="2025-01-01", to_date="2024-01-01",
+                                         limit=10)
+    assert fake_live.calls == 0, "neither source may be queried on invalid input"
+
+
+def test_neither_source_is_queried_on_invalid_input(snapshot_routing, monkeypatch,
+                                                    fake_live):
+    from property_core.exceptions import InvalidDateRangeError
+
+    def _must_not_run(*a, **k):
+        raise AssertionError("the snapshot was queried with an invalid date range")
+
+    monkeypatch.setattr(type(snapshot_routing.adapter), "search", _must_not_run)
+    with pytest.raises(InvalidDateRangeError):
+        PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                         from_date="2025-01-01", to_date="2024-01-01",
+                                         limit=10)
+    assert fake_live.calls == 0
+
+
+@pytest.mark.parametrize("params, expected", [
+    ({"to_date": "nonsense"}, 422),
+    ({"from_date": "2025-01-01", "to_date": "2024-01-01"}, 422),
+])
+def test_rest_reports_a_bad_range_as_a_caller_error(snapshot_routing, params, expected):
+    """Previously 502 (an upstream outage) and 200 (an empty complete answer)."""
+    from fastapi.testclient import TestClient
+
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        response = client.get("/v1/ppd/transactions",
+                              params={"postcode_prefix": "B5", **params})
+    assert response.status_code == expected
+    assert response.json()["detail"]["error"] == "invalid_date_range"
+
+
+def test_resolve_coverage_validates_before_comparing(snapshot_routing):
+    """Defence in depth: the comparison itself refuses unvalidated input.
+
+    `resolve_coverage` is where the lexical comparisons live, so it must not
+    depend on a caller having checked first.
+    """
+    from property_core.exceptions import InvalidDateRangeError
+    from property_core.ppd_source import CoveragePolicy, resolve_coverage
+
+    with pytest.raises(InvalidDateRangeError):
+        resolve_coverage(snapshot_routing.adapter, from_date="2025-01-01",
+                         to_date="2024-01-01", policy=CoveragePolicy.EXPLICIT)
+    with pytest.raises(InvalidDateRangeError):
+        resolve_coverage(snapshot_routing.adapter, from_date=None,
+                         to_date="nonsense", policy=CoveragePolicy.EXPLICIT)
+
+
+# ---------------------------------------------------------------------------
+# 7. The adapter's own evidence must not contradict its documentation
+# ---------------------------------------------------------------------------
+
+
+def test_an_offset_page_carries_no_completeness_basis(tmp_path):
+    """`SnapshotPage` is exported, and says a basis means everything was seen.
+
+    The service withdrew the basis afterwards, so no response was wrong -- but
+    the adapter still handed out a page whose own evidence contradicted its
+    documented meaning, and it is a public type. Fixed at the source; the
+    central withdrawal stays as defence in depth.
+    """
+    directory, record = build_snapshot(tmp_path, default_rows())
+    with SnapshotAdapter.open(directory, record) as adapter:
+        page = adapter.search(postcode_prefix="B5", offset=1, limit=50)
+        assert page.completeness_basis is None
+        # `exhausted` is a fact about the page that was fetched and stays true.
+        assert page.exhausted is True
+        assert page.offset == 1
+
+        first = adapter.search(postcode_prefix="B5", offset=0, limit=50)
+        assert first.completeness_basis is not None
+
+
+def test_the_central_withdrawal_is_retained(snapshot_routing):
+    """Belt and braces: provenance drops a basis at an offset regardless."""
+    from property_core.provenance import CompletenessBasis
+    from property_core.ppd_source import CoverageDecision, snapshot_provenance
+
+    decision = CoverageDecision(
+        from_date="2016-01-01", to_date="2026-06-30", warnings=(),
+        from_narrowed=False, to_clamped=False, recent_period_provisional=False,
+        fully_contained=True,
+    )
+    provenance = snapshot_provenance(
+        snapshot_routing.adapter, decision=decision, sample_count=1, sample_limit=50,
+        completeness_basis=CompletenessBasis.LIMIT_PLUS_ONE, offset=3,
+    )
+    assert provenance.sample_complete is False
+    assert provenance.completeness_basis is None

--- a/tests/snapshot/test_review_blockers_pr4.py
+++ b/tests/snapshot/test_review_blockers_pr4.py
@@ -1,0 +1,359 @@
+"""Five defects found reviewing PR 4, each reproduced before it was fixed.
+
+They share one shape: **the snapshot answered, and said the answer was
+complete, when it was not.** That is the single worst thing this design can do,
+because a caller cannot tell a confidently wrong answer from a right one.
+
+1. `union_by_name=true` validated the combined view, so a partition missing a
+   required column passed the schema gate and silently contributed no matching
+   rows -- while the response claimed exhaustion.
+2. `offset` was accepted, echoed back, and ignored, so paging returned the same
+   row forever.
+3. Coverage was checked only at its lower bound, so a window entirely *after*
+   `coverage_to` returned an empty, "complete" snapshot answer.
+4. Coverage metadata was optional at the routing gate, so a record with no
+   bounds answered a 1995 request from an 11-year snapshot with null bounds and
+   no warning.
+5. The attribution statement substituted the current year. HM Land Registry
+   prescribes a fixed 2021 statement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+from property_core.exceptions import PPDCoverageError, SnapshotFailure  # noqa: E402
+from property_core.ppd_service import PPDService  # noqa: E402
+from property_core.snapshot.adapter import SnapshotAdapter  # noqa: E402
+from property_core.snapshot.models import VerificationRecord  # noqa: E402
+from property_core.snapshot.store import VERIFIED_RECORD, SnapshotStore  # noqa: E402
+from tests.snapshot.snapshot_fixtures import (  # noqa: E402
+    build_snapshot,
+    default_rows,
+    row,
+    write_parquet_snapshot,
+)
+
+
+def _record(directory, **over) -> VerificationRecord:
+    payload = dict(
+        version="v20260101T000000Z", bundle_sha256="0" * 64, bundle_bytes=1024,
+        bundle_object="b.tar",
+        parquet_files=len(list(directory.rglob("*.parquet"))),
+        rows=0, verified_at="2026-01-01T00:00:00Z",
+        coverage_from="2016-01-01", coverage_to="2026-06-30",
+        provisional_from="2026-04-01", layout="year", duckdb_version="1.5.5",
+        inventory=SnapshotStore.inventory(directory),
+    )
+    payload.update(over)
+    return VerificationRecord(**payload)
+
+
+def _materialize(tmp_path, partitions, **over):
+    """Write partitions into one snapshot directory and return (dir, record)."""
+    store = SnapshotStore(tmp_path)
+    directory = store.snapshots_dir / "v20260101T000000Z"
+    total = 0
+    for rows, drop in partitions:
+        write_parquet_snapshot(directory, rows, drop_columns=drop)
+        total += len(rows)
+    record = _record(directory, rows=total, **over)
+    (directory / VERIFIED_RECORD).write_text(record.model_dump_json())
+    store.set_current(record.version)
+    return directory, record
+
+
+# ---------------------------------------------------------------------------
+# 1. Per-partition schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_a_partition_missing_a_required_column_is_rejected(tmp_path):
+    """`union_by_name` fills the gap with NULLs, so the union view looks fine.
+
+    The 2023 partition has no `outcode`. Under the union it reads as NULL, so
+    an outcode search matches nothing from that year -- and the adapter, having
+    seen fewer than `limit + 1` rows, reports the result COMPLETE. A whole year
+    of sales vanishes and the response says nothing is missing.
+    """
+    directory, record = _materialize(tmp_path, [
+        ([row("T-2024", "B5 7AA", "2024-03-01")], ()),
+        ([row("T-2023", "B5 7AB", "2023-03-01")], ("outcode",)),
+    ])
+    with pytest.raises(SnapshotFailure) as exc:
+        SnapshotAdapter.open(directory, record)
+    assert "outcode" in str(exc.value)
+    # The message must name the offending file, or an operator cannot act on it.
+    assert "2023" in str(exc.value)
+
+
+def test_a_partition_with_a_wrong_column_type_is_rejected(tmp_path):
+    directory, record = _materialize(tmp_path, [
+        ([row("T-2024", "B5 7AA", "2024-03-01")], ()),
+    ])
+    write_parquet_snapshot(directory / "extra", [row("T-2023", "B5 7AB", "2023-03-01")],
+                           types={"price": "VARCHAR"})
+    record = _record(directory, rows=2)
+    with pytest.raises(SnapshotFailure) as exc:
+        SnapshotAdapter.open(directory, record)
+    assert "price" in str(exc.value)
+
+
+def test_every_partition_is_described_individually(tmp_path, monkeypatch):
+    """Proof the check is per file, not one DESCRIBE over the union."""
+    directory, record = _materialize(tmp_path, [
+        ([row("T-2024", "B5 7AA", "2024-03-01")], ()),
+        ([row("T-2023", "B5 7AB", "2023-03-01")], ()),
+    ])
+    seen: list[str] = []
+    original = SnapshotAdapter._execute
+
+    def _record_sql(self, sql, params=()):
+        seen.append(sql)
+        return original(self, sql, params)
+
+    monkeypatch.setattr(SnapshotAdapter, "_execute", _record_sql)
+    SnapshotAdapter.open(directory, record).close()
+
+    described = [s for s in seen if s.upper().startswith("DESCRIBE")]
+    assert sum("year=2024" in s for s in described) == 1
+    assert sum("year=2023" in s for s in described) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Offset
+# ---------------------------------------------------------------------------
+
+
+def test_offset_advances_the_snapshot_page(snapshot_routing):
+    """A parameter that is accepted and echoed must do something."""
+    svc = PPDService()
+    first = svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                    from_date="2016-01-01", to_date="2026-06-30",
+                                    limit=1, offset=0)
+    second = svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                     from_date="2016-01-01", to_date="2026-06-30",
+                                     limit=1, offset=1)
+    assert first["results"][0].transaction_id != second["results"][0].transaction_id
+    assert second["offset"] == 1
+
+
+def test_offset_walks_the_whole_result_set_without_repeats(snapshot_routing):
+    """The adapter's order is total, so paging must be exact -- no gaps, no dupes."""
+    svc = PPDService()
+    paged = []
+    for offset in range(6):
+        page = svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                       from_date="2016-01-01", to_date="2026-06-30",
+                                       limit=1, offset=offset)
+        paged.extend(t.transaction_id for t in page["results"])
+    whole = [t.transaction_id for t in
+             svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                     from_date="2016-01-01", to_date="2026-06-30",
+                                     limit=50)["results"]]
+    assert paged == whole
+
+
+def test_a_deep_page_never_claims_whole_sample_completeness(snapshot_routing):
+    """`limit + 1` on page three proves page three ended, not that we saw page one.
+
+    `sample_complete` is a claim about the whole matching set, so an offset page
+    can never establish it however short the final page is.
+    """
+    svc = PPDService()
+    result = svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                     from_date="2016-01-01", to_date="2026-06-30",
+                                     limit=50, offset=1)
+    assert result["count"] > 0
+    assert result["provenance"].sample_complete is False
+    assert result["provenance"].completeness_basis is None
+
+
+# ---------------------------------------------------------------------------
+# 3. The upper coverage boundary
+# ---------------------------------------------------------------------------
+
+
+def test_a_window_entirely_after_coverage_is_refused(snapshot_routing):
+    """Nothing in this window is in the snapshot, so an empty answer is a lie."""
+    svc = PPDService()
+    with pytest.raises(PPDCoverageError) as exc:
+        svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                from_date="2026-07-01", to_date="2026-08-01",
+                                limit=10)
+    payload = exc.value.to_dict()
+    assert payload["requested"]["from_date"] == "2026-07-01"
+    assert payload["available"]["coverage_to"] == "2026-06-30"
+    assert "2026-06-30" in payload["remedy"]
+
+
+def test_a_window_entirely_before_coverage_is_refused(snapshot_routing):
+    svc = PPDService()
+    with pytest.raises(PPDCoverageError):
+        svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                from_date="2001-01-01", to_date="2002-01-01",
+                                limit=10)
+
+
+def test_a_guaranteed_surface_falls_back_when_coverage_cannot_reach(tmp_path,
+                                                                    monkeypatch,
+                                                                    fake_live):
+    """comps must still answer. A snapshot too stale for the window is a failure.
+
+    A refusal would be wrong here -- `months` is bounded and the caller was
+    promised an answer -- and an empty "complete" result would be worse. The
+    snapshot steps aside and live answers, exactly as for any other typed
+    snapshot failure.
+    """
+    from property_core.snapshot import state
+
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    directory, record = build_snapshot(
+        tmp_path, default_rows(), coverage_from="2001-01-01",
+        coverage_to="2002-12-31", provisional_from="2002-10-01")
+    state.clear()
+    state.install(SnapshotAdapter.open(directory, record))
+    try:
+        result = PPDService().comps(postcode="B5 7AA", months=24,
+                                    search_level="district")
+    finally:
+        state.clear()
+
+    assert result.provenance.source.value == "sparql"
+    assert any("snapshot" in w and "live" in w for w in result.warnings)
+
+
+def test_a_window_extending_past_coverage_is_clamped_and_not_complete(snapshot_routing):
+    """Partial overlap: serve the intersection, say what was cut, claim nothing.
+
+    The caller asked for a period the snapshot only partly holds. Answering the
+    overlap is useful; calling it complete is false.
+    """
+    svc = PPDService()
+    result = svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                     from_date="2020-01-01", to_date="2026-12-31",
+                                     limit=50)
+    provenance = result["provenance"]
+    assert result["count"] > 0
+    assert provenance.sample_complete is False
+    assert provenance.completeness_basis is None
+    assert any("2026-06-30" in w and "coverage" in w for w in result["warnings"])
+
+
+def test_an_open_ended_window_is_not_complete(snapshot_routing):
+    """No `to_date` means "up to now", and now is past `coverage_to`."""
+    svc = PPDService()
+    result = svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                     from_date="2020-01-01", limit=50)
+    assert result["provenance"].sample_complete is False
+
+
+def test_a_fully_contained_window_is_still_complete(snapshot_routing):
+    """The gate must not swallow the case completeness exists for."""
+    svc = PPDService()
+    result = svc.search_transactions(postcode=None, postcode_prefix="M3 7",
+                                     from_date="2016-01-01", to_date="2026-06-30",
+                                     limit=50)
+    assert result["provenance"].sample_complete is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Coverage metadata at the routing gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "override, why",
+    [
+        ({"coverage_from": None, "coverage_to": None}, "no bounds at all"),
+        ({"coverage_from": None}, "half a range is not a range"),
+        ({"coverage_from": "not-a-date"}, "unparseable lower bound"),
+        ({"coverage_to": "2026-13-45"}, "unparseable upper bound"),
+        ({"coverage_from": "2026-06-30", "coverage_to": "2016-01-01"},
+         "bounds inverted"),
+        ({"provisional_from": "2030-01-01"}, "provisional boundary outside coverage"),
+        ({"provisional_from": "2015-01-01"}, "provisional boundary before coverage"),
+        ({"provisional_from": "nonsense"}, "unparseable provisional boundary"),
+    ],
+)
+def test_unusable_coverage_metadata_is_a_typed_failure(tmp_path, override, why):
+    """Routing answers coverage questions from this metadata. It must be sound.
+
+    Without the check, a record with no bounds answered a 1995 request from an
+    11-year snapshot, reported null coverage, claimed completeness, and warned
+    about nothing.
+    """
+    directory, _ = _materialize(tmp_path, [
+        ([row("T-2024", "B5 7AA", "2024-03-01")], ()),
+    ])
+    record = _record(directory, rows=1, **override)
+    with pytest.raises(SnapshotFailure, match="coverage|provisional"):
+        SnapshotAdapter.open(directory, record)
+
+
+def test_a_snapshot_with_unusable_coverage_falls_back_to_live(tmp_path, monkeypatch,
+                                                              fake_live):
+    """The boot leaves nothing installed, so requests go to live -- not to a lie."""
+    from property_core.snapshot import bootstrap, state
+
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    directory, _ = _materialize(tmp_path, [
+        ([row("T-2024", "B5 7AA", "2024-03-01")], ()),
+    ])
+    record = _record(directory, rows=1, coverage_from=None, coverage_to=None)
+    with pytest.raises(SnapshotFailure):
+        SnapshotAdapter.open(directory, record)
+
+    bootstrap.reset_for_tests()
+    assert state.active_adapter() is None
+    result = PPDService().search_transactions(postcode=None, postcode_prefix="B5",
+                                              limit=10)
+    assert result["provenance"].source.value == "sparql"
+
+
+# ---------------------------------------------------------------------------
+# 5. Attribution
+# ---------------------------------------------------------------------------
+
+
+# The literal itself is pinned in tests/test_ppd_spec_and_attribution.py, which
+# now checks the runtime constant as well as the specification. What is tested
+# here is the mechanism that produced the wrong statement.
+
+
+def test_the_attribution_never_consults_the_calendar():
+    """The statement is fixed, so nothing may derive it from today's date.
+
+    Checked over the parsed AST rather than by calling it: a call-based test
+    passes today and starts failing on 1 January, which is precisely how the
+    defect reached review.
+    """
+    import ast
+    import inspect
+
+    import property_core.attribution as attribution
+
+    tree = ast.parse(inspect.getsource(attribution))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in {"today", "now", "utcnow"}:
+            raise AssertionError(
+                "attribution derives the statement from the current date")
+        if isinstance(node, ast.Name) and node.id in {"date", "datetime"}:
+            raise AssertionError("attribution still imports a date type")
+
+
+def test_the_runtime_statement_matches_the_frozen_specification():
+    """The spec quotes it in section 6; drift between them is a defect either way."""
+    from pathlib import Path
+
+    from property_core.attribution import hmlr_attribution
+
+    spec = Path(__file__).resolve().parents[2] / "docs/design/ppd-source-routing.md"
+    # The spec quotes it as a two-line markdown blockquote, so the "> " markers
+    # come out mid-sentence unless they are stripped first.
+    body = " ".join(
+        line.lstrip("> ") for line in spec.read_text().splitlines()
+    )
+    assert " ".join(hmlr_attribution().split()) in " ".join(body.split())

--- a/tests/snapshot/test_rollout_prerequisites.py
+++ b/tests/snapshot/test_rollout_prerequisites.py
@@ -286,14 +286,25 @@ def test_the_lifespan_rule_is_recorded_in_the_specification(requirement):
     )
 
 
-def test_no_lifespan_wiring_exists_yet():
-    """The rule is recorded; PR 4 implements it. Nothing boots a snapshot now."""
+def test_the_lifespan_rule_is_wired_in_both_deployments():
+    """PR 4 implements the rule recorded above, in both deployed servers.
+
+    `property-shared` mounts the MCP app inside FastAPI, so its FastAPI lifespan
+    must await the FastMCP one explicitly -- mounting does not chain them.
+    `propertydata` is deployed on its own and carries the lifespan directly.
+    """
     import inspect
 
-    import app.main as api
-    import property_app.server as mcp_app
+    from property_core.snapshot.bootstrap import lifespan_is_installed
 
-    for module in (api, mcp_app):
-        src = inspect.getsource(module)
-        assert "SnapshotRuntime" not in src, f"{module.__name__} boots a snapshot"
-        assert "property_core.snapshot" not in src
+    import app.main as api
+    from app.mcp.server import mcp as plain_server
+    from property_app.server import mcp as app_server
+
+    for server in (plain_server, app_server):
+        assert lifespan_is_installed(server), f"{server.name} never boots"
+
+    assert "_mcp_http_app.lifespan" in inspect.getsource(api.lifespan), (
+        "app/main.py no longer awaits the FastMCP lifespan; the mounted "
+        "deployment would never boot a snapshot"
+    )

--- a/tests/snapshot/test_source_fallback.py
+++ b/tests/snapshot/test_source_fallback.py
@@ -1,0 +1,150 @@
+"""Missing is not unavailable: what each failure is allowed to look like.
+
+Spec section 3.2 and tests 15-19. Three outcomes that a naive implementation
+collapses into one empty list:
+
+* no rows matched inside coverage -> 200, empty, honest;
+* the snapshot could not answer -> fall back to the LIVE source, warn, and say
+  `source: sparql`. The materialization is ephemeral, so "no snapshot" is a
+  normal state, not an outage;
+* the live upstream failed -> a typed upstream error, never empty data.
+
+The fallback is on the *snapshot* failure taxonomy only. A caller error
+(`InvalidPostcodeError`) and a coverage refusal (`PPDCoverageError`) must reach
+the caller unchanged -- retrying those against live would hide the very thing
+this design exists to report.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+from property_core.exceptions import (  # noqa: E402
+    InvalidPostcodeError,
+    PPDCoverageError,
+    SnapshotFailure,
+    UpstreamUnavailableError,
+)
+from property_core.ppd_service import PPDService  # noqa: E402
+from property_core.provenance import SourceKind  # noqa: E402
+from property_core.snapshot.errors import SnapshotQueryError  # noqa: E402
+
+
+def test_no_snapshot_open_uses_the_live_source(live_only, fake_live):
+    """Spec test 15, under section 4.5.
+
+    UNREADY is a normal outcome after every restart, so it hands off to live
+    rather than surfacing an error. What must never happen is empty data.
+    """
+    svc = PPDService()
+    result = svc.search_transactions(postcode=None, postcode_prefix="B5", limit=10)
+    assert result["provenance"].source is SourceKind.SPARQL
+    assert result["provenance"].source_release is None
+    assert result["count"] == len(fake_live.rows)
+
+
+def test_snapshot_query_failure_falls_back_to_live_and_says_so(snapshot_routing,
+                                                               fake_live, monkeypatch):
+    """Every typed snapshot failure hands off, and the handoff is declared."""
+    def _boom(*a, **k):
+        raise SnapshotQueryError("duckdb blew up mid-query")
+
+    monkeypatch.setattr(type(snapshot_routing.adapter), "search", _boom)
+
+    svc = PPDService()
+    result = svc.search_transactions(postcode=None, postcode_prefix="B5", limit=10)
+    assert result["provenance"].source is SourceKind.SPARQL
+    assert any("snapshot" in w and "live" in w for w in result["warnings"])
+    assert result["count"] == len(fake_live.rows)
+
+
+def test_snapshot_failure_subclasses_all_fall_back(snapshot_routing, fake_live,
+                                                   monkeypatch):
+    """The taxonomy is the contract, not an enumeration of known classes."""
+    class NovelSnapshotFailure(SnapshotFailure):
+        code = "snapshot_something_new"
+
+    def _boom(*a, **k):
+        raise NovelSnapshotFailure("a failure mode added after this test was written")
+
+    monkeypatch.setattr(type(snapshot_routing.adapter), "search", _boom)
+    svc = PPDService()
+    result = svc.search_transactions(postcode=None, postcode_prefix="B5", limit=10)
+    assert result["provenance"].source is SourceKind.SPARQL
+
+
+def test_coverage_refusal_is_never_softened_into_a_live_fallback(snapshot_routing,
+                                                                 fake_live):
+    """The behavioural change of this design, and the one it must not undo."""
+    svc = PPDService()
+    with pytest.raises(PPDCoverageError):
+        svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                from_date="2004-01-01", limit=10)
+    assert fake_live.calls == 0
+
+
+def test_caller_error_is_never_softened_into_a_live_fallback(snapshot_routing,
+                                                             fake_live):
+    svc = PPDService()
+    with pytest.raises(InvalidPostcodeError):
+        svc.search_transactions(postcode=None, postcode_prefix="not a postcode",
+                                limit=10)
+    assert fake_live.calls == 0
+
+
+def test_live_upstream_failure_is_typed_never_empty(live_only, fake_live):
+    """Spec test 16. Distinct from both 'empty' and 'no snapshot'."""
+    fake_live.raises = RuntimeError("SPARQL 503")
+    svc = PPDService()
+    with pytest.raises(Exception) as exc:
+        svc.search_transactions(postcode=None, postcode_prefix="B5", limit=10)
+    assert not isinstance(exc.value, SnapshotFailure)
+
+
+def test_rest_maps_live_failure_to_502(live_only, fake_live):
+    from fastapi.testclient import TestClient
+
+    from app.main import create_app
+
+    fake_live.raises = RuntimeError("SPARQL 503")
+    with TestClient(create_app()) as client:
+        response = client.get("/v1/ppd/transactions", params={"postcode_prefix": "B5"})
+    assert response.status_code == 502
+
+
+def test_record_status_still_rejected_against_the_snapshot(snapshot_routing):
+    """Spec test 19. Parity with live: a scope decision, not an ontology gap."""
+    from property_core.ppd_client import UnsupportedRecordStatusFilterError
+
+    svc = PPDService()
+    with pytest.raises(UnsupportedRecordStatusFilterError):
+        svc.search_transactions(postcode=None, postcode_prefix="B5",
+                                record_status="A", limit=10)
+
+
+def test_exact_id_lookup_stays_on_linked_data(snapshot_routing, monkeypatch):
+    """Spec test 18. Exact ID works outside coverage, so it never routes to snapshot."""
+    from property_core.models.ppd import PPDTransactionRecord
+    from property_core.ppd_client import PricePaidDataClient
+
+    seen: list[str] = []
+
+    def _fake(self, transaction_id, view="all"):
+        seen.append(transaction_id)
+        return PPDTransactionRecord(transaction_id=transaction_id, price_paid=1,
+                                    transaction_date="1998-04-01")
+
+    monkeypatch.setattr(PricePaidDataClient, "get_transaction_record", _fake)
+    svc = PPDService()
+    out = svc.transaction_record("abc-123")
+    assert seen == ["abc-123"]
+    assert out["provenance"].source is SourceKind.LINKED_DATA
+    assert out["provenance"].coverage_from is None
+
+
+def test_upstream_unavailable_is_not_a_snapshot_failure():
+    """The two taxonomies must not overlap, or fallback would loop."""
+    assert not issubclass(UpstreamUnavailableError, SnapshotFailure)
+    assert not issubclass(SnapshotFailure, UpstreamUnavailableError)

--- a/tests/test_ppd_response_contract.py
+++ b/tests/test_ppd_response_contract.py
@@ -11,9 +11,25 @@ same harness run on the pre-PR-2 tree (377a553). Every difference was intended:
   `sector`, `escalated_from`/`escalated_to` are null, and a warning explains
   why (live-source completeness cannot authorise escalation).
 
-Everything else -- `core.search_transactions`, both MCP `ppd_transactions`
-tools, `rest.transactions`, `rest.meta_integrations` -- is byte-identical to
-pre-PR-2, which is the point: containment changed comps and nothing else.
+**PR 4 adds source routing**, so the golden was regenerated again and that
+delta reviewed line by line. It is additive apart from one line:
+
+* every PPD-bearing surface gains a `provenance` block. With no snapshot
+  materialized -- which is what this harness captures -- it reports
+  `source: "sparql"`, null coverage fields, and whatever completeness the
+  transport actually observed;
+* `cli.ppd_comps` stdout changes for a second reason: `_echo_json` no longer
+  goes through rich's `print`, which soft-wrapped long strings and left a
+  newline inside a JSON value, so the document did not parse. JSON output
+  exists to be machine-read.
+
+Nothing else moved. `rest.meta_integrations` is untouched, the live-path
+warning strings are byte-identical, and no row of data changed -- routing is
+inert until a snapshot is materialized and the flag is on.
+
+The harness also clears `PPD_SNAPSHOT_ENABLED`: this golden pins the LIVE-path
+contract, and a developer with the flag set in their shell would otherwise
+capture a different one.
 
 This is a change-detector, not a correctness oracle. Input is a fixed binding
 fixture patched in at the real transport boundary (`_fetch_sparql`) with sockets
@@ -67,8 +83,9 @@ def test_golden_covers_every_named_surface(golden):
 )
 def test_surface_is_unchanged(surface, golden, actual):
     assert actual[surface] == golden[surface], (
-        f"{surface} changed; PR 1 must add no behaviour. "
-        f"If this change is intended it belongs in a later PR with its own tests."
+        f"{surface} changed. If the change is intended, regenerate the golden "
+        f"(`python -m tests.ppd_golden_harness`), review the delta line by line, "
+        f"and record it in this module's docstring and the changelog."
     )
 
 
@@ -114,9 +131,42 @@ def test_surfaces_pr2_should_not_have_touched_carry_no_warnings(actual):
         assert actual[surface]["warnings"] == [], actual[surface]
 
 
-def test_no_provenance_fields_leaked_into_responses(actual):
-    """The provenance model exists but is still wired nowhere (PR 4 does that)."""
+def test_every_ppd_bearing_surface_carries_provenance(actual):
+    """PR 4 wires the block in. Inverted from PR 1's inertness assertion.
+
+    `rest.meta_integrations` is excluded: it carries no PPD rows, so a
+    provenance block there would describe nothing.
+    """
+    for surface in ("core.comps", "core.search_transactions",
+                    "mcp.plain.ppd_transactions", "mcp.app.ppd_transactions"):
+        provenance = actual[surface]["provenance"]
+        assert provenance is not None, surface
+        assert provenance["source"] == "sparql", surface
+        assert provenance["attribution_ref"] == "/v1/meta#attribution", surface
+
+    for surface in ("rest.comps", "rest.transactions"):
+        assert actual[surface]["body"]["provenance"]["source"] == "sparql", surface
+
+    assert "provenance" not in actual["rest.meta_integrations"]["body"]
+
+
+def test_licence_prose_is_never_inlined_into_a_response(actual):
+    """Spec test 28c. Responses carry a reference; the licence lives at /v1/meta."""
     blob = json.dumps(actual)
-    for field in ("attribution_ref", "completeness_basis", "source_release",
-                  "older_records_exist", "sample_complete"):
-        assert field not in blob, f"{field} was wired into a response in PR 1"
+    assert "Open Government Licence" not in blob
+    assert "Crown copyright" not in blob
+
+
+def test_the_live_path_declares_no_snapshot_coverage(actual):
+    """With nothing materialized, the snapshot fields must be null, not empty.
+
+    A `coverage_from` of `""` or `0` would read as a stated bound. Null is the
+    only honest value for "this answer has no coverage bounds".
+    """
+    for surface in ("core.comps", "core.search_transactions"):
+        provenance = actual[surface]["provenance"]
+        assert provenance["source_release"] is None, surface
+        assert provenance["coverage_from"] is None, surface
+        assert provenance["coverage_to"] is None, surface
+        assert provenance["freshness_days"] is None, surface
+        assert provenance["older_records_exist"] is None, surface

--- a/tests/test_ppd_spec_and_attribution.py
+++ b/tests/test_ppd_spec_and_attribution.py
@@ -27,7 +27,7 @@ def test_governing_specification_ships_with_the_code():
 
 def test_specification_is_version_stamped():
     head = SPEC.read_text().splitlines()[0]
-    assert "rev 5" in head and "FROZEN" in head, head
+    assert "rev 6" in head and "FROZEN" in head, head
 
 
 def _normalised(text: str) -> str:
@@ -41,6 +41,19 @@ def _normalised(text: str) -> str:
 
 def test_specification_states_the_exact_attribution():
     assert _normalised(REQUIRED_ATTRIBUTION) in _normalised(SPEC.read_text())
+
+
+def test_the_runtime_emits_the_exact_attribution():
+    """The gap this file used to leave open.
+
+    It pinned the literal against the SPECIFICATION only, so a runtime that
+    computed the statement from the current year satisfied every assertion here
+    while emitting the wrong sentence. The year is part of the prescribed
+    wording, not a copyright notice rendered for today.
+    """
+    from property_core.attribution import hmlr_attribution
+
+    assert hmlr_attribution() == REQUIRED_ATTRIBUTION
 
 
 def test_runtime_attribution_ref_is_compact_and_carries_no_prose():


### PR DESCRIPTION
Implements **PR 4** of the frozen specification at `docs/design/ppd-source-routing.md`, from `origin/main` at `81e8c80`. Red tests were written first; the predicted failures are recorded below.

`PPD_SNAPSHOT_ENABLED` stays **off**. No Dockerfile, Fly configuration, cloud resource, upload, release, deployment or production secret is touched, and neither production image installs the `snapshot` extra — which rollout gate G3 requires *before* the flag may be enabled.

## What this does

**READY becomes permission to route only after the adapter earns it (§4.4/§4.5).** The boot runtime from PR 3 establishes structural facts — digest, member safety, file inventory. None of those say the Parquet parses, carries the columns a query needs, or holds the rows the record claims. `SnapshotAdapter.open` checks the column schema *and types*, the row count against the verification record, and runs a real query, before it will answer anything. Every failure is a typed `SnapshotFailure`, which routing turns into a **live fallback** — never an empty result set that would read as "no sales here".

**Geography cannot be wrong by construction.** Membership is `outcode = ?` / `sector = ?` against materialized columns, so the `STRSTARTS("B5")` class of bug — matching `B50`, twenty miles away — is not expressible against this schema. Every filter is pushed into SQL, which is what makes the adapter's `limit + 1` completeness evidence independent of the caller's page size, unlike the live path's `raw_bindings < fetch_limit`.

**Coverage routing splits on whether the caller's window is bounded (§2.5).** Surfaces whose `months` is bounded (comps at 60/120, yield, report) narrow to `coverage_from` and warn — a window past coverage there means a stale snapshot, not an impossible request. Surfaces taking explicit or unbounded dates (`/v1/ppd/transactions`, `/v1/ppd/blocks`) are refused with a typed **422** carrying `requested` and `available` as structured fields plus a remedy. Never a partial 200: a truncated answer is indistinguishable from a complete one.

**An empty result is never allowed to mean "never sold" (§2.4).** On zero rows from a narrowed dateless window, one bounded existence probe runs against the live source — `LIMIT 1`, three-second timeout, no retries. `older_records_exist` is `true` (warn), `false` (honest empty, no warning), or `null` (warn). A probe that failed or timed out yields `null` and **never** `false`: `false` is a positive claim about the world, and only a completed probe may make it. No probe is issued when the snapshot returned rows.

**Boot happens once per process, through the FastMCP lifespan (§4.10).** `app/main.py` awaits the FastMCP lifespan explicitly from inside its FastAPI lifespan, because mounting does not chain them. Runtime state is process-scoped, never MCP session state. The filesystem single-flight lock still coordinates workers on one Machine. A boot failure is not a startup error — the server comes up and serves from live.

**Provenance reaches all four consumers**, built atomically from evidence already gathered (§3.1.2). Mixed-source responses declare both halves separately: comps may be `snapshot` while `subject_property` carries its own `source: "sparql"`, because a property's history routinely predates coverage. `YieldAnalysis` gains `sale_provenance` for the same reason it already carries its comps warnings.

## Red-first record

The seven new test modules were written and run before any implementation. Predicted and observed first failures:

| Module | Predicted failure | Observed |
|---|---|---|
| `test_adapter_validation` | no `property_core.snapshot.adapter` | `ModuleNotFoundError` ✓ |
| `test_adapter_queries` | same | `ModuleNotFoundError` ✓ |
| `test_source_fallback` | no `SnapshotFailure` in `exceptions` | `ImportError` ✓ |
| `test_lifespan_wiring` | no `bootstrap` / `state` in `property_core.snapshot` | `ImportError` ✓ |
| `test_coverage_routing`, `test_existence_probe`, `test_provenance_propagation` | fixtures cannot build an adapter | fixture `ModuleNotFoundError` ✓ |

Three test defects were found and fixed *in the tests*, not worked around in the code:
- `"COUNT" not in query` matched the projected `?county` column — tightened to the aggregate `\bCOUNT\s*\(`.
- Spec test 21c was written against evidence that *did* carry an exhaustion observation, which §3.1.1 says is admissible. Split into two tests: no observation → incomplete; observation → `source_exhausted`.
- The `model_copy(update=...)` prohibition was checked by text search, so prose explaining the prohibition read as a violation. Now checked over the parsed AST.

## Golden contract delta

`tests/fixtures/ppd/response_contract_golden.json` was regenerated and the delta reviewed line by line. It is **purely additive except one line**:

- every PPD-bearing surface gains a `provenance` block. With nothing materialized — which is what the harness captures — it reports `source: "sparql"`, null coverage fields, and whatever completeness the transport actually observed;
- `cli.ppd_comps` stdout also changes because `_echo_json` no longer goes through rich's `print`. Rich soft-wraps at the terminal width, so a long coverage warning arrived with a newline inside a JSON string and the document did not parse. A latent defect that provenance surfaced; JSON output exists to be machine-read.

No row of data changed, `rest.meta_integrations` is untouched, and the live-path warning strings are byte-identical — the escalation message is now source-specific, so live keeps its exact PR-2 wording. The harness now also clears `PPD_SNAPSHOT_ENABLED`, since this golden pins the live-path contract and a developer with the flag set would otherwise capture a different one.

## Two superseded PR-3 tests

Both asserted "PR 4 has not happened yet" and are replaced by their PR-4 form rather than deleted:
- `test_no_lifespan_wiring_exists_yet` → asserts both servers carry the lifespan and `app/main.py` awaits the MCP one.
- `test_no_request_path_boots_a_snapshot` → still a real invariant, narrowed to "no request path constructs `SnapshotRuntime`", plus a new test that exactly one module in the repo does.

## Deliberately not done

**Auto-escalation stays disabled on both sources.** §8 anticipated that snapshot routing "may re-enable it on limit-independent evidence", and the adapter now supplies exactly that. But changing which geography a caller's request covers is a behaviour change of its own and was not in this PR's scope. Both paths return the requested area with a warning; the wording differs by source because the reasons genuinely differ — saying "live-source completeness cannot establish safe escalation" over a snapshot answer would be false.

Also out of scope and untouched: the build pipeline, artifact distribution, the shadow corpus, and gates G1–G3.

## Verification

| Check | Result |
|---|---|
| Full suite, `--extra snapshot` | **1283 passed, 26 skipped** |
| Full suite, no snapshot extra (isolated venv, `duckdb` absent) | **1209 passed, 34 skipped** — adapter modules skip, none error |
| `uv lock --check` | clean; `pyproject.toml` and `uv.lock` unchanged |
| `uv build` | wheel + sdist include all seven new modules |
| Deploy config | `git diff` empty for both Dockerfiles, both fly configs and `.github/` |
| Flag default | `False`; `snapshot_status()` reports `routable: false` |

Held for review. No rollout, no build pipeline, no deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
