### PR TITLE
feat(ppd): local snapshot build and validation pipeline (PR 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,7 +220,13 @@ coverage take effect only once a snapshot is enabled and materialized.
   999,999,999-byte release under a different ETag. The receipt records the
   SHA-256 and length computed from the file alongside the release's validators,
   and the build refuses unless file, receipt and latest observation all agree.
-  A missing receipt is a refusal, not a default. The release check now uses the
+  A missing receipt is a refusal, not a default, and a receipt cannot be minted
+  from a file alone: it requires the SHA-256 captured when the release was
+  downloaded, since length agreement lets same-length bytes through under any
+  ETag. `download` mints one while streaming the release, taking bytes, digest
+  and validators from a single response; `receipt --expected-sha256` is the
+  weaker path for a file already on disk, and the receipt records which was
+  used. The release check now uses the
   official **HTTPS** endpoint published on GOV.UK rather than the plaintext S3
   website endpoint, so neither the validators nor the body are open to tampering
   in transit.
@@ -231,12 +237,21 @@ coverage take effect only once a snapshot is enabled and materialized.
   unparseable `price` or blank `transaction_id` inside the window, now stops the
   build, and two new gates enforce it independently: `required_values` (no NULL
   in a required column) and `reconciliation` (rows counted from the source equal
-  rows written).
-- **Releases are assembled in a candidate directory and promoted only after
-  booting.** A forced-`UNREADY` boot previously left the bundle, manifest and
-  `current.json` in the final directory — a publishable release nobody had
-  validated. `current.json` is now written last, so an interrupted promotion
-  leaves no pointer naming a manifest that is not there.
+  rows written). A price must be **written as digits**, not merely be castable:
+  `TRY_CAST` silently turns `1.5` into 2, `2.5` into 3, `1e3` into 1000, `0x10`
+  into 16 and `1_000` into 1000, each landing in the snapshot as a plausible
+  integer no gate can question.
+- **Releases are assembled outside the publishing directory and promoted only
+  after booting.** A forced-`UNREADY` boot previously left the bundle, manifest
+  and `current.json` in the final directory — a publishable release nobody had
+  validated. Candidates now live under the work directory, not under `dist/`,
+  and `current.json` is replaced **last and atomically**: `write_text`
+  truncates before writing, so an interrupted promotion used to leave an empty
+  pointer where a working release's pointer had been.
+- **The expected coverage end cannot be passed in.** `build` and `all` derive it
+  from the bound release's publication date; there is no `--source-coverage-end`
+  on either. Setting both dates so they agreed published a 28 July release as
+  covering 31 July.
 - Optional `snapshot` extra (`duckdb==1.5.5`) and `PPD_SNAPSHOT_ENABLED`
   (default **off**). The published library gains no required dependency.
 - `docs/design/ppd-source-routing.md` — the frozen specification governing this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,7 +258,13 @@ coverage take effect only once a snapshot is enabled and materialized.
   downloader streams into a unique sibling temporary file and replaces the
   destination only after the transfer's length is confirmed; writing the
   destination directly truncated a working CSV as soon as a refresh began, and
-  a mid-stream failure erased it while its receipt survived to describe it.
+  a mid-stream failure erased it while its receipt survived to describe it. The
+  CSV and its receipt are committed as a pair, with the CSV rolled back if the
+  receipt cannot be written, and a destination that resolves to the receipt path
+  is refused before any request. Every document the pipeline replaces — release
+  state, receipt, manifest, build report, `current.json` — is now written by
+  sibling-and-rename; the release state in particular carries the timestamp the
+  seven-day uningested alert is measured from.
 - **Promotion is a rename, on one filesystem, and says so.** The device IDs of
   the candidate and dist directories are compared before anything moves;
   `shutil.move` across a boundary would silently copy 266 MiB, which is neither

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,30 @@ coverage take effect only once a snapshot is enabled and materialized.
   observation. **Local only** — no upload, bucket, cloud resource, Fly command,
   secret, image or deployment change (§4.8). Runbook:
   `docs/ops/ppd-snapshot-build.md`.
+- **A source receipt binds the CSV to the release it claims to be.** Every gate
+  downstream checks the snapshot against itself, so an internally consistent
+  snapshot of the wrong file passed all of them: a 131-byte stale CSV built,
+  validated and booted `READY` while the release record described a
+  999,999,999-byte release under a different ETag. The receipt records the
+  SHA-256 and length computed from the file alongside the release's validators,
+  and the build refuses unless file, receipt and latest observation all agree.
+  A missing receipt is a refusal, not a default. The release check now uses the
+  official **HTTPS** endpoint published on GOV.UK rather than the plaintext S3
+  website endpoint, so neither the validators nor the body are open to tampering
+  in transit.
+- **The build fails closed on malformed required source values.** `TRY_CAST`
+  silently turned an unparseable price into NULL and published the row as a sale
+  with no price, while an unparseable date made a row vanish; every count-based
+  gate was happy either way. An unparseable `transfer_date` anywhere, or an
+  unparseable `price` or blank `transaction_id` inside the window, now stops the
+  build, and two new gates enforce it independently: `required_values` (no NULL
+  in a required column) and `reconciliation` (rows counted from the source equal
+  rows written).
+- **Releases are assembled in a candidate directory and promoted only after
+  booting.** A forced-`UNREADY` boot previously left the bundle, manifest and
+  `current.json` in the final directory — a publishable release nobody had
+  validated. `current.json` is now written last, so an interrupted promotion
+  leaves no pointer naming a manifest that is not there.
 - Optional `snapshot` extra (`duckdb==1.5.5`) and `PPD_SNAPSHOT_ENABLED`
   (default **off**). The published library gains no required dependency.
 - `docs/design/ppd-source-routing.md` — the frozen specification governing this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,21 @@ coverage take effect only once a snapshot is enabled and materialized.
   `TransactionNotFoundError`, `UpstreamShapeError`, `SnapshotFailure`,
   `SnapshotUnavailableError`, `UpstreamUnavailableError`), all exported from
   `property_core`.
+- **Local snapshot build and validation pipeline** (`tools/ppd_snapshot/`),
+  deliberately outside the published wheel. Builds the eleven year-only Parquet
+  partitions from `pp-complete.csv`, publishes the immutable manifest the runtime
+  reads plus a separate build report, and gates the artifact on schema and column
+  types (per partition, never over the union), row count, `transaction_id`
+  uniqueness, declared-coverage containment, the 120-month guarantee, the
+  provisional boundary, the file inventory, the bundle digest and deterministic
+  ordering. It then boots the result through the real `SnapshotRuntime` and opens
+  it with the real `SnapshotAdapter`, which is the only claim worth making about
+  a build. Also carries the section 4.9 release check: a `HEAD` on
+  `pp-complete.csv` comparing `ETag`/`Last-Modified`/`Content-Length` against the
+  recorded release, with the seven-day uningested alert measured from
+  observation. **Local only** — no upload, bucket, cloud resource, Fly command,
+  secret, image or deployment change (§4.8). Runbook:
+  `docs/ops/ppd-snapshot-build.md`.
 - Optional `snapshot` extra (`duckdb==1.5.5`) and `PPD_SNAPSHOT_ENABLED`
   (default **off**). The published library gains no required dependency.
 - `docs/design/ppd-source-routing.md` — the frozen specification governing this
@@ -230,10 +245,18 @@ coverage take effect only once a snapshot is enabled and materialized.
   changing which area a caller's request covers is a behaviour change of its
   own. Both paths return the requested area with a warning saying why, and the
   reason differs by source because the reasons genuinely differ.
-- The build pipeline, artifact distribution, the shadow corpus, and rollout
-  gates G1–G3. No Dockerfile, Fly config, image, secret or deployment is touched
-  here, and neither production image installs the `snapshot` extra yet — which
-  G3 requires **before** the flag may be enabled.
+- Artifact distribution, the shadow corpus, and rollout gates G1–G3. No
+  Dockerfile, Fly config, image, secret or deployment is touched here, and
+  neither production image installs the `snapshot` extra yet — which G3 requires
+  **before** the flag may be enabled. The build pipeline produces a bundle on a
+  workstation and stops there; where one would be hosted is separately approved.
+- **A measurement the rollout needs, recorded rather than acted on:** the real
+  eleven-partition **year-only** bundle is **266.2 MiB**, not the 214 MiB §1.1
+  estimates — that figure is a year+area measurement, while §1.2 mandates
+  year-only, which the same Phase 3 run measured at +22%. This moves §1.1's
+  download estimate and the G1 transient-disk budget. The specification is frozen
+  and is not edited here; correcting its sizing table is a decision round that
+  belongs before G1.
 
 
 ## v1.14.2 (2026-08-26) — MCP server card version; inferred-GBP warning ordering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,7 +251,19 @@ coverage take effect only once a snapshot is enabled and materialized.
 - **The expected coverage end cannot be passed in.** `build` and `all` derive it
   from the bound release's publication date; there is no `--source-coverage-end`
   on either. Setting both dates so they agreed published a 28 July release as
-  covering 31 July.
+  covering 31 July. The declaration is compared with the derived end **before
+  the build runs**, so a mismatch writes no Parquet at all rather than leaving a
+  failed snapshot directory behind.
+- **A failed refresh no longer destroys the release already held.** The
+  downloader streams into a unique sibling temporary file and replaces the
+  destination only after the transfer's length is confirmed; writing the
+  destination directly truncated a working CSV as soon as a refresh began, and
+  a mid-stream failure erased it while its receipt survived to describe it.
+- **Promotion is a rename, on one filesystem, and says so.** The device IDs of
+  the candidate and dist directories are compared before anything moves;
+  `shutil.move` across a boundary would silently copy 266 MiB, which is neither
+  atomic nor within the transient-disk and timing model G1 was measured
+  against.
 - Optional `snapshot` extra (`duckdb==1.5.5`) and `PPD_SNAPSHOT_ENABLED`
   (default **off**). The published library gains no required dependency.
 - `docs/design/ppd-source-routing.md` — the frozen specification governing this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,8 +259,11 @@ coverage take effect only once a snapshot is enabled and materialized.
   destination only after the transfer's length is confirmed; writing the
   destination directly truncated a working CSV as soon as a refresh began, and
   a mid-stream failure erased it while its receipt survived to describe it. The
-  CSV and its receipt are committed as a pair, with the CSV rolled back if the
-  receipt cannot be written, and a destination that resolves to the receipt path
+  CSV and its receipt are committed as a pair by an explicit transaction that
+  removes the renamed-aside backup only after publication or a confirmed
+  restoration — if the rollback itself fails the backup is kept and its path
+  reported, because it is then the only copy of the previous release — with the
+  CSV rolled back if the receipt cannot be written, and a destination that resolves to the receipt path
   is refused before any request. Every document the pipeline replaces — release
   state, receipt, manifest, build report, `current.json` — is now written by
   sibling-and-rename; the release state in particular carries the timestamp the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,11 @@ uv run --extra cli property-cli ppd comps "SW1A 1AA" --api-url http://localhost:
 
 # Tests — all four extras are required: `api` provides fastapi (test_http_metrics,
 # test_mcp_server), `apps` provides fastmcp[apps], `cli` provides typer.
-uv run --extra dev --extra api --extra apps --extra cli pytest                  # unit tests (mocked)
-RUN_LIVE_TESTS=1 uv run --extra dev --extra api --extra apps --extra cli pytest # live network tests
+# Add `--extra snapshot` as well, or the ~200 tests under tests/snapshot/ that
+# need DuckDB SKIP rather than fail (they use importorskip), and a green run
+# says nothing about them.
+uv run --extra dev --extra api --extra apps --extra cli --extra snapshot pytest  # unit tests (mocked)
+RUN_LIVE_TESTS=1 uv run --extra dev --extra api --extra apps --extra cli --extra snapshot pytest
 
 # Single test
 uv run --extra dev --extra api --extra apps --extra cli pytest tests/test_ppd_service_live.py -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,11 @@ property_app/               # FastMCP MCP app server (4th consumer of property_c
 ├── server.py               # FastMCP tools + Prefab dashboards entry point
 ├── tools.py                # @mcp.tool() definitions
 └── dashboards/             # Prefab UI dashboard views
+
+tools/                      # Local operator tooling. NOT in the published wheel.
+└── ppd_snapshot/           # PPD snapshot build + validation pipeline. Local
+                            # build only, no distribution — see
+                            # docs/ops/ppd-snapshot-build.md
 ```
 
 **Three-layer separation**:

--- a/docs/ops/ppd-snapshot-build.md
+++ b/docs/ops/ppd-snapshot-build.md
@@ -25,8 +25,8 @@ runbook.
 |---|---|
 | `pp-complete.csv` | HM Land Registry public open data, unauthenticated, over **HTTPS**: `https://price-paid-data.publicdata.landregistry.gov.uk/pp-complete.csv` (the [GOV.UK single-file page](https://www.gov.uk/government/statistical-data-sets/price-paid-data-single-file)). ~5.5 GB |
 | The release's `ETag` / `Last-Modified` / `Content-Length` | recorded by `check-release` into the release-state file |
-| The **source receipt** | written by `receipt`: the SHA-256 and byte length computed from the file, alongside the validators of the release it was fetched for |
-| `--coverage-to` | the release's declared coverage end, stated by the operator |
+| The **source receipt** | minted by `download` while streaming the release, or by `receipt` for a file already on disk — the SHA-256 and byte length computed from the bytes, alongside the validators of the release they arrived with |
+| `--coverage-to` | the operator's declaration of the window end, **checked** against the end derived from the bound release |
 
 The plaintext S3 *website* endpoint used during the lab phase is not used: over
 HTTP both the validators this pipeline trusts and the 5.5 GB body are open to
@@ -40,10 +40,29 @@ internally consistent snapshot of the **wrong file** passes all of them. A
 131-byte stale CSV once built, validated and booted `READY` while the release
 record described a 999,999,999-byte release under a different ETag.
 
-The receipt is the binding, and refuses in three directions:
+The receipt is the binding, and it has to be **grounded in evidence captured at
+download time** or it binds nothing: a receipt minted from a file plus a set of
+validators accepts any same-length bytes under any ETag. So there are two ways
+to obtain one, and they are not equally strong:
 
-* **file vs release** — writing a receipt refuses unless the file's length is
-  the length the observed release declares;
+* `download` streams the release, digests the bytes as they arrive and reads the
+  validators off the **same response** — file, digest and provenance from one
+  observation (`evidence: "streamed-download"`). This is the intended path.
+  *It has never been pointed at the real host in this work; no download of the
+  5.5 GB object is authorised here, and the mechanism is exercised against a
+  loopback server.*
+* `receipt --expected-sha256 <digest>` mints one for a file already on disk, and
+  refuses unless the file's computed digest matches the digest recorded when it
+  was fetched. Weaker — it trusts a record made elsewhere — and the receipt says
+  so (`evidence: "recorded-checksum"`).
+
+It then refuses in three directions:
+
+* **file vs recorded download** — minting refuses unless the file's SHA-256 is
+  the one recorded when the release was fetched; length agreement alone would
+  let same-length bytes through;
+* **file vs release** — minting also refuses unless the file's length is the
+  length the observed release declares;
 * **file vs receipt** — every build recomputes SHA-256 and length, so a file
   edited or replaced since is refused (including an edit that preserves length);
 * **receipt vs latest observation** — if `ETag`, `Last-Modified` or
@@ -56,8 +75,12 @@ blesses, so it is not a way around the binding.
 
 `--coverage-to` and the release record are kept **independent on purpose**: the
 coverage gate checks that the operator's declaration matches the end implied by
-the release's publication date (a file published in July covers to 30 June).
-Deriving one from the other would make the gate say nothing.
+the bound release's publication date (a file published in July covers to 30
+June). `build` and `all` therefore accept **no** way to set that expected end —
+a 28 July release was once published as covering 31 July by passing both dates
+so they agreed with each other. `validate` still accepts `--source-coverage-end`
+as a diagnostic and says out loud when the gate is comparing two operator-stated
+dates.
 
 ## Commands
 
@@ -66,11 +89,11 @@ Deriving one from the other would make the gate say nothing.
 uv run --extra snapshot python -m tools.ppd_snapshot check-release \
     --state ~/ppd-snapshot/release-state.json
 
-# 2. Bind the downloaded CSV to that release. Refuses if it is not that file.
-uv run --extra snapshot python -m tools.ppd_snapshot receipt \
-    --csv           ~/ppd-snapshot/pp-complete.csv \
-    --release-state ~/ppd-snapshot/release-state.json \
-    --receipt       ~/ppd-snapshot/receipt.json
+# 2. Fetch the release and mint its receipt from the same response. (For a file
+#    already on disk, use `receipt --expected-sha256 <digest recorded at fetch>`.)
+uv run --extra snapshot python -m tools.ppd_snapshot download \
+    --dest    ~/ppd-snapshot/pp-complete.csv \
+    --receipt ~/ppd-snapshot/receipt.json
 
 # 3. Verify the source, build, validate, package into a candidate, boot it
 #    through the real runtime and adapter, and only then promote. Stops before
@@ -83,6 +106,9 @@ uv run --extra snapshot python -m tools.ppd_snapshot all \
     --release-state  ~/ppd-snapshot/release-state.json \
     --source-receipt ~/ppd-snapshot/receipt.json \
     --memory 4GB
+# `--coverage-to` is the operator's declaration. The end it is checked against
+# is DERIVED from the bound release's publication date and cannot be passed in:
+# a flag that sets both makes the coverage gate compare a claim with itself.
 
 # 4. Re-run the gates against an existing snapshot directory. Without
 #    --rows and --eligible-source-rows the reconciliation gate cannot run, and
@@ -100,21 +126,26 @@ gets slower, not less correct.
 ## Outputs
 
 ```
-dist/candidate-<version>/                  assembled here, booted from here, never published from here
-dist/current.json                          written LAST, at promotion
+work/candidates/candidate-<version>/       assembled here, booted from here -- OUTSIDE dist
+dist/current.json                          replaced atomically, LAST, at promotion
 dist/manifest-<version>.json               exactly the eleven SnapshotManifest fields
 dist/snapshot-<version>.tar.zst            eleven year=YYYY/data.parquet members, nothing else
 dist/build-report-<version>.json           provenance, timings, per-year rows, boot-check result
 ```
 
-**Nothing reaches the dist root until it has booted.** A bundle sitting beside a
-`current.json` is a release someone can publish, so the pipeline assembles into
-`candidate-<version>/`, boots *that* directory through the real runtime, and
-promotes only on `READY`. Promotion moves the bundle, then the manifest, then
-the report, and writes `current.json` last: a pointer is a promise that what it
-names is present, so an interrupted promotion leaves a partial directory and no
-pointer, which reads as "nothing published". A failed boot leaves the candidate
-in place for diagnosis and the dist root untouched.
+**Nothing reaches the dist root until it has booted, and the candidate is not
+inside it.** A candidate under `dist/` is still inside the directory something
+else may sync, mirror or serve — "ignore the subdirectory" is a convention, not
+a boundary — so candidates are assembled under the work directory, booted
+through the real runtime from there, and promoted only on `READY`.
+
+Promotion moves the bundle, then the manifest, then the report, and replaces
+`current.json` **last and atomically** (write beside, then rename). A pointer is
+a promise that what it names is present, and `write_text` truncates before it
+writes: interrupted, it would leave an empty pointer where a working one used to
+be, taking down the release that was already published. An interrupted promotion
+now leaves the previous pointer byte-for-byte intact. A failed boot leaves the
+candidate in place for diagnosis and the dist root untouched.
 
 The published manifest carries **only** what
 `property_core.snapshot.models.SnapshotManifest` declares. That model is frozen
@@ -146,9 +177,16 @@ The gates in `validate.py` check what the build *declared* against what it
 The build itself **fails closed** before any of this: a source row whose
 `transfer_date` does not parse stops the build outright — it can be neither
 placed in the window nor shown to be outside it, so dropping it would be
-deciding silently — and an unparseable `price` or a blank `transaction_id`
+deciding silently — and a non-canonical `price` or a blank `transaction_id`
 *inside* the window stops it too. Rows outside the window are not the
 snapshot's problem and are not policed.
+
+**A price must be written as digits, not merely be castable.** `TRY_CAST` is not
+a validity test: it accepts and silently *changes* `1.5` to 2, `2.5` to 3, `.5`
+to 1, `1e3` to 1000, `0x10` to 16 and `1_000` to 1000. Each lands in the
+snapshot as a plausible integer that no gate reading the artifact can question,
+so the source text is matched against `^[0-9]+$` before any cast. Signed forms
+are refused too: guessing at intent is how the rounding got in.
 
 **Coverage is a declaration about the source release, not a measurement of the
 rows.** `min(transfer_date) == coverage_from` is deliberately *not* required: a
@@ -181,8 +219,9 @@ Halt and report; there is no override flag for any of these.
 * Any gate fails, or the boot check does not end `READY` (nothing is promoted).
 * The CSV does not match its receipt, or the receipt does not match the latest
   observed release — including a release that has moved on since the download.
-* A source row inside the window has an unparseable `price` or no
+* A source row inside the window has a non-canonical `price` or no
   `transaction_id`, or any source row has an unparseable `transfer_date`.
+* The declared `--coverage-to` is not the end the bound release implies.
 * The recorded `ETag` differs from the release the CSV was fetched from — a fresh
   5.5 GB download is a cost decision, not something the pipeline should make.
 * `transaction_id` is not unique within the window, or the row count disagrees.
@@ -204,6 +243,7 @@ no deployed system touched). Source: the HM Land Registry release fetched on
 | Rows in the eleven-year window | **10,394,935** |
 | Eligible source rows (counted from the source) | 10,394,935 — equal, so nothing was lost between reading and writing |
 | Source rows with a malformed required value | 0 (`transfer_date` anywhere, `price`/`transaction_id` in window) |
+| Source rows with a non-canonical price | 0 of 31,430,611 — checked across the whole file, not only the window |
 | Distinct `transaction_id` | 10,394,935 — equal, so the key holds |
 | Rows with no parseable date | 0 |
 | Partitions | 11 (`year=2016` … `year=2026`) |
@@ -231,10 +271,11 @@ files and a byte-identical bundle** — the same sha256 `50f802b2…9072c` — a
 identical logical content digests.
 
 The fail-closed source checks were added after that build and re-run against the
-same CSV using the shipped predicates: **zero** rows with a malformed required
-value, and an eligible source count of 10,394,935 — exactly the published row
-count. The artifact's content and size are therefore unchanged by that work, and
-the build was not re-run. The per-partition content digests recorded in the
+same CSV using the shipped predicates — including the stricter canonical-price
+rule: **zero** rows with a malformed required value, **zero** non-canonical
+prices anywhere in the 31,430,611-row file, and an eligible source count of
+10,394,935 — exactly the published row count. The artifact's content and size
+are therefore unchanged by that work, and the build was not re-run. The per-partition content digests recorded in the
 build report predate the switch to the length-prefixed encoding and are not
 comparable across that change; the bundle digest is.
 

--- a/docs/ops/ppd-snapshot-build.md
+++ b/docs/ops/ppd-snapshot-build.md
@@ -51,7 +51,12 @@ to obtain one, and they are not equally strong:
   streams into a unique sibling temporary file and replaces the destination only
   once the length agrees with `Content-Length`, so **a failed refresh leaves the
   release already held byte-for-byte intact**; writing the destination directly
-  would truncate a working CSV the moment a refresh began.
+  would truncate a working CSV the moment a refresh began. The CSV and its
+  receipt are one fact in two files, so both are written before either is
+  published and the CSV is rolled back if the receipt cannot be committed — a
+  half-committed pair is worse than a refused refresh, because nothing
+  downstream can tell it happened. A destination that resolves to the receipt
+  path is refused before any request is made.
   *It has never been pointed at the real host in this work; no download of the
   5.5 GB object is authorised here, and the mechanism is exercised against a
   loopback server.*
@@ -224,6 +229,13 @@ queryability validation. `all` exits non-zero unless that ends in `READY`.
   build concern. A stale but verified snapshot is always served in preference to
   going unready.
 
+Every document this pipeline replaces — the release state, the receipt, the
+manifest, the build report, `current.json` — is written to a unique sibling,
+fsynced, and renamed over its target. `write_text` truncates first, so an
+interrupted write would leave an empty file where a working one was; for the
+release state that would reset the first-observed timestamp the seven-day alert
+is measured from.
+
 ## Stop conditions
 
 Halt and report; there is no override flag for any of these.
@@ -238,6 +250,7 @@ Halt and report; there is no override flag for any of these.
   Parquet at all — a directory that failed validation is still a directory
   someone can point `validate` at.
 * The candidate and dist directories are on different filesystems.
+* The download destination and the receipt path are the same file.
 * The recorded `ETag` differs from the release the CSV was fetched from — a fresh
   5.5 GB download is a cost decision, not something the pipeline should make.
 * `transaction_id` is not unique within the window, or the row count disagrees.

--- a/docs/ops/ppd-snapshot-build.md
+++ b/docs/ops/ppd-snapshot-build.md
@@ -50,7 +50,9 @@ The receipt is the binding, and refuses in three directions:
   `Content-Length` have moved, the file on disk is a previous release and the
   build refuses.
 
-There is no default and no override: a missing receipt is a refusal.
+There is no default and no override: a missing receipt is a refusal, and
+`build` applies the same check as `all` — it writes the artifact `validate` then
+blesses, so it is not a way around the binding.
 
 `--coverage-to` and the release record are kept **independent on purpose**: the
 coverage gate checks that the operator's declaration matches the end implied by

--- a/docs/ops/ppd-snapshot-build.md
+++ b/docs/ops/ppd-snapshot-build.md
@@ -57,6 +57,13 @@ to obtain one, and they are not equally strong:
   half-committed pair is worse than a refused refresh, because nothing
   downstream can tell it happened. A destination that resolves to the receipt
   path is refused before any request is made.
+
+  The commit is an explicit transaction (`staged` → `backed_up` →
+  `dest_published` → `published`). While it is open, the renamed-aside backup is
+  the **only** copy of the previous release, so it is deleted at exactly two
+  points: after publication, and after a restoration confirmed to have worked.
+  **If the rollback itself fails**, `download` exits `3`, keeps the backup and
+  prints its path — see below.
   *It has never been pointed at the real host in this work; no download of the
   5.5 GB object is authorised here, and the mechanism is exercised against a
   loopback server.*
@@ -235,6 +242,14 @@ fsynced, and renamed over its target. `write_text` truncates first, so an
 interrupted write would leave an empty file where a working one was; for the
 release state that would reset the first-observed timestamp the seven-day alert
 is measured from.
+
+### If `download` exits 3
+
+The commit failed *and* the previous release could not be put back. The
+destination holds the new bytes, the receipt still describes the old ones, and
+the previous release is retained in the temporary file whose path is printed.
+Recover by moving that file back over the destination, or by re-running
+`download`. Nothing deletes it for you: it is the only copy.
 
 ## Stop conditions
 

--- a/docs/ops/ppd-snapshot-build.md
+++ b/docs/ops/ppd-snapshot-build.md
@@ -23,9 +23,34 @@ runbook.
 
 | Input | Where it comes from |
 |---|---|
-| `pp-complete.csv` | HM Land Registry public open data, unauthenticated. ~5.5 GB |
+| `pp-complete.csv` | HM Land Registry public open data, unauthenticated, over **HTTPS**: `https://price-paid-data.publicdata.landregistry.gov.uk/pp-complete.csv` (the [GOV.UK single-file page](https://www.gov.uk/government/statistical-data-sets/price-paid-data-single-file)). ~5.5 GB |
 | The release's `ETag` / `Last-Modified` / `Content-Length` | recorded by `check-release` into the release-state file |
+| The **source receipt** | written by `receipt`: the SHA-256 and byte length computed from the file, alongside the validators of the release it was fetched for |
 | `--coverage-to` | the release's declared coverage end, stated by the operator |
+
+The plaintext S3 *website* endpoint used during the lab phase is not used: over
+HTTP both the validators this pipeline trusts and the 5.5 GB body are open to
+tampering in transit, and the receipt would then faithfully bind the build to
+whatever arrived.
+
+### The source receipt
+
+Every gate after the build checks the snapshot against *itself*, so an
+internally consistent snapshot of the **wrong file** passes all of them. A
+131-byte stale CSV once built, validated and booted `READY` while the release
+record described a 999,999,999-byte release under a different ETag.
+
+The receipt is the binding, and refuses in three directions:
+
+* **file vs release** — writing a receipt refuses unless the file's length is
+  the length the observed release declares;
+* **file vs receipt** — every build recomputes SHA-256 and length, so a file
+  edited or replaced since is refused (including an edit that preserves length);
+* **receipt vs latest observation** — if `ETag`, `Last-Modified` or
+  `Content-Length` have moved, the file on disk is a previous release and the
+  build refuses.
+
+There is no default and no override: a missing receipt is a refusal.
 
 `--coverage-to` and the release record are kept **independent on purpose**: the
 coverage gate checks that the operator's declaration matches the end implied by
@@ -39,20 +64,31 @@ Deriving one from the other would make the gate say nothing.
 uv run --extra snapshot python -m tools.ppd_snapshot check-release \
     --state ~/ppd-snapshot/release-state.json
 
-# 2. Build, validate, package, verify the digest, and boot the result
-#    through the real runtime and adapter. Stops before packaging if a gate fails.
+# 2. Bind the downloaded CSV to that release. Refuses if it is not that file.
+uv run --extra snapshot python -m tools.ppd_snapshot receipt \
+    --csv           ~/ppd-snapshot/pp-complete.csv \
+    --release-state ~/ppd-snapshot/release-state.json \
+    --receipt       ~/ppd-snapshot/receipt.json
+
+# 3. Verify the source, build, validate, package into a candidate, boot it
+#    through the real runtime and adapter, and only then promote. Stops before
+#    packaging if a gate fails, and before promotion if the boot fails.
 uv run --extra snapshot python -m tools.ppd_snapshot all \
     --csv  ~/ppd-snapshot/pp-complete.csv \
     --work ~/ppd-snapshot/work \
     --dist ~/ppd-snapshot/dist \
     --coverage-to 2026-06-30 \
-    --release-state ~/ppd-snapshot/release-state.json \
+    --release-state  ~/ppd-snapshot/release-state.json \
+    --source-receipt ~/ppd-snapshot/receipt.json \
     --memory 4GB
 
-# 3. Re-run the gates against an existing snapshot directory.
+# 4. Re-run the gates against an existing snapshot directory. Without
+#    --rows and --eligible-source-rows the reconciliation gate cannot run, and
+#    an unrunnable gate is reported as skipped and exits non-zero.
 uv run --extra snapshot python -m tools.ppd_snapshot validate \
     --snapshot ~/ppd-snapshot/work/snapshot \
-    --coverage-to 2026-06-30 --source-coverage-end 2026-06-30
+    --coverage-to 2026-06-30 --source-coverage-end 2026-06-30 \
+    --rows 10394935 --eligible-source-rows 10394935
 ```
 
 `--memory` is the DuckDB limit, not a peak-RSS promise; DuckDB spills to
@@ -62,11 +98,21 @@ gets slower, not less correct.
 ## Outputs
 
 ```
-dist/current.json                          {"current_manifest": "manifest-<version>.json"}
+dist/candidate-<version>/                  assembled here, booted from here, never published from here
+dist/current.json                          written LAST, at promotion
 dist/manifest-<version>.json               exactly the eleven SnapshotManifest fields
 dist/snapshot-<version>.tar.zst            eleven year=YYYY/data.parquet members, nothing else
 dist/build-report-<version>.json           provenance, timings, per-year rows, boot-check result
 ```
+
+**Nothing reaches the dist root until it has booted.** A bundle sitting beside a
+`current.json` is a release someone can publish, so the pipeline assembles into
+`candidate-<version>/`, boots *that* directory through the real runtime, and
+promotes only on `READY`. Promotion moves the bundle, then the manifest, then
+the report, and writes `current.json` last: a pointer is a promise that what it
+names is present, so an interrupted promotion leaves a partial directory and no
+pointer, which reads as "nothing published". A failed boot leaves the candidate
+in place for diagnosis and the dist root untouched.
 
 The published manifest carries **only** what
 `property_core.snapshot.models.SnapshotManifest` declares. That model is frozen
@@ -86,12 +132,21 @@ The gates in `validate.py` check what the build *declared* against what it
 |---|---|
 | `partitions` | exactly the eleven expected years, one `data.parquet` each, nothing else in the tree |
 | `schema` | every partition on its own terms against `property_core.snapshot.schema.REQUIRED_COLUMNS`, names **and** types — per file, never over the union, because `union_by_name` hides a partition missing a column |
+| `required_values` | no row has a NULL `transaction_id`, `price` or `transfer_date`. `TRY_CAST` turns an unparseable value into NULL, which every count-based gate then waves through — the snapshot would serve a sale with no price |
+| `reconciliation` | the rows the **source** held for this window, counted from the staged source with its own predicate, equal the rows the snapshot wrote. Every other count comes from the artifact, so a row lost between reading and writing is invisible to all of them |
 | `rows` | the declared count, the union count and the sum of the parts agree |
 | `uniqueness` | `transaction_id` is a key across the whole window |
 | `coverage` | the bounds are the intended partition boundary and the release's declared end, and every row falls **inside** them |
 | `guarantee` | the window still answers a 120-month request — what makes eleven partitions load-bearing rather than ten |
 | `provisional` | the boundary is the computed month and lies inside the window |
 | `ordering` | each partition is in `transfer_date DESC, transaction_id ASC`, checked by physical row number |
+
+The build itself **fails closed** before any of this: a source row whose
+`transfer_date` does not parse stops the build outright — it can be neither
+placed in the window nor shown to be outside it, so dropping it would be
+deciding silently — and an unparseable `price` or a blank `transaction_id`
+*inside* the window stops it too. Rows outside the window are not the
+snapshot's problem and are not policed.
 
 **Coverage is a declaration about the source release, not a measurement of the
 rows.** `min(transfer_date) == coverage_from` is deliberately *not* required: a
@@ -121,7 +176,11 @@ queryability validation. `all` exits non-zero unless that ends in `READY`.
 
 Halt and report; there is no override flag for any of these.
 
-* Any gate fails, or the boot check does not end `READY`.
+* Any gate fails, or the boot check does not end `READY` (nothing is promoted).
+* The CSV does not match its receipt, or the receipt does not match the latest
+  observed release — including a release that has moved on since the download.
+* A source row inside the window has an unparseable `price` or no
+  `transaction_id`, or any source row has an unparseable `transfer_date`.
 * The recorded `ETag` differs from the release the CSV was fetched from — a fresh
   5.5 GB download is a cost decision, not something the pipeline should make.
 * `transaction_id` is not unique within the window, or the row count disagrees.
@@ -141,6 +200,8 @@ no deployed system touched). Source: the HM Land Registry release fetched on
 | Declared coverage | `2016-01-01` … `2026-06-30`, `provisional_from` `2026-03-01` |
 | Source rows | 31,430,611 |
 | Rows in the eleven-year window | **10,394,935** |
+| Eligible source rows (counted from the source) | 10,394,935 — equal, so nothing was lost between reading and writing |
+| Source rows with a malformed required value | 0 (`transfer_date` anywhere, `price`/`transaction_id` in window) |
 | Distinct `transaction_id` | 10,394,935 — equal, so the key holds |
 | Rows with no parseable date | 0 |
 | Partitions | 11 (`year=2016` … `year=2026`) |
@@ -166,6 +227,14 @@ object storage, can produce that.
 Two independent full builds from the same CSV produced **byte-identical Parquet
 files and a byte-identical bundle** — the same sha256 `50f802b2…9072c` — and
 identical logical content digests.
+
+The fail-closed source checks were added after that build and re-run against the
+same CSV using the shipped predicates: **zero** rows with a malformed required
+value, and an eligible source count of 10,394,935 — exactly the published row
+count. The artifact's content and size are therefore unchanged by that work, and
+the build was not re-run. The per-partition content digests recorded in the
+build report predate the switch to the length-prefixed encoding and are not
+comparable across that change; the bundle digest is.
 
 **Observed twice on one machine; not a guarantee.** Nothing here establishes that
 DuckDB 1.5.5 or zstd promise byte-reproducible output, so the pipeline does not

--- a/docs/ops/ppd-snapshot-build.md
+++ b/docs/ops/ppd-snapshot-build.md
@@ -26,7 +26,7 @@ runbook.
 | `pp-complete.csv` | HM Land Registry public open data, unauthenticated, over **HTTPS**: `https://price-paid-data.publicdata.landregistry.gov.uk/pp-complete.csv` (the [GOV.UK single-file page](https://www.gov.uk/government/statistical-data-sets/price-paid-data-single-file)). ~5.5 GB |
 | The release's `ETag` / `Last-Modified` / `Content-Length` | recorded by `check-release` into the release-state file |
 | The **source receipt** | minted by `download` while streaming the release, or by `receipt` for a file already on disk — the SHA-256 and byte length computed from the bytes, alongside the validators of the release they arrived with |
-| `--coverage-to` | the operator's declaration of the window end, **checked** against the end derived from the bound release |
+| `--coverage-to` | the operator's declaration of the window end, **checked before the build runs** against the end derived from the bound release |
 
 The plaintext S3 *website* endpoint used during the lab phase is not used: over
 HTTP both the validators this pipeline trusts and the 5.5 GB body are open to
@@ -47,7 +47,11 @@ to obtain one, and they are not equally strong:
 
 * `download` streams the release, digests the bytes as they arrive and reads the
   validators off the **same response** — file, digest and provenance from one
-  observation (`evidence: "streamed-download"`). This is the intended path.
+  observation (`evidence: "streamed-download"`). This is the intended path. It
+  streams into a unique sibling temporary file and replaces the destination only
+  once the length agrees with `Content-Length`, so **a failed refresh leaves the
+  release already held byte-for-byte intact**; writing the destination directly
+  would truncate a working CSV the moment a refresh began.
   *It has never been pointed at the real host in this work; no download of the
   5.5 GB object is authorised here, and the mechanism is exercised against a
   loopback server.*
@@ -139,8 +143,16 @@ else may sync, mirror or serve — "ignore the subdirectory" is a convention, no
 a boundary — so candidates are assembled under the work directory, booted
 through the real runtime from there, and promoted only on `READY`.
 
+**The work and dist directories must be on one filesystem**, and this is
+enforced rather than advised: promotion compares their device IDs and refuses
+before moving anything if they differ. `os.replace` cannot cross devices and
+`shutil.move` silently degrades to a copy — not atomic, and it doubles both the
+transient disk and the wall time the G1 model was measured against, while
+leaving a window where a half-copied bundle sits in the publishing directory.
+Promotion is `os.replace` throughout, never a copy.
+
 Promotion moves the bundle, then the manifest, then the report, and replaces
-`current.json` **last and atomically** (write beside, then rename). A pointer is
+`current.json` **last and atomically** (write a unique sibling, then rename). A pointer is
 a promise that what it names is present, and `write_text` truncates before it
 writes: interrupted, it would leave an empty pointer where a working one used to
 be, taking down the release that was already published. An interrupted promotion
@@ -221,7 +233,11 @@ Halt and report; there is no override flag for any of these.
   observed release — including a release that has moved on since the download.
 * A source row inside the window has a non-canonical `price` or no
   `transaction_id`, or any source row has an unparseable `transfer_date`.
-* The declared `--coverage-to` is not the end the bound release implies.
+* The declared `--coverage-to` is not the end the bound release implies. This
+  is checked **before the build runs**, so a mismatched declaration writes no
+  Parquet at all — a directory that failed validation is still a directory
+  someone can point `validate` at.
+* The candidate and dist directories are on different filesystems.
 * The recorded `ETag` differs from the release the CSV was fetched from — a fresh
   5.5 GB download is a cost decision, not something the pipeline should make.
 * `transaction_id` is not unique within the window, or the row count disagrees.

--- a/docs/ops/ppd-snapshot-build.md
+++ b/docs/ops/ppd-snapshot-build.md
@@ -1,0 +1,204 @@
+# PPD snapshot build — local runbook
+
+How the Price Paid Data snapshot is built and validated on a workstation.
+Governed by [`docs/design/ppd-source-routing.md`](../design/ppd-source-routing.md)
+rev 6 (§1.1–1.3, §4.8, §4.9). The pipeline lives in
+[`tools/ppd_snapshot/`](../../tools/ppd_snapshot/) and is deliberately
+outside the published wheel.
+
+## Scope — and what this must not do
+
+**Build and validate locally. Nothing else** (§4.8). No upload, bucket, cloud
+resource, Fly command, secret, Dockerfile change, deployment config, feature-flag
+change, release or version bump happens here or is enabled by anything here.
+`--dist` is a directory on this machine; `current.json` is written beside the
+manifest only so the whole boot path can be exercised offline through
+`LocalDirectorySource`.
+
+**Artifact distribution — where a bundle is hosted and how a deployed app
+reaches it — is a separately approved decision** and is not settled by this
+runbook.
+
+## Inputs
+
+| Input | Where it comes from |
+|---|---|
+| `pp-complete.csv` | HM Land Registry public open data, unauthenticated. ~5.5 GB |
+| The release's `ETag` / `Last-Modified` / `Content-Length` | recorded by `check-release` into the release-state file |
+| `--coverage-to` | the release's declared coverage end, stated by the operator |
+
+`--coverage-to` and the release record are kept **independent on purpose**: the
+coverage gate checks that the operator's declaration matches the end implied by
+the release's publication date (a file published in July covers to 30 June).
+Deriving one from the other would make the gate say nothing.
+
+## Commands
+
+```bash
+# 1. Has HMLR published? HEAD only -- nothing is downloaded.
+uv run --extra snapshot python -m tools.ppd_snapshot check-release \
+    --state ~/ppd-snapshot/release-state.json
+
+# 2. Build, validate, package, verify the digest, and boot the result
+#    through the real runtime and adapter. Stops before packaging if a gate fails.
+uv run --extra snapshot python -m tools.ppd_snapshot all \
+    --csv  ~/ppd-snapshot/pp-complete.csv \
+    --work ~/ppd-snapshot/work \
+    --dist ~/ppd-snapshot/dist \
+    --coverage-to 2026-06-30 \
+    --release-state ~/ppd-snapshot/release-state.json \
+    --memory 4GB
+
+# 3. Re-run the gates against an existing snapshot directory.
+uv run --extra snapshot python -m tools.ppd_snapshot validate \
+    --snapshot ~/ppd-snapshot/work/snapshot \
+    --coverage-to 2026-06-30 --source-coverage-end 2026-06-30
+```
+
+`--memory` is the DuckDB limit, not a peak-RSS promise; DuckDB spills to
+`--work/tmp` beneath it. On a machine with little free RAM, lower it — the build
+gets slower, not less correct.
+
+## Outputs
+
+```
+dist/current.json                          {"current_manifest": "manifest-<version>.json"}
+dist/manifest-<version>.json               exactly the eleven SnapshotManifest fields
+dist/snapshot-<version>.tar.zst            eleven year=YYYY/data.parquet members, nothing else
+dist/build-report-<version>.json           provenance, timings, per-year rows, boot-check result
+```
+
+The published manifest carries **only** what
+`property_core.snapshot.models.SnapshotManifest` declares. That model is frozen
+and `extra="forbid"`, so a manifest carrying build provenance does not degrade
+gracefully — it fails to parse at boot and the Machine falls back to the live
+source. (The Phase 3 prototype's manifest is exactly that shape: it carries
+`source_sha256`, `compression`, `row_group_size` and `logical_sort_order`, and is
+not publishable as-is.) Everything else lives in the build report, which nothing
+reads at runtime.
+
+## What is checked, and by whom
+
+The gates in `validate.py` check what the build *declared* against what it
+*wrote*:
+
+| Gate | What it establishes |
+|---|---|
+| `partitions` | exactly the eleven expected years, one `data.parquet` each, nothing else in the tree |
+| `schema` | every partition on its own terms against `property_core.snapshot.schema.REQUIRED_COLUMNS`, names **and** types — per file, never over the union, because `union_by_name` hides a partition missing a column |
+| `rows` | the declared count, the union count and the sum of the parts agree |
+| `uniqueness` | `transaction_id` is a key across the whole window |
+| `coverage` | the bounds are the intended partition boundary and the release's declared end, and every row falls **inside** them |
+| `guarantee` | the window still answers a 120-month request — what makes eleven partitions load-bearing rather than ten |
+| `provisional` | the boundary is the computed month and lies inside the window |
+| `ordering` | each partition is in `transfer_date DESC, transaction_id ASC`, checked by physical row number |
+
+**Coverage is a declaration about the source release, not a measurement of the
+rows.** `min(transfer_date) == coverage_from` is deliberately *not* required: a
+window whose first day saw no sale is normal, and requiring it would make the
+declaration follow the data instead of the other way round.
+
+Then the artifact is judged by the code that has to serve it: `SnapshotRuntime`
+streams and digest-verifies the bundle, extracts it with member validation,
+checks the exact Parquet-file count and full file inventory, and activates it
+atomically; `SnapshotAdapter.open` runs its own schema, row-count and
+queryability validation. `all` exits non-zero unless that ends in `READY`.
+
+## Cadence (§4.9)
+
+* **Daily** `check-release`. One `HEAD`; no download unless the validators moved.
+* **Rebuild monthly, following each observed release** — cadence follows the
+  release, not the calendar.
+* An observed release still uningested after **7 days** raises an alert from
+  `check-release`: that means the pipeline is failing, which is a different fact
+  from the snapshot merely being old. The clock runs from **observation**, and
+  `all` stops it by recording the ingested release in the state file.
+* `freshness_days > 45` is a *runtime* warning in the provenance block, not a
+  build concern. A stale but verified snapshot is always served in preference to
+  going unready.
+
+## Stop conditions
+
+Halt and report; there is no override flag for any of these.
+
+* Any gate fails, or the boot check does not end `READY`.
+* The recorded `ETag` differs from the release the CSV was fetched from — a fresh
+  5.5 GB download is a cost decision, not something the pipeline should make.
+* `transaction_id` is not unique within the window, or the row count disagrees.
+* Anything that would need an upload, bucket, Fly command, secret, image change,
+  flag change or release.
+
+## Measured results
+
+Recorded from two full local builds on 2026-08-28 (workstation, no network,
+no deployed system touched). Source: the HM Land Registry release fetched on
+2026-08-27.
+
+| | |
+|---|---|
+| Source file | `pp-complete.csv`, 5,494,145,759 bytes, sha256 `b643c0ff…4031d0` |
+| Source release | ETag `"333695120b2f0a82265a499df7682980-655"`, Last-Modified Tue, 28 Jul 2026 |
+| Declared coverage | `2016-01-01` … `2026-06-30`, `provisional_from` `2026-03-01` |
+| Source rows | 31,430,611 |
+| Rows in the eleven-year window | **10,394,935** |
+| Distinct `transaction_id` | 10,394,935 — equal, so the key holds |
+| Rows with no parseable date | 0 |
+| Partitions | 11 (`year=2016` … `year=2026`) |
+| Parquet on disk | 280,924,336 B (**267.9 MiB**) |
+| Bundle `.tar.zst` | 279,109,872 B (**266.2 MiB**), sha256 `50f802b2…9072c` |
+| Extracted by the runtime | 280,925,271 B (267.9 MiB) |
+| Build | ingest 44.6 s · derive 13.5 s · write 8.7 s |
+| Whole pipeline | **82 s** wall clock: build → validate → package → verify → boot |
+| Peak RSS | 2,912.5 MB with `--memory 2GB` (DuckDB spills beneath the limit) |
+| Boot through `SnapshotRuntime` + `SnapshotAdapter` | **READY**, 1.4 s |
+| DuckDB | v1.5.5 |
+
+Rows per partition: 2016 1,046,436 · 2017 1,067,591 · 2018 1,037,613 ·
+2019 1,012,160 · 2020 897,565 · 2021 1,281,653 · 2022 1,076,779 · 2023 860,931 ·
+2024 929,467 · 2025 932,678 · 2026 252,062.
+
+The 1.4 s boot is from a **local directory** source: it contains no transfer and
+is not a readiness-target measurement. Only G1, on the real machine against real
+object storage, can produce that.
+
+### Reproducibility, as observed
+
+Two independent full builds from the same CSV produced **byte-identical Parquet
+files and a byte-identical bundle** — the same sha256 `50f802b2…9072c` — and
+identical logical content digests.
+
+**Observed twice on one machine; not a guarantee.** Nothing here establishes that
+DuckDB 1.5.5 or zstd promise byte-reproducible output, so the pipeline does not
+depend on it: what it checks is the *logical* content digest — same rows, same
+values, same order, per partition — which is a property of the build rather than
+of the writer.
+
+### What this means for G1
+
+| | Specification §1.1 / §4.7 | Measured |
+|---|---|---|
+| Bundle size | 214 MiB | **266.2 MiB** (+24.4%) |
+| Download @100 Mbit/s | 18.0 s | **~22.3 s** |
+| Peak transient boot disk | ~444 MiB implied | **~534.1 MiB** (bundle and extraction both live until the bundle is unlinked) |
+| §4.7 free-space precondition (`bundle_bytes * 2.5`) | ~535 MiB | **665.4 MiB** |
+
+These are inputs to G1, not a G1 result: G1 is a measurement on the real 512 MB
+Fly machine and is **not** part of this work.
+
+## Known correction required before G1
+
+§1.1 of the frozen specification sizes eleven partitions at **214 MiB**. That
+figure is a **year+area** measurement, while §1.2 mandates **year-only**, which
+the same Phase 3 run measured at **+22%**. The real year-only bundle is
+materially larger (see the table above), which moves two numbers the rollout
+depends on:
+
+* the §1.1 download estimate (18.0 s @100 Mbit/s) understates transfer time, and
+  therefore overstates the headroom inside the 30 s readiness target; and
+* **G1** — transient boot disk on the 512 MB Fly app — must be measured against
+  the real bundle size, with §4.7's `bundle_bytes * 2.5` free-space rule applied
+  to it.
+
+**The specification is frozen and is not edited by this PR.** Correcting §1.1's
+sizing table is a decision round that belongs before G1 and the rollout.
+`MAX_BUNDLE_BYTES` (1 GiB) is unaffected and still has ample margin.

--- a/tests/snapshot/build_fixtures.py
+++ b/tests/snapshot/build_fixtures.py
@@ -1,0 +1,66 @@
+"""Synthetic HM Land Registry Price Paid CSV rows.
+
+The real feed is headerless, quoted, and sixteen columns wide in a fixed order.
+These fixtures reproduce that shape exactly -- a build test that reads a
+convenient made-up layout proves nothing about the file the pipeline is pointed
+at in production.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable, Sequence
+
+#: The published column order of `pp-complete.csv`. No header row is emitted:
+#: the real file has none.
+SOURCE_COLUMNS: tuple[str, ...] = (
+    "transaction_id", "price", "transfer_date", "postcode", "property_type",
+    "new_build", "duration", "paon", "saon", "street", "locality", "town",
+    "district", "county", "ppd_category", "record_status",
+)
+
+
+def csv_row(
+    transaction_id: str,
+    postcode: str,
+    transfer_date: str,
+    price: int = 250_000,
+    *,
+    property_type: str = "F",
+    new_build: str = "N",
+    duration: str = "L",
+    paon: str = "1",
+    saon: str = "",
+    street: str = "HIGH STREET",
+    locality: str = "",
+    town: str = "BIRMINGHAM",
+    district: str = "BIRMINGHAM",
+    county: str = "WEST MIDLANDS",
+    ppd_category: str = "A",
+    record_status: str = "A",
+) -> tuple[str, ...]:
+    """One source row, in published column order."""
+    return (
+        transaction_id, str(price), transfer_date, postcode, property_type,
+        new_build, duration, paon, saon, street, locality, town, district,
+        county, ppd_category, record_status,
+    )
+
+
+def write_source_csv(path: Path, rows: Iterable[Sequence[str]]) -> Path:
+    """Write rows in the published dialect: quoted, comma separated, no header."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh, quoting=csv.QUOTE_ALL, lineterminator="\n")
+        for row in rows:
+            writer.writerow(list(row))
+    return path
+
+
+def spanning_rows(years: Iterable[int]) -> list[tuple[str, ...]]:
+    """One row per year, enough to fill an eleven-partition window."""
+    return [
+        csv_row(f"{{T-{year}}}", "B5 7AA", f"{year}-06-15 00:00", 200_000 + year)
+        for year in years
+    ]

--- a/tests/snapshot/test_snapshot_build.py
+++ b/tests/snapshot/test_snapshot_build.py
@@ -114,3 +114,64 @@ def test_build_reports_the_window_it_was_given(built):
 
 def test_build_records_the_duckdb_version_that_wrote_the_files(built):
     assert built.duckdb_version.startswith("v1.5.")
+
+
+# -- malformed required source values fail the build ------------------------
+
+def build_from(tmp_path: Path, rows, name: str = "s"):
+    csv_path = write_source_csv(tmp_path / f"pp-{name}.csv", rows)
+    return build_snapshot(BuildRequest(
+        csv_path=csv_path, out_dir=tmp_path / name, coverage_to=date(2026, 6, 30),
+        temp_dir=tmp_path / f"tmp-{name}"))
+
+
+def test_an_unparseable_date_anywhere_in_the_source_fails_the_build(tmp_path):
+    from tools.ppd_snapshot.build import MalformedSourceRows
+
+    with pytest.raises(MalformedSourceRows, match="transfer_date"):
+        build_from(tmp_path, [
+            csv_row("{OK}", "B5 7AA", "2024-03-01 00:00", 200_000),
+            # Unplaceable: it may or may not belong in the window, and dropping
+            # it would silently decide that it does not.
+            csv_row("{BAD}", "B5 7AB", "not-a-date", 210_000),
+        ])
+
+
+def test_an_unparseable_price_inside_the_window_fails_the_build(tmp_path):
+    from tools.ppd_snapshot.build import MalformedSourceRows
+
+    rows = [csv_row("{OK}", "B5 7AA", "2024-03-01 00:00", 200_000)]
+    bad = list(csv_row("{BAD}", "B5 7AB", "2024-04-01 00:00", 0))
+    bad[1] = "not-a-price"
+    with pytest.raises(MalformedSourceRows, match="price"):
+        build_from(tmp_path, rows + [tuple(bad)])
+
+
+def test_a_blank_transaction_id_inside_the_window_fails_the_build(tmp_path):
+    from tools.ppd_snapshot.build import MalformedSourceRows
+
+    with pytest.raises(MalformedSourceRows, match="transaction_id"):
+        build_from(tmp_path, [
+            csv_row("{OK}", "B5 7AA", "2024-03-01 00:00", 200_000),
+            csv_row("  ", "B5 7AB", "2024-04-01 00:00", 210_000),
+        ])
+
+
+def test_a_malformed_price_outside_the_window_does_not_fail_the_build(tmp_path):
+    # Rows the snapshot never serves are not its problem.
+    bad = list(csv_row("{OLD}", "B5 7AB", "2011-04-01 00:00", 0))
+    bad[1] = "not-a-price"
+    built = build_from(tmp_path, [
+        csv_row("{OK}", "B5 7AA", "2024-03-01 00:00", 200_000), tuple(bad)])
+    assert built.rows == 1
+
+
+def test_the_build_counts_eligible_source_rows_independently_of_what_it_wrote(
+        tmp_path):
+    built = build_from(tmp_path, [
+        csv_row("{A}", "B5 7AA", "2024-03-01 00:00", 200_000),
+        csv_row("{B}", "B5 7AB", "2016-03-01 00:00", 210_000),
+        csv_row("{OLD}", "B5 7AC", "2011-03-01 00:00", 100_000),
+    ])
+    assert built.eligible_source_rows == 2
+    assert built.rows == 2

--- a/tests/snapshot/test_snapshot_build.py
+++ b/tests/snapshot/test_snapshot_build.py
@@ -175,3 +175,48 @@ def test_the_build_counts_eligible_source_rows_independently_of_what_it_wrote(
     ])
     assert built.eligible_source_rows == 2
     assert built.rows == 2
+
+
+# -- prices must be canonical integers, not merely castable ------------------
+
+def _with_price(text: str):
+    row = list(csv_row("{BAD}", "B5 7AB", "2024-04-01 00:00", 0))
+    row[1] = text
+    return tuple(row)
+
+
+@pytest.mark.parametrize("text,cast_to", [
+    ("1.5", "2"),        # rounded, not rejected
+    ("2.5", "3"),
+    (".5", "1"),
+    ("100.", "100"),
+    ("1e3", "1000"),     # scientific notation
+    ("0x10", "16"),      # hexadecimal
+    ("1_000", "1000"),   # digit separators
+    ("+100", "100"),     # signed forms
+    ("-100", "-100"),
+])
+def test_a_non_canonical_price_fails_the_build(tmp_path, text, cast_to):
+    """`TRY_CAST` accepts far more than an integer and silently changes it.
+
+    A price of "1.5" becomes 2 and a price of "0x10" becomes 16, with nothing
+    downstream able to tell: the artifact holds a plausible integer, so every
+    gate that reads the snapshot agrees with itself.
+    """
+    from tools.ppd_snapshot.build import MalformedSourceRows
+
+    with pytest.raises(MalformedSourceRows, match="price"):
+        build_from(tmp_path, [
+            csv_row("{OK}", "B5 7AA", "2024-03-01 00:00", 200_000),
+            _with_price(text),
+        ], name=f"p{abs(hash(text))}")
+
+
+def test_a_canonical_price_is_accepted(tmp_path):
+    built = build_from(tmp_path, [_with_price("100")])
+    assert built.rows == 1
+
+
+def test_surrounding_whitespace_does_not_make_a_price_non_canonical(tmp_path):
+    built = build_from(tmp_path, [_with_price(" 100 ")], name="ws")
+    assert built.rows == 1

--- a/tests/snapshot/test_snapshot_build.py
+++ b/tests/snapshot/test_snapshot_build.py
@@ -1,0 +1,116 @@
+"""Red-first tests for the snapshot build window, layout and derived columns.
+
+Everything here runs on a handful of synthetic CSV rows. The real 5.5 GB
+`pp-complete.csv` is never touched by the test suite: a build gate that can only
+be exercised at full scale is a gate nobody runs.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+from tools.ppd_snapshot.build import (  # noqa: E402
+    PARTITION_YEARS,
+    PROVISIONAL_MONTHS,
+    BuildRequest,
+    build_snapshot,
+    coverage_start,
+    expected_years,
+    provisional_boundary,
+)
+from tests.snapshot.build_fixtures import csv_row, write_source_csv  # noqa: E402
+
+
+# -- window arithmetic -------------------------------------------------------
+
+def test_coverage_starts_at_january_of_the_eleventh_calendar_year_back():
+    # Eleven partitions ending 2026 means the window opens on 2016-01-01, which
+    # is what makes a 120-month request from any date in 2026 serviceable.
+    assert coverage_start(date(2026, 6, 30)) == date(2016, 1, 1)
+
+
+def test_expected_years_are_eleven_consecutive_calendar_years():
+    assert expected_years(date(2026, 6, 30)) == tuple(range(2016, 2027))
+    assert len(expected_years(date(2026, 6, 30))) == PARTITION_YEARS
+
+
+def test_provisional_boundary_is_first_day_of_the_month_three_before_the_end():
+    assert PROVISIONAL_MONTHS == 3
+    assert provisional_boundary(date(2026, 6, 30)) == date(2026, 3, 1)
+
+
+def test_provisional_boundary_wraps_across_the_year_end():
+    assert provisional_boundary(date(2026, 1, 31)) == date(2025, 10, 1)
+
+
+# -- the build ---------------------------------------------------------------
+
+@pytest.fixture
+def built(tmp_path: Path):
+    csv_path = write_source_csv(tmp_path / "pp.csv", [
+        csv_row("{AAA}", "B5 7AA", "2016-01-01 00:00", 200_000),
+        csv_row("{BBB}", "B5 7AB", "2024-03-01 00:00", 210_000),
+        csv_row("{CCC}", "B50 4AA", "2024-03-01 00:00", 400_000),
+        csv_row("{DDD}", "M3 7AA", "2026-06-30 00:00", 250_000),
+        # Outside the window on both sides -- must not reach the snapshot.
+        csv_row("{OLD}", "B5 7AC", "2015-12-31 00:00", 100_000),
+        csv_row("{NEW}", "B5 7AD", "2026-07-01 00:00", 500_000),
+    ])
+    result = build_snapshot(BuildRequest(
+        csv_path=csv_path,
+        out_dir=tmp_path / "snapshot",
+        coverage_to=date(2026, 6, 30),
+        temp_dir=tmp_path / "tmp",
+    ))
+    return result
+
+
+def test_build_writes_one_parquet_file_per_expected_year(built):
+    written = sorted(p.relative_to(built.snapshot_dir).as_posix()
+                     for p in built.snapshot_dir.rglob("*.parquet"))
+    assert written == [f"year={y}/data.parquet" for y in range(2016, 2027)]
+    assert built.parquet_files == PARTITION_YEARS
+
+
+def test_build_writes_nothing_but_parquet_partitions(built):
+    stray = [p.relative_to(built.snapshot_dir).as_posix()
+             for p in built.snapshot_dir.rglob("*")
+             if p.is_file() and p.suffix != ".parquet"]
+    assert stray == []
+
+
+def test_build_excludes_rows_outside_the_declared_window(built):
+    con = duckdb.connect()
+    ids = [r[0] for r in con.execute(
+        f"SELECT transaction_id FROM read_parquet("
+        f"'{built.snapshot_dir}/**/*.parquet') ORDER BY transaction_id").fetchall()]
+    assert ids == ["AAA", "BBB", "CCC", "DDD"]
+    assert built.rows == 4
+
+
+def test_build_derives_exact_outcode_and_sector_columns(built):
+    con = duckdb.connect()
+    rows = con.execute(
+        f"SELECT transaction_id, outcode, sector FROM read_parquet("
+        f"'{built.snapshot_dir}/**/*.parquet') ORDER BY transaction_id").fetchall()
+    assert rows == [
+        ("AAA", "B5", "B5 7"),
+        ("BBB", "B5", "B5 7"),
+        ("CCC", "B50", "B50 4"),
+        ("DDD", "M3", "M3 7"),
+    ]
+
+
+def test_build_reports_the_window_it_was_given(built):
+    assert built.coverage_from == date(2016, 1, 1)
+    assert built.coverage_to == date(2026, 6, 30)
+    assert built.provisional_from == date(2026, 3, 1)
+
+
+def test_build_records_the_duckdb_version_that_wrote_the_files(built):
+    assert built.duckdb_version.startswith("v1.5.")

--- a/tests/snapshot/test_snapshot_cli.py
+++ b/tests/snapshot/test_snapshot_cli.py
@@ -7,6 +7,7 @@ can publish, and "we knew it was bad" is not a control.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -52,7 +53,6 @@ def argv(tmp_path: Path, **over) -> list[str]:
         "--work": str(tmp_path / "work"),
         "--dist": str(tmp_path / "dist"),
         "--coverage-to": "2026-06-30",
-        "--source-coverage-end": "2026-06-30",
         "--today": "2026-07-15",
         "--version": "v20260828T101500Z",
         "--release-state": str(tmp_path / "release-state.json"),
@@ -66,11 +66,17 @@ def argv(tmp_path: Path, **over) -> list[str]:
 
 
 def bound(tmp_path: Path, **over) -> list[str]:
-    """`prepare` plus a written receipt: the ordinary, authorised flow."""
-    prepare(tmp_path, **over)
-    assert main(["receipt", "--csv", str(tmp_path / "pp.csv"),
+    """`prepare` plus a written receipt: the ordinary, authorised flow.
+
+    The digest stands in for the one recorded when the file was downloaded --
+    the receipt refuses to be minted without it.
+    """
+    csv_path = prepare(tmp_path, **over)
+    recorded = hashlib.sha256(csv_path.read_bytes()).hexdigest()
+    assert main(["receipt", "--csv", str(csv_path),
                  "--release-state", str(tmp_path / "release-state.json"),
-                 "--receipt", str(tmp_path / "receipt.json")]) == 0
+                 "--receipt", str(tmp_path / "receipt.json"),
+                 "--expected-sha256", recorded]) == 0
     return argv(tmp_path)
 
 
@@ -87,10 +93,11 @@ def test_the_all_command_builds_validates_packages_and_boots(tmp_path, capsys):
 def test_a_failing_gate_stops_before_anything_is_packaged(tmp_path, capsys):
     # The snapshot claims a window the source release does not cover.
     bound(tmp_path)
-    code = main(["all", *argv(tmp_path,
-                              **{"--source-coverage-end": "2026-05-31"})])
+    # The declared window disagrees with the release the receipt binds to.
+    code = main(["all", *argv(tmp_path, **{"--coverage-to": "2026-05-31"})])
     assert code != 0
-    assert list((tmp_path / "dist").glob("*.tar.zst")) == []
+    assert not (tmp_path / "dist").exists() or \
+        list((tmp_path / "dist").glob("*.tar.zst")) == []
     assert "coverage" in capsys.readouterr().out
 
 
@@ -135,10 +142,12 @@ def test_a_failed_boot_check_leaves_the_dist_root_empty(tmp_path, monkeypatch):
 
     dist = tmp_path / "dist"
     assert not (dist / "current.json").exists()
-    assert list(dist.glob("*.tar.zst")) == []
-    assert list(dist.glob("manifest-*.json")) == []
-    # The candidate is kept for diagnosis, and is not a published release.
-    assert [p.name for p in dist.iterdir()] == ["candidate-v20260828T101500Z"]
+    # Nothing is in the publishing directory at all -- not even a subdirectory
+    # someone could mistake for a release.
+    assert not dist.exists() or list(dist.iterdir()) == []
+    # The candidate is kept for diagnosis, outside dist.
+    assert (tmp_path / "work" / "candidates" /
+            "candidate-v20260828T101500Z").is_dir()
 
 
 # -- the source must be bound to a release ----------------------------------
@@ -154,10 +163,12 @@ def test_the_all_command_refuses_without_a_source_receipt(tmp_path, capsys):
 def test_a_receipt_is_refused_for_a_file_the_release_contradicts(tmp_path, capsys):
     """The reproduction: a stale local CSV under a release describing something
     far larger. It used to build, validate and boot READY."""
-    prepare(tmp_path, content_length=999_999_999)
-    code = main(["receipt", "--csv", str(tmp_path / "pp.csv"),
+    csv_path = prepare(tmp_path, content_length=999_999_999)
+    code = main(["receipt", "--csv", str(csv_path),
                  "--release-state", str(tmp_path / "release-state.json"),
-                 "--receipt", str(tmp_path / "receipt.json")])
+                 "--receipt", str(tmp_path / "receipt.json"),
+                 "--expected-sha256",
+                 hashlib.sha256(csv_path.read_bytes()).hexdigest()])
     assert code != 0
     assert "999999999" in capsys.readouterr().out
     assert not (tmp_path / "receipt.json").exists()
@@ -203,3 +214,30 @@ def test_the_build_command_also_refuses_an_unbound_source(tmp_path, capsys):
     assert main(["build", *argv(tmp_path)]) != 0
     assert "no source receipt" in capsys.readouterr().out
     assert not (tmp_path / "work" / "snapshot").exists()
+
+
+# -- the declared window cannot be talked past ------------------------------
+
+def test_the_all_command_does_not_accept_a_source_coverage_end_override(tmp_path):
+    """The reproduction: a 28 July release was published as covering 31 July by
+    setting both date arguments to agree with each other."""
+    bound(tmp_path)
+    with pytest.raises(SystemExit):
+        main(["all", *argv(tmp_path), "--source-coverage-end", "2026-07-31"])
+
+
+def test_a_window_the_release_does_not_cover_is_refused(tmp_path, capsys):
+    bound(tmp_path)
+    code = main(["all", *argv(tmp_path, **{"--coverage-to": "2026-07-31"})])
+    assert code != 0
+    out = capsys.readouterr().out
+    assert "coverage" in out and "2026-06-30" in out
+    assert not (tmp_path / "dist").exists() or \
+        list((tmp_path / "dist").glob("*.tar.zst")) == []
+
+
+def test_the_expected_end_comes_from_the_receipt_not_the_command_line(tmp_path,
+                                                                     capsys):
+    bound(tmp_path)
+    assert main(["all", *argv(tmp_path)]) == 0
+    assert "2026-06-30" in capsys.readouterr().out

--- a/tests/snapshot/test_snapshot_cli.py
+++ b/tests/snapshot/test_snapshot_cli.py
@@ -275,3 +275,23 @@ def test_the_source_is_verified_once_per_run(tmp_path, monkeypatch):
                         lambda *a, **k: (calls.append(1), real(*a, **k))[1])
     assert main(["all", *argv(tmp_path)]) == 0
     assert len(calls) == 1
+
+
+def test_a_retained_backup_is_reported_to_the_operator(tmp_path, monkeypatch,
+                                                       capsys):
+    """A rollback failure leaves the only copy of the previous release in a
+    temporary file. Its path is the whole recovery instruction."""
+    from tools.ppd_snapshot import __main__ as cli
+    from tools.ppd_snapshot.source_receipt import ReceiptRollbackFailed
+
+    backup = tmp_path / ".pp.csv.xyz.prev"
+
+    def _boom(*args, **kwargs):
+        raise ReceiptRollbackFailed(f"retained at {backup}", backup_path=backup)
+
+    monkeypatch.setattr(cli, "download_with_receipt", _boom)
+    code = cli.main(["download", "--url", "http://example.invalid/pp.csv",
+                     "--dest", str(tmp_path / "pp.csv"),
+                     "--receipt", str(tmp_path / "receipt.json")])
+    assert code != 0
+    assert str(backup) in capsys.readouterr().out

--- a/tests/snapshot/test_snapshot_cli.py
+++ b/tests/snapshot/test_snapshot_cli.py
@@ -194,3 +194,12 @@ def test_validate_without_a_source_count_does_not_report_success(tmp_path, capsy
                  "--source-coverage-end", "2026-06-30", "--today", "2026-07-15"])
     assert code != 0
     assert "skip" in capsys.readouterr().out
+
+
+def test_the_build_command_also_refuses_an_unbound_source(tmp_path, capsys):
+    # `build` writes the artifact that `validate` then blesses, so it applies
+    # the same binding as `all` rather than being a way around it.
+    prepare(tmp_path)
+    assert main(["build", *argv(tmp_path)]) != 0
+    assert "no source receipt" in capsys.readouterr().out
+    assert not (tmp_path / "work" / "snapshot").exists()

--- a/tests/snapshot/test_snapshot_cli.py
+++ b/tests/snapshot/test_snapshot_cli.py
@@ -25,15 +25,38 @@ ROWS = [
 ]
 
 
+#: Validators for the synthetic "release". `Last-Modified` in July implies a
+#: coverage end of 30 June, which is what the coverage gate checks against.
+LAST_MODIFIED = "Tue, 28 Jul 2026 05:16:16 GMT"
+
+
+def prepare(tmp_path: Path, *, content_length: int | None = None,
+            etag: str = '"a-release-etag"') -> Path:
+    """A source CSV bound to an observed release by a receipt."""
+    csv_path = write_source_csv(tmp_path / "pp.csv", ROWS)
+    state = tmp_path / "release-state.json"
+    state.write_text(json.dumps({
+        "url": "https://example.invalid/pp-complete.csv",
+        "etag": etag,
+        "last_modified": LAST_MODIFIED,
+        "content_length": (csv_path.stat().st_size if content_length is None
+                           else content_length),
+        "first_observed_utc": "2026-08-28T09:00:00+00:00",
+    }))
+    return csv_path
+
+
 def argv(tmp_path: Path, **over) -> list[str]:
     args = {
-        "--csv": str(write_source_csv(tmp_path / "pp.csv", ROWS)),
+        "--csv": str(tmp_path / "pp.csv"),
         "--work": str(tmp_path / "work"),
         "--dist": str(tmp_path / "dist"),
         "--coverage-to": "2026-06-30",
         "--source-coverage-end": "2026-06-30",
         "--today": "2026-07-15",
         "--version": "v20260828T101500Z",
+        "--release-state": str(tmp_path / "release-state.json"),
+        "--source-receipt": str(tmp_path / "receipt.json"),
     }
     args.update(over)
     flat: list[str] = []
@@ -42,8 +65,17 @@ def argv(tmp_path: Path, **over) -> list[str]:
     return flat
 
 
+def bound(tmp_path: Path, **over) -> list[str]:
+    """`prepare` plus a written receipt: the ordinary, authorised flow."""
+    prepare(tmp_path, **over)
+    assert main(["receipt", "--csv", str(tmp_path / "pp.csv"),
+                 "--release-state", str(tmp_path / "release-state.json"),
+                 "--receipt", str(tmp_path / "receipt.json")]) == 0
+    return argv(tmp_path)
+
+
 def test_the_all_command_builds_validates_packages_and_boots(tmp_path, capsys):
-    assert main(["all", *argv(tmp_path)]) == 0
+    assert main(["all", *bound(tmp_path)]) == 0
     dist = tmp_path / "dist"
     assert (dist / "current.json").is_file()
     assert (dist / "manifest-v20260828T101500Z.json").is_file()
@@ -54,14 +86,16 @@ def test_the_all_command_builds_validates_packages_and_boots(tmp_path, capsys):
 
 def test_a_failing_gate_stops_before_anything_is_packaged(tmp_path, capsys):
     # The snapshot claims a window the source release does not cover.
-    code = main(["all", *argv(tmp_path, **{"--source-coverage-end": "2026-05-31"})])
+    bound(tmp_path)
+    code = main(["all", *argv(tmp_path,
+                              **{"--source-coverage-end": "2026-05-31"})])
     assert code != 0
     assert list((tmp_path / "dist").glob("*.tar.zst")) == []
     assert "coverage" in capsys.readouterr().out
 
 
 def test_the_build_report_records_what_was_measured(tmp_path):
-    assert main(["all", *argv(tmp_path)]) == 0
+    assert main(["all", *bound(tmp_path)]) == 0
     report = json.loads(
         (tmp_path / "dist" / "build-report-v20260828T101500Z.json").read_text())
     assert report["rows"] == 2
@@ -72,12 +106,91 @@ def test_the_build_report_records_what_was_measured(tmp_path):
 
 
 def test_validate_alone_reports_every_gate(tmp_path, capsys):
+    bound(tmp_path)
+    assert main(["build", *argv(tmp_path)]) == 0
+    code = main(["validate", "--snapshot", str(tmp_path / "work" / "snapshot"),
+                 "--coverage-to", "2026-06-30",
+                 "--source-coverage-end", "2026-06-30", "--today", "2026-07-15",
+                 "--rows", "2", "--eligible-source-rows", "2"])
+    assert code == 0
+    out = capsys.readouterr().out
+    for gate in ("partitions", "schema", "rows", "uniqueness", "coverage",
+                 "guarantee", "provisional", "ordering", "required_values",
+                 "reconciliation"):
+        assert gate in out
+
+
+def test_a_failed_boot_check_leaves_the_dist_root_empty(tmp_path, monkeypatch):
+    """A bundle in `dist` is a bundle someone can publish.
+
+    Reproduction: with the boot check forced to fail, the pipeline used to leave
+    the bundle, the manifest and `current.json` sitting in the final directory.
+    """
+    from tools.ppd_snapshot import __main__ as cli
+
+    monkeypatch.setattr(cli, "_boot_check", lambda *a, **k: {
+        "readiness": "unready", "version": None, "activated": False,
+        "bytes_downloaded": 0, "source_error": "forced", "timings_ms": {}})
+    assert main(["all", *bound(tmp_path)]) != 0
+
+    dist = tmp_path / "dist"
+    assert not (dist / "current.json").exists()
+    assert list(dist.glob("*.tar.zst")) == []
+    assert list(dist.glob("manifest-*.json")) == []
+    # The candidate is kept for diagnosis, and is not a published release.
+    assert [p.name for p in dist.iterdir()] == ["candidate-v20260828T101500Z"]
+
+
+# -- the source must be bound to a release ----------------------------------
+
+def test_the_all_command_refuses_without_a_source_receipt(tmp_path, capsys):
+    prepare(tmp_path)
+    assert main(["all", *argv(tmp_path)]) != 0
+    assert "no source receipt" in capsys.readouterr().out
+    assert not (tmp_path / "dist").exists() or \
+        list((tmp_path / "dist").iterdir()) == []
+
+
+def test_a_receipt_is_refused_for_a_file_the_release_contradicts(tmp_path, capsys):
+    """The reproduction: a stale local CSV under a release describing something
+    far larger. It used to build, validate and boot READY."""
+    prepare(tmp_path, content_length=999_999_999)
+    code = main(["receipt", "--csv", str(tmp_path / "pp.csv"),
+                 "--release-state", str(tmp_path / "release-state.json"),
+                 "--receipt", str(tmp_path / "receipt.json")])
+    assert code != 0
+    assert "999999999" in capsys.readouterr().out
+    assert not (tmp_path / "receipt.json").exists()
+
+
+def test_the_all_command_refuses_once_the_release_has_moved_on(tmp_path, capsys):
+    bound(tmp_path)
+    # HMLR publishes again: the CSV on disk is now the previous release.
+    state = tmp_path / "release-state.json"
+    payload = json.loads(state.read_text())
+    payload["etag"] = '"a-newer-etag"'
+    payload["content_length"] = 999_999_999
+    state.write_text(json.dumps(payload))
+
+    assert main(["all", *argv(tmp_path)]) != 0
+    out = capsys.readouterr().out
+    assert "refusing to build" in out and "moved" in out
+    assert list((tmp_path / "dist").glob("*.tar.zst")) == []
+
+
+def test_the_all_command_refuses_a_csv_edited_since_its_receipt(tmp_path, capsys):
+    bound(tmp_path)
+    (tmp_path / "pp.csv").write_text("\"{X}\",\"1\",\"2024-01-01 00:00\"\n")
+    assert main(["all", *argv(tmp_path)]) != 0
+    assert "refusing to build" in capsys.readouterr().out
+
+
+def test_validate_without_a_source_count_does_not_report_success(tmp_path, capsys):
+    # Reconciliation cannot run, and an unrunnable gate is not a passing one.
+    bound(tmp_path)
     assert main(["build", *argv(tmp_path)]) == 0
     code = main(["validate", "--snapshot", str(tmp_path / "work" / "snapshot"),
                  "--coverage-to", "2026-06-30",
                  "--source-coverage-end", "2026-06-30", "--today", "2026-07-15"])
-    assert code == 0
-    out = capsys.readouterr().out
-    for gate in ("partitions", "schema", "rows", "uniqueness", "coverage",
-                 "guarantee", "provisional", "ordering"):
-        assert gate in out
+    assert code != 0
+    assert "skip" in capsys.readouterr().out

--- a/tests/snapshot/test_snapshot_cli.py
+++ b/tests/snapshot/test_snapshot_cli.py
@@ -1,0 +1,83 @@
+"""The operator entry point, exercised end to end on a synthetic source file.
+
+The important behaviour under test is the ordering: a snapshot that fails a gate
+must never reach the packaging step. A bundle that exists is a bundle someone
+can publish, and "we knew it was bad" is not a control.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+zstandard = pytest.importorskip("zstandard",
+                                reason="needs the optional 'snapshot' extra")
+
+from tools.ppd_snapshot.__main__ import main  # noqa: E402
+from tests.snapshot.build_fixtures import csv_row, write_source_csv  # noqa: E402
+
+ROWS = [
+    csv_row("{T-2024}", "B5 7AA", "2024-03-01 00:00", 210_000),
+    csv_row("{T-2026}", "M3 7AA", "2026-06-30 00:00", 250_000),
+]
+
+
+def argv(tmp_path: Path, **over) -> list[str]:
+    args = {
+        "--csv": str(write_source_csv(tmp_path / "pp.csv", ROWS)),
+        "--work": str(tmp_path / "work"),
+        "--dist": str(tmp_path / "dist"),
+        "--coverage-to": "2026-06-30",
+        "--source-coverage-end": "2026-06-30",
+        "--today": "2026-07-15",
+        "--version": "v20260828T101500Z",
+    }
+    args.update(over)
+    flat: list[str] = []
+    for key, value in args.items():
+        flat += [key, value]
+    return flat
+
+
+def test_the_all_command_builds_validates_packages_and_boots(tmp_path, capsys):
+    assert main(["all", *argv(tmp_path)]) == 0
+    dist = tmp_path / "dist"
+    assert (dist / "current.json").is_file()
+    assert (dist / "manifest-v20260828T101500Z.json").is_file()
+    assert (dist / "snapshot-v20260828T101500Z.tar.zst").is_file()
+    assert (dist / "build-report-v20260828T101500Z.json").is_file()
+    assert "READY" in capsys.readouterr().out
+
+
+def test_a_failing_gate_stops_before_anything_is_packaged(tmp_path, capsys):
+    # The snapshot claims a window the source release does not cover.
+    code = main(["all", *argv(tmp_path, **{"--source-coverage-end": "2026-05-31"})])
+    assert code != 0
+    assert list((tmp_path / "dist").glob("*.tar.zst")) == []
+    assert "coverage" in capsys.readouterr().out
+
+
+def test_the_build_report_records_what_was_measured(tmp_path):
+    assert main(["all", *argv(tmp_path)]) == 0
+    report = json.loads(
+        (tmp_path / "dist" / "build-report-v20260828T101500Z.json").read_text())
+    assert report["rows"] == 2
+    assert report["parquet_files"] == 11
+    assert report["gates"] == "passed"
+    assert report["rows_per_year"]["2024"] == 1
+    assert report["boot_check"]["readiness"] == "ready"
+
+
+def test_validate_alone_reports_every_gate(tmp_path, capsys):
+    assert main(["build", *argv(tmp_path)]) == 0
+    code = main(["validate", "--snapshot", str(tmp_path / "work" / "snapshot"),
+                 "--coverage-to", "2026-06-30",
+                 "--source-coverage-end", "2026-06-30", "--today", "2026-07-15"])
+    assert code == 0
+    out = capsys.readouterr().out
+    for gate in ("partitions", "schema", "rows", "uniqueness", "coverage",
+                 "guarantee", "provisional", "ordering"):
+        assert gate in out

--- a/tests/snapshot/test_snapshot_cli.py
+++ b/tests/snapshot/test_snapshot_cli.py
@@ -241,3 +241,37 @@ def test_the_expected_end_comes_from_the_receipt_not_the_command_line(tmp_path,
     bound(tmp_path)
     assert main(["all", *argv(tmp_path)]) == 0
     assert "2026-06-30" in capsys.readouterr().out
+
+
+def test_the_build_command_refuses_a_window_the_release_does_not_cover(
+        tmp_path, capsys):
+    """`build` writes the artifact `validate` later blesses, so the declaration
+    has to be checked before anything is written -- not by a gate afterwards."""
+    bound(tmp_path)
+    code = main(["build", *argv(tmp_path, **{"--coverage-to": "2026-07-31"})])
+    assert code != 0
+    out = capsys.readouterr().out
+    assert "2026-06-30" in out and "2026-07-31" in out
+    assert not (tmp_path / "work" / "snapshot").exists()
+    assert list((tmp_path / "work").rglob("*.parquet")) == []
+
+
+def test_a_mismatched_window_writes_no_snapshot_at_all(tmp_path):
+    # `all` fails the same way, and fails before the build rather than after it.
+    bound(tmp_path)
+    assert main(["all", *argv(tmp_path, **{"--coverage-to": "2026-07-31"})]) != 0
+    assert list((tmp_path / "work").rglob("*.parquet")) == []
+
+
+def test_the_source_is_verified_once_per_run(tmp_path, monkeypatch):
+    """Verification digests the whole CSV. Doing it twice is a second full pass
+    over 5.5 GB for no additional evidence."""
+    from tools.ppd_snapshot import __main__ as cli
+
+    bound(tmp_path)
+    calls = []
+    real = cli.verify_source
+    monkeypatch.setattr(cli, "verify_source",
+                        lambda *a, **k: (calls.append(1), real(*a, **k))[1])
+    assert main(["all", *argv(tmp_path)]) == 0
+    assert len(calls) == 1

--- a/tests/snapshot/test_snapshot_end_to_end.py
+++ b/tests/snapshot/test_snapshot_end_to_end.py
@@ -30,7 +30,11 @@ from property_core.snapshot.runtime import SnapshotRuntime  # noqa: E402
 from property_core.snapshot.source import LocalDirectorySource  # noqa: E402
 from property_core.snapshot.store import SnapshotStore  # noqa: E402
 from tools.ppd_snapshot.build import BuildRequest, build_snapshot  # noqa: E402
-from tools.ppd_snapshot.package import package_release, snapshot_version  # noqa: E402
+from tools.ppd_snapshot.package import (  # noqa: E402
+    package_release,
+    promote_release,
+    snapshot_version,
+)
 from tests.snapshot.build_fixtures import csv_row, write_source_csv  # noqa: E402
 
 COVERAGE_TO = date(2026, 6, 30)
@@ -54,7 +58,9 @@ def published(tmp_path: Path):
         built, dist_dir=tmp_path / "dist",
         version=snapshot_version(datetime(2026, 8, 28, 10, 15, tzinfo=timezone.utc)),
         source={"file": "pp.csv"}, facts={})
-    return release
+    # Promoted, because a published release is what the runtime is pointed at.
+    # The candidate stage is exercised by the CLI tests.
+    return promote_release(release)
 
 
 def boot(release, tmp_path: Path):

--- a/tests/snapshot/test_snapshot_end_to_end.py
+++ b/tests/snapshot/test_snapshot_end_to_end.py
@@ -55,7 +55,7 @@ def published(tmp_path: Path):
         csv_path=csv_path, out_dir=tmp_path / "snapshot",
         coverage_to=COVERAGE_TO, temp_dir=tmp_path / "tmp"))
     release = package_release(
-        built, dist_dir=tmp_path / "dist",
+        built, dist_dir=tmp_path / "dist", candidate_root=tmp_path / "work",
         version=snapshot_version(datetime(2026, 8, 28, 10, 15, tzinfo=timezone.utc)),
         source={"file": "pp.csv"}, facts={})
     # Promoted, because a published release is what the runtime is pointed at.

--- a/tests/snapshot/test_snapshot_end_to_end.py
+++ b/tests/snapshot/test_snapshot_end_to_end.py
@@ -1,0 +1,138 @@
+"""Acceptance: the artifact this pipeline builds is booted by the merged runtime.
+
+Nothing here re-implements verification. The bundle goes through
+`SnapshotRuntime` -- streamed fetch, digest and length check, member-validated
+extraction, exact Parquet-file count, full file inventory, atomic activation --
+and is then opened by `SnapshotAdapter`, which runs its own schema, row-count and
+queryability validation before it will answer anything. That is the only
+statement worth making about a build: not "our gates were happy", but "the code
+that has to serve it accepted it".
+
+The object source is a local directory. No network, no bucket, no upload.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+zstandard = pytest.importorskip("zstandard",
+                                reason="needs the optional 'snapshot' extra")
+
+from property_core.provenance import CompletenessBasis  # noqa: E402
+from property_core.snapshot.adapter import SnapshotAdapter  # noqa: E402
+from property_core.snapshot.models import Readiness  # noqa: E402
+from property_core.snapshot.runtime import SnapshotRuntime  # noqa: E402
+from property_core.snapshot.source import LocalDirectorySource  # noqa: E402
+from property_core.snapshot.store import SnapshotStore  # noqa: E402
+from tools.ppd_snapshot.build import BuildRequest, build_snapshot  # noqa: E402
+from tools.ppd_snapshot.package import package_release, snapshot_version  # noqa: E402
+from tests.snapshot.build_fixtures import csv_row, write_source_csv  # noqa: E402
+
+COVERAGE_TO = date(2026, 6, 30)
+
+ROWS = [
+    csv_row("{T-B57-2024}", "B5 7AA", "2024-03-01 00:00", 200_000),
+    csv_row("{T-B57-2023}", "B5 7AB", "2023-06-15 00:00", 210_000),
+    csv_row("{T-B56-2024}", "B5 6QQ", "2024-03-01 00:00", 300_000),
+    csv_row("{T-B50-2024}", "B50 4AA", "2024-05-01 00:00", 400_000),
+    csv_row("{T-M37-2026}", "M3 7AA", "2026-06-30 00:00", 250_000),
+]
+
+
+@pytest.fixture
+def published(tmp_path: Path):
+    csv_path = write_source_csv(tmp_path / "pp.csv", ROWS)
+    built = build_snapshot(BuildRequest(
+        csv_path=csv_path, out_dir=tmp_path / "snapshot",
+        coverage_to=COVERAGE_TO, temp_dir=tmp_path / "tmp"))
+    release = package_release(
+        built, dist_dir=tmp_path / "dist",
+        version=snapshot_version(datetime(2026, 8, 28, 10, 15, tzinfo=timezone.utc)),
+        source={"file": "pp.csv"}, facts={})
+    return release
+
+
+def boot(release, tmp_path: Path):
+    runtime = SnapshotRuntime(
+        source=LocalDirectorySource(release.dist_dir),
+        store=SnapshotStore(tmp_path / "store"))
+    return runtime, runtime.boot()
+
+
+def test_the_published_bundle_boots_through_the_real_runtime(published, tmp_path):
+    _, report = boot(published, tmp_path)
+    assert report.readiness is Readiness.READY, report.source_error
+    assert report.activated is True
+    assert report.fallback_to_live is False
+    assert report.version == published.version
+    assert report.bytes_downloaded == published.bundle_bytes
+
+
+def test_the_materialized_snapshot_holds_exactly_the_published_partitions(
+        published, tmp_path):
+    _, report = boot(published, tmp_path)
+    directory = Path(report.snapshot_dir)
+    written = sorted(p.relative_to(directory).as_posix()
+                     for p in directory.rglob("*.parquet"))
+    assert written == [f"year={y}/data.parquet" for y in range(2016, 2027)]
+
+
+def test_the_verification_record_carries_the_declared_coverage(published, tmp_path):
+    runtime, report = boot(published, tmp_path)
+    record = runtime.store.verified_record(report.version)
+    assert record.coverage_from == "2016-01-01"
+    assert record.coverage_to == "2026-06-30"
+    assert record.provisional_from == "2026-03-01"
+    assert record.layout == "year"
+    assert record.rows == published.rows
+
+
+def test_the_booted_snapshot_opens_through_the_real_adapter(published, tmp_path):
+    runtime, report = boot(published, tmp_path)
+    record = runtime.store.verified_record(report.version)
+    with SnapshotAdapter.open(Path(report.snapshot_dir), record) as adapter:
+        assert adapter.coverage_from == "2016-01-01"
+        assert adapter.version == published.version
+
+
+def test_the_adapter_answers_a_sector_query_without_bleeding_into_b50(
+        published, tmp_path):
+    runtime, report = boot(published, tmp_path)
+    record = runtime.store.verified_record(report.version)
+    with SnapshotAdapter.open(Path(report.snapshot_dir), record) as adapter:
+        page = adapter.search(postcode_prefix="B5 7", limit=10)
+    assert [t.transaction_id for t in page.transactions] == [
+        "T-B57-2024", "T-B57-2023"]
+
+
+def test_the_adapter_reports_limit_independent_completeness(published, tmp_path):
+    runtime, report = boot(published, tmp_path)
+    record = runtime.store.verified_record(report.version)
+    with SnapshotAdapter.open(Path(report.snapshot_dir), record) as adapter:
+        page = adapter.search(postcode_prefix="B5", limit=10)
+    assert page.exhausted is True
+    assert page.completeness_basis is CompletenessBasis.LIMIT_PLUS_ONE
+
+
+def test_a_manifest_understating_the_parquet_count_is_refused(published, tmp_path):
+    payload = json.loads(published.manifest_path.read_text())
+    payload["parquet_files"] = 10
+    published.manifest_path.write_text(json.dumps(payload))
+    _, report = boot(published, tmp_path)
+    assert report.readiness is Readiness.UNREADY
+    assert report.fallback_to_live is True
+    assert "parquet" in (report.source_error or "")
+
+
+def test_a_bundle_whose_digest_moved_is_refused(published, tmp_path):
+    blob = bytearray(published.bundle_path.read_bytes())
+    blob[len(blob) // 2] ^= 0x01
+    published.bundle_path.write_bytes(bytes(blob))
+    _, report = boot(published, tmp_path)
+    assert report.readiness is Readiness.UNREADY
+    assert report.fallback_to_live is True

--- a/tests/snapshot/test_snapshot_gates.py
+++ b/tests/snapshot/test_snapshot_gates.py
@@ -62,6 +62,7 @@ def snapshot(tmp_path: Path):
         provisional_from=result.provisional_from,
         rows=result.rows,
         parquet_files=result.parquet_files,
+        eligible_source_rows=result.eligible_source_rows,
     )
     return result, declared
 
@@ -100,8 +101,8 @@ def test_every_declared_gate_reports_a_result(snapshot):
     _, declared = snapshot
     report = run(declared)
     assert {g.name for g in report.gates} == {
-        "schema", "partitions", "rows", "uniqueness", "coverage", "guarantee",
-        "provisional", "ordering",
+        "partitions", "schema", "required_values", "rows", "reconciliation",
+        "uniqueness", "coverage", "guarantee", "provisional", "ordering",
     }
 
 
@@ -367,3 +368,76 @@ def test_validation_records_the_content_digest_as_a_fact(snapshot):
 def test_the_build_records_its_peak_memory(snapshot):
     built, _ = snapshot
     assert built.peak_rss_mb > 0
+
+
+def test_the_content_digest_separates_values_that_share_a_delimiter(tmp_path: Path):
+    """Two different rows must not digest the same because of a field separator.
+
+    `paon="A|B", saon="C"` and `paon="A", saon="B|C"` are different properties.
+    Joining fields with a delimiter that can occur inside a field makes them the
+    same string, so the digest silently stops distinguishing them.
+    """
+    from tools.ppd_snapshot.validate import content_digests
+
+    def digest_for(paon: str, saon: str) -> dict[str, str]:
+        name = f"{paon}-{saon}".replace("|", "")
+        path = write_source_csv(tmp_path / f"pp-{name}.csv", [
+            csv_row("{T-2024-A}", "B5 7AA", "2024-03-01 00:00", 210_000,
+                    paon=paon, saon=saon),
+        ])
+        built = build_snapshot(BuildRequest(
+            csv_path=path, out_dir=tmp_path / name, coverage_to=COVERAGE_TO,
+            temp_dir=tmp_path / f"tmp-{name}"))
+        return content_digests(built.snapshot_dir)
+
+    assert digest_for("A|B", "C")["2024"] != digest_for("A", "B|C")["2024"]
+
+
+# -- required values --------------------------------------------------------
+
+def test_required_values_gate_rejects_a_null_price(snapshot):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2024" / "data.parquet",
+            projection="* REPLACE (CAST(NULL AS BIGINT) AS price)")
+    report = run(declared)
+    assert failed(report) == {"required_values"}
+    assert "price" in report.failures[0].detail
+
+
+def test_required_values_gate_rejects_a_null_transfer_date(snapshot):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2016" / "data.parquet",
+            projection="* REPLACE (CAST(NULL AS DATE) AS transfer_date)")
+    report = run(declared)
+    assert failed(report) == {"required_values"}
+    assert "transfer_date" in report.failures[0].detail
+
+
+def test_required_values_gate_is_what_rejects_a_null_price(snapshot, monkeypatch):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2024" / "data.parquet",
+            projection="* REPLACE (CAST(NULL AS BIGINT) AS price)")
+    monkeypatch.setattr(gates, "_gate_required_values", lambda *a, **k: None)
+    assert run(declared).failures == ()
+
+
+# -- reconciliation against the source --------------------------------------
+
+def test_reconciliation_gate_rejects_a_snapshot_holding_fewer_rows_than_the_source(
+        snapshot):
+    _, declared = snapshot
+    # The source held one more eligible row than the snapshot wrote: a row was
+    # lost between reading and writing, which no count taken from the artifact
+    # alone can see.
+    report = run(declared.replace(eligible_source_rows=declared.rows + 1))
+    assert failed(report) == {"reconciliation"}
+
+
+def test_reconciliation_gate_is_skipped_rather_than_passed_without_a_source_count(
+        snapshot):
+    _, declared = snapshot
+    report = run(declared.replace(eligible_source_rows=None))
+    assert report.failures == ()
+    assert "reconciliation" in report.skipped
+    # A skipped gate is not a passing gate.
+    assert report.passed is False

--- a/tests/snapshot/test_snapshot_gates.py
+++ b/tests/snapshot/test_snapshot_gates.py
@@ -1,0 +1,369 @@
+"""Red-first tests for the build's validation gates.
+
+Every negative case corrupts a **real** built snapshot in exactly one way and
+asserts that exactly one gate fires. Asserting the set of failed gates -- not
+merely that validation failed -- is what stops a test passing because some other
+gate happened to trip on the same fixture.
+
+The load-bearing gates additionally get a narrow mutation check: with that one
+gate neutralised the corrupt artifact passes, which proves the gate is what
+rejects it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+from tools.ppd_snapshot import validate as gates  # noqa: E402
+from tools.ppd_snapshot.build import (  # noqa: E402
+    BuildRequest,
+    build_snapshot,
+)
+from tools.ppd_snapshot.validate import (  # noqa: E402
+    DeclaredSnapshot,
+    validate_snapshot,
+)
+from tests.snapshot.build_fixtures import csv_row, write_source_csv  # noqa: E402
+
+COVERAGE_TO = date(2026, 6, 30)
+TODAY = date(2026, 7, 15)
+
+#: Rows in 2016, three in 2024 and one in 2026, so 2017-2023 and 2025 are empty
+#: partitions. An empty partition is what lets a test remove one file without
+#: also changing the row count.
+SOURCE_ROWS = [
+    csv_row("{T-2016}", "B5 7AA", "2016-01-04 00:00", 150_000),
+    csv_row("{T-2024-A}", "B5 7AB", "2024-03-01 00:00", 210_000),
+    csv_row("{T-2024-B}", "B50 4AA", "2024-05-20 00:00", 400_000),
+    csv_row("{T-2024-C}", "M3 7AA", "2024-11-11 00:00", 260_000),
+    csv_row("{T-2026}", "M3 7AB", "2026-06-30 00:00", 250_000),
+    csv_row("{T-OLD}", "B5 7AC", "2015-12-31 00:00", 100_000),
+]
+
+
+@pytest.fixture
+def snapshot(tmp_path: Path):
+    csv_path = write_source_csv(tmp_path / "pp.csv", SOURCE_ROWS)
+    result = build_snapshot(BuildRequest(
+        csv_path=csv_path,
+        out_dir=tmp_path / "snapshot",
+        coverage_to=COVERAGE_TO,
+        temp_dir=tmp_path / "tmp",
+    ))
+    declared = DeclaredSnapshot(
+        directory=result.snapshot_dir,
+        coverage_from=result.coverage_from,
+        coverage_to=result.coverage_to,
+        provisional_from=result.provisional_from,
+        rows=result.rows,
+        parquet_files=result.parquet_files,
+    )
+    return result, declared
+
+
+def failed(report) -> set[str]:
+    return {failure.gate for failure in report.failures}
+
+
+def rewrite(path: Path, projection: str = "*", clause: str = "") -> None:
+    """Rewrite one partition file from a query over itself."""
+    con = duckdb.connect()
+    try:
+        con.execute(f"CREATE TABLE t AS SELECT * FROM read_parquet('{path}')")
+        con.execute(f"COPY (SELECT {projection} FROM t {clause}) TO '{path}' "
+                    f"(FORMAT parquet)")
+    finally:
+        con.close()
+
+
+def run(declared: DeclaredSnapshot, **over):
+    kwargs = {"source_coverage_end": COVERAGE_TO, "today": TODAY}
+    kwargs.update(over)
+    return validate_snapshot(declared, **kwargs)
+
+
+# -- the artifact the build actually produces passes ------------------------
+
+def test_a_freshly_built_snapshot_passes_every_gate(snapshot):
+    _, declared = snapshot
+    report = run(declared)
+    assert report.failures == ()
+    assert report.passed
+
+
+def test_every_declared_gate_reports_a_result(snapshot):
+    _, declared = snapshot
+    report = run(declared)
+    assert {g.name for g in report.gates} == {
+        "schema", "partitions", "rows", "uniqueness", "coverage", "guarantee",
+        "provisional", "ordering",
+    }
+
+
+# -- schema -----------------------------------------------------------------
+
+def test_schema_gate_rejects_a_partition_missing_a_required_column(snapshot):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2024" / "data.parquet",
+            projection="* EXCLUDE (sector)")
+    report = run(declared)
+    assert failed(report) == {"schema"}
+    assert "sector" in report.failures[0].detail
+
+
+def test_schema_gate_rejects_a_date_column_stored_as_text(snapshot):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2024" / "data.parquet",
+            projection="* REPLACE (CAST(transfer_date AS VARCHAR) AS transfer_date)")
+    report = run(declared)
+    assert failed(report) == {"schema"}
+    assert "transfer_date" in report.failures[0].detail
+
+
+def test_schema_gate_checks_every_partition_not_only_the_first(snapshot):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2026" / "data.parquet",
+            projection="* EXCLUDE (outcode)")
+    report = run(declared)
+    assert failed(report) == {"schema"}
+    assert "year=2026" in report.failures[0].detail
+
+
+# -- partitions -------------------------------------------------------------
+
+def test_partitions_gate_rejects_a_missing_year(snapshot):
+    result, declared = snapshot
+    (result.snapshot_dir / "year=2020" / "data.parquet").unlink()
+    report = run(declared)
+    assert failed(report) == {"partitions"}
+    assert "2020" in report.failures[0].detail
+
+
+def test_partitions_gate_rejects_a_file_that_is_not_a_partition(snapshot):
+    result, declared = snapshot
+    (result.snapshot_dir / "year=2024" / "notes.txt").write_text("stray")
+    report = run(declared)
+    assert failed(report) == {"partitions"}
+    assert "notes.txt" in report.failures[0].detail
+
+
+def test_partitions_gate_rejects_a_declared_file_count_that_disagrees(snapshot):
+    _, declared = snapshot
+    report = run(declared.replace(parquet_files=10))
+    assert failed(report) == {"partitions"}
+
+
+# -- rows -------------------------------------------------------------------
+
+def test_rows_gate_rejects_a_declared_count_the_data_does_not_hold(snapshot):
+    _, declared = snapshot
+    report = run(declared.replace(rows=declared.rows + 1))
+    assert failed(report) == {"rows"}
+    assert str(declared.rows + 1) in report.failures[0].detail
+
+
+def test_rows_gate_is_what_rejects_a_wrong_declared_count(snapshot, monkeypatch):
+    # Mutation check: neutralise this gate alone and the same artifact passes.
+    _, declared = snapshot
+    monkeypatch.setattr(gates, "_gate_rows", lambda *a, **k: None)
+    assert run(declared.replace(rows=declared.rows + 1)).failures == ()
+
+
+# -- uniqueness -------------------------------------------------------------
+
+def test_uniqueness_gate_rejects_a_repeated_transaction_id(snapshot):
+    result, declared = snapshot
+    # One id overwritten with another's: the row count is untouched, so only
+    # uniqueness can fire.
+    rewrite(result.snapshot_dir / "year=2024" / "data.parquet",
+            projection="* REPLACE ('T-2024-A' AS transaction_id)")
+    report = run(declared)
+    assert failed(report) == {"uniqueness"}
+
+
+def test_uniqueness_gate_is_what_rejects_a_repeated_id(snapshot, monkeypatch):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2024" / "data.parquet",
+            projection="* REPLACE ('T-2024-A' AS transaction_id)")
+    monkeypatch.setattr(gates, "_gate_uniqueness", lambda *a, **k: None)
+    assert run(declared).failures == ()
+
+
+# -- coverage ---------------------------------------------------------------
+
+def test_coverage_gate_rejects_a_row_after_the_declared_end(snapshot):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2026" / "data.parquet",
+            projection="* REPLACE (DATE '2026-12-01' AS transfer_date)")
+    report = run(declared)
+    assert failed(report) == {"coverage"}
+
+
+def test_coverage_gate_rejects_a_row_before_the_declared_start(snapshot):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2016" / "data.parquet",
+            projection="* REPLACE (DATE '2015-06-01' AS transfer_date, "
+                       "2016 AS year)")
+    report = run(declared)
+    assert failed(report) == {"coverage"}
+
+
+def test_coverage_gate_rejects_a_row_filed_under_the_wrong_year(snapshot):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2024" / "data.parquet",
+            projection="* REPLACE (DATE '2023-04-04' AS transfer_date)",
+            clause="ORDER BY transaction_id ASC")
+    report = run(declared)
+    assert failed(report) == {"coverage"}
+    assert "year=2024" in report.failures[0].detail
+
+
+def test_coverage_gate_rejects_a_start_that_is_not_the_partition_boundary(snapshot):
+    _, declared = snapshot
+    report = run(declared.replace(coverage_from=date(2016, 2, 1)))
+    assert failed(report) == {"coverage"}
+
+
+def test_coverage_gate_rejects_an_end_the_source_release_does_not_declare(snapshot):
+    _, declared = snapshot
+    # The snapshot claims a window the release it was built from never covered.
+    report = run(declared, source_coverage_end=date(2026, 5, 31))
+    assert failed(report) == {"coverage"}
+
+
+def test_coverage_gate_does_not_require_data_at_the_window_edges(snapshot):
+    # The window is a declaration about the release, not a measurement of the
+    # rows: no sale on 2016-01-01 or 2026-06-30 is required for it to hold.
+    result, declared = snapshot
+    con = duckdb.connect()
+    bounds = con.execute(
+        f"SELECT min(transfer_date), max(transfer_date) FROM read_parquet("
+        f"'{result.snapshot_dir}/**/*.parquet')").fetchone()
+    con.close()
+    assert bounds[0] > declared.coverage_from or bounds[1] < declared.coverage_to
+    assert run(declared).failures == ()
+
+
+def test_coverage_gate_is_what_rejects_an_out_of_window_row(snapshot, monkeypatch):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2026" / "data.parquet",
+            projection="* REPLACE (DATE '2026-12-01' AS transfer_date)")
+    monkeypatch.setattr(gates, "_gate_coverage", lambda *a, **k: None)
+    assert run(declared).failures == ()
+
+
+# -- guarantee --------------------------------------------------------------
+
+def test_guarantee_gate_rejects_a_window_that_does_not_reach_back_120_months(snapshot):
+    _, declared = snapshot
+    # The shape a shortened partition count produces: the window opens later
+    # than `today - 120 months`, so the largest legal request falls outside it.
+    # Nothing else in the report reads `today`, so only this gate can fire.
+    report = run(declared, today=date(2025, 1, 1))
+    assert failed(report) == {"guarantee"}
+
+
+def test_guarantee_gate_passes_once_the_window_reaches_back_far_enough(snapshot):
+    _, declared = snapshot
+    assert run(declared, today=date(2025, 11, 15)).failures == ()
+
+
+# -- provisional ------------------------------------------------------------
+
+def test_provisional_gate_rejects_a_boundary_that_is_not_the_computed_month(snapshot):
+    _, declared = snapshot
+    report = run(declared.replace(provisional_from=date(2026, 4, 1)))
+    assert failed(report) == {"provisional"}
+
+
+def test_provisional_gate_rejects_a_boundary_outside_the_coverage_window(snapshot):
+    _, declared = snapshot
+    report = run(declared.replace(provisional_from=date(2026, 9, 1)))
+    assert failed(report) == {"provisional"}
+
+
+# -- ordering ---------------------------------------------------------------
+
+def test_ordering_gate_rejects_a_partition_written_in_the_wrong_order(snapshot):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2024" / "data.parquet",
+            clause="ORDER BY transfer_date ASC")
+    report = run(declared)
+    assert failed(report) == {"ordering"}
+    assert "year=2024" in report.failures[0].detail
+
+
+def test_ordering_gate_is_what_rejects_a_misordered_partition(snapshot, monkeypatch):
+    result, declared = snapshot
+    rewrite(result.snapshot_dir / "year=2024" / "data.parquet",
+            clause="ORDER BY transfer_date ASC")
+    monkeypatch.setattr(gates, "_gate_ordering", lambda *a, **k: None)
+    assert run(declared).failures == ()
+
+
+# -- deterministic content --------------------------------------------------
+
+def test_the_content_digest_is_stable_across_a_rebuild(tmp_path: Path):
+    """Rebuilding the same source must yield the same rows in the same order.
+
+    Deliberately a *logical* check. Byte-identical Parquet across rebuilds is a
+    property of the writer, and DuckDB 1.5.5 makes no such guarantee -- asserting
+    it would be testing an assumption rather than the pipeline.
+    """
+    from tools.ppd_snapshot.validate import content_digests
+
+    csv_path = write_source_csv(tmp_path / "pp.csv", SOURCE_ROWS)
+    first = build_snapshot(BuildRequest(
+        csv_path=csv_path, out_dir=tmp_path / "a", coverage_to=COVERAGE_TO,
+        temp_dir=tmp_path / "tmp-a"))
+    second = build_snapshot(BuildRequest(
+        csv_path=csv_path, out_dir=tmp_path / "b", coverage_to=COVERAGE_TO,
+        temp_dir=tmp_path / "tmp-b"))
+    assert content_digests(first.snapshot_dir) == content_digests(second.snapshot_dir)
+
+
+def test_the_content_digest_moves_when_a_single_value_changes(tmp_path: Path):
+    from tools.ppd_snapshot.validate import content_digests
+
+    csv_path = write_source_csv(tmp_path / "pp.csv", SOURCE_ROWS)
+    built = build_snapshot(BuildRequest(
+        csv_path=csv_path, out_dir=tmp_path / "a", coverage_to=COVERAGE_TO,
+        temp_dir=tmp_path / "tmp-a"))
+    before = content_digests(built.snapshot_dir)
+    rewrite(built.snapshot_dir / "year=2024" / "data.parquet",
+            projection="* REPLACE (price + 1 AS price)")
+    after = content_digests(built.snapshot_dir)
+    assert after["2024"] != before["2024"]
+    assert after["2026"] == before["2026"]
+
+
+def test_the_content_digest_moves_when_only_the_order_changes(tmp_path: Path):
+    # Order is part of the artifact, so a reordered partition is different
+    # content even though it holds exactly the same rows.
+    from tools.ppd_snapshot.validate import content_digests
+
+    csv_path = write_source_csv(tmp_path / "pp.csv", SOURCE_ROWS)
+    built = build_snapshot(BuildRequest(
+        csv_path=csv_path, out_dir=tmp_path / "a", coverage_to=COVERAGE_TO,
+        temp_dir=tmp_path / "tmp-a"))
+    before = content_digests(built.snapshot_dir)
+    rewrite(built.snapshot_dir / "year=2024" / "data.parquet",
+            clause="ORDER BY transfer_date ASC")
+    assert content_digests(built.snapshot_dir)["2024"] != before["2024"]
+
+
+def test_validation_records_the_content_digest_as_a_fact(snapshot):
+    _, declared = snapshot
+    report = run(declared)
+    assert set(report.facts["content_digest_per_year"]) == {
+        str(y) for y in range(2016, 2027)}
+
+
+def test_the_build_records_its_peak_memory(snapshot):
+    built, _ = snapshot
+    assert built.peak_rss_mb > 0

--- a/tests/snapshot/test_snapshot_package.py
+++ b/tests/snapshot/test_snapshot_package.py
@@ -227,6 +227,20 @@ def test_promotion_moves_the_release_into_the_dist_root(released):
     assert not release.candidate_dir.exists()
 
 
+def _fail_replace_on(monkeypatch, needle: str):
+    """Break exactly one `os.replace`, leaving the others working."""
+    from tools.ppd_snapshot import package as pkg
+
+    real = pkg.os.replace
+
+    def _replace(src, dst, *args, **kwargs):
+        if needle in str(dst):
+            raise OSError("disk went away")
+        return real(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(pkg.os, "replace", _replace)
+
+
 def test_promotion_writes_the_pointer_last(released, monkeypatch):
     """A pointer is a promise that what it names is there.
 
@@ -236,14 +250,7 @@ def test_promotion_writes_the_pointer_last(released, monkeypatch):
     from tools.ppd_snapshot import package as pkg
 
     _, release = released
-    real_move = pkg.shutil.move
-
-    def _fail_on_manifest(src, dst, *args, **kwargs):
-        if "manifest" in str(dst):
-            raise OSError("disk went away")
-        return real_move(src, dst, *args, **kwargs)
-
-    monkeypatch.setattr(pkg.shutil, "move", _fail_on_manifest)
+    _fail_replace_on(monkeypatch, "manifest")
     with pytest.raises(OSError):
         pkg.promote_release(release)
     assert not (release.dist_dir / "current.json").exists()
@@ -274,10 +281,7 @@ def test_an_interrupted_promotion_leaves_a_previous_pointer_untouched(
     previous.write_text(json.dumps({"current_manifest": "manifest-v1.json"}))
     before = previous.read_bytes()
 
-    real_move = pkg.shutil.move
-    monkeypatch.setattr(pkg.shutil, "move", lambda src, dst, *a, **k: (
-        (_ for _ in ()).throw(OSError("disk went away")) if "manifest" in str(dst)
-        else real_move(src, dst, *a, **k)))
+    _fail_replace_on(monkeypatch, "manifest")
 
     with pytest.raises(OSError):
         pkg.promote_release(release)
@@ -294,8 +298,7 @@ def test_a_pointer_write_that_fails_leaves_the_previous_one_intact(
     previous.write_text(json.dumps({"current_manifest": "manifest-v1.json"}))
     before = previous.read_bytes()
 
-    monkeypatch.setattr(pkg.os, "replace", lambda *a, **k: (
-        _ for _ in ()).throw(OSError("rename failed")))
+    _fail_replace_on(monkeypatch, "current.json")
     with pytest.raises(OSError):
         pkg.promote_release(release)
     assert previous.read_bytes() == before
@@ -313,3 +316,50 @@ def test_promotion_replaces_an_existing_pointer(released):
     assert json.loads(promoted.current_path.read_text()) == {
         "current_manifest": release.manifest_path.name}
     assert not list(release.dist_dir.glob("*.tmp"))
+
+
+# -- promotion must be a rename, on one filesystem --------------------------
+
+def test_promotion_refuses_a_candidate_on_another_filesystem(released,
+                                                             monkeypatch):
+    """A cross-device `move` is a copy, which is neither atomic nor free.
+
+    It also silently doubles the transient disk and the time the G1 model was
+    measured against, so it is refused before anything moves rather than
+    discovered afterwards.
+    """
+    from tools.ppd_snapshot import package as pkg
+    from tools.ppd_snapshot.package import CrossFilesystemPromotion
+
+    _, release = released
+    release.dist_dir.mkdir(parents=True, exist_ok=True)
+    previous = release.dist_dir / "current.json"
+    previous.write_text(json.dumps({"current_manifest": "manifest-v1.json"}))
+    before = previous.read_bytes()
+
+    monkeypatch.setattr(pkg, "_device_of",
+                        lambda path: 1 if "dist" in str(path) else 2)
+
+    with pytest.raises(CrossFilesystemPromotion, match="filesystem"):
+        pkg.promote_release(release)
+
+    assert previous.read_bytes() == before
+    assert list(release.dist_dir.glob("*.tar.zst")) == []
+    # Nothing moved: the candidate is still whole.
+    assert release.bundle_path.is_file()
+    assert release.manifest_path.is_file()
+
+
+def test_promotion_never_falls_back_to_a_copy(released, monkeypatch):
+    from tools.ppd_snapshot import package as pkg
+    from tools.ppd_snapshot.package import promote_release
+
+    _, release = released
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError("promotion must rename, never copy")
+
+    monkeypatch.setattr(pkg.shutil, "move", _forbidden)
+    monkeypatch.setattr(pkg.shutil, "copy2", _forbidden)
+    promoted = promote_release(release)
+    assert promoted.bundle_path.is_file()

--- a/tests/snapshot/test_snapshot_package.py
+++ b/tests/snapshot/test_snapshot_package.py
@@ -45,7 +45,7 @@ def released(tmp_path: Path):
         csv_path=csv_path, out_dir=tmp_path / "snapshot",
         coverage_to=COVERAGE_TO, temp_dir=tmp_path / "tmp"))
     release = package_release(
-        built, dist_dir=tmp_path / "dist",
+        built, dist_dir=tmp_path / "dist", candidate_root=tmp_path / "work",
         version=snapshot_version(datetime(2026, 8, 28, 10, 15, tzinfo=timezone.utc)),
         source={"file": "pp.csv", "sha256": "a" * 64, "etag": '"abc"'},
         facts={"rows_per_year": {"2024": 1, "2026": 1}},
@@ -188,8 +188,9 @@ def test_verify_bundle_rejects_a_length_that_disagrees(released):
 def test_publishing_the_same_version_twice_is_refused(released, tmp_path):
     built, release = released
     with pytest.raises(VersionAlreadyPublished):
-        package_release(built, dist_dir=release.dist_dir, version=release.version,
-                        source={}, facts={})
+        package_release(built, dist_dir=release.dist_dir,
+                        candidate_root=release.candidate_dir.parent,
+                        version=release.version, source={}, facts={})
 
 
 # -- candidate, then promotion ----------------------------------------------
@@ -197,15 +198,15 @@ def test_publishing_the_same_version_twice_is_refused(released, tmp_path):
 def test_packaging_writes_into_a_candidate_directory(released):
     _, release = released
     assert release.candidate_dir.name == f"candidate-{release.version}"
-    assert release.candidate_dir.parent == release.dist_dir
+    assert release.candidate_dir.parent == release.dist_dir.parent / "work"
     assert release.bundle_path.parent == release.candidate_dir
     assert release.manifest_path.parent == release.candidate_dir
 
 
 def test_packaging_leaves_the_dist_root_empty(released):
     _, release = released
-    assert sorted(p.name for p in release.dist_dir.iterdir()) == [
-        release.candidate_dir.name]
+    assert not release.dist_dir.exists() or \
+        list(release.dist_dir.iterdir()) == []
 
 
 def test_the_candidate_carries_its_own_pointer_so_it_can_be_booted(released):
@@ -246,3 +247,69 @@ def test_promotion_writes_the_pointer_last(released, monkeypatch):
     with pytest.raises(OSError):
         pkg.promote_release(release)
     assert not (release.dist_dir / "current.json").exists()
+
+
+# -- the candidate lives outside dist; the pointer is replaced atomically ----
+
+def test_the_candidate_is_not_inside_the_dist_root(released):
+    _, release = released
+    assert release.dist_dir not in release.candidate_dir.parents
+    assert not release.dist_dir.exists() or \
+        list(release.dist_dir.iterdir()) == []
+
+
+def test_an_interrupted_promotion_leaves_a_previous_pointer_untouched(
+        released, monkeypatch):
+    """A dist root with a working release must survive a failed promotion.
+
+    Truncating `current.json` and then dying takes down the release that was
+    already published, which is worse than never having tried: the pointer is
+    the one file a booting Machine reads first.
+    """
+    from tools.ppd_snapshot import package as pkg
+
+    _, release = released
+    release.dist_dir.mkdir(parents=True, exist_ok=True)
+    previous = release.dist_dir / "current.json"
+    previous.write_text(json.dumps({"current_manifest": "manifest-v1.json"}))
+    before = previous.read_bytes()
+
+    real_move = pkg.shutil.move
+    monkeypatch.setattr(pkg.shutil, "move", lambda src, dst, *a, **k: (
+        (_ for _ in ()).throw(OSError("disk went away")) if "manifest" in str(dst)
+        else real_move(src, dst, *a, **k)))
+
+    with pytest.raises(OSError):
+        pkg.promote_release(release)
+    assert previous.read_bytes() == before
+
+
+def test_a_pointer_write_that_fails_leaves_the_previous_one_intact(
+        released, monkeypatch):
+    from tools.ppd_snapshot import package as pkg
+
+    _, release = released
+    release.dist_dir.mkdir(parents=True, exist_ok=True)
+    previous = release.dist_dir / "current.json"
+    previous.write_text(json.dumps({"current_manifest": "manifest-v1.json"}))
+    before = previous.read_bytes()
+
+    monkeypatch.setattr(pkg.os, "replace", lambda *a, **k: (
+        _ for _ in ()).throw(OSError("rename failed")))
+    with pytest.raises(OSError):
+        pkg.promote_release(release)
+    assert previous.read_bytes() == before
+    assert json.loads(previous.read_text())["current_manifest"] == "manifest-v1.json"
+
+
+def test_promotion_replaces_an_existing_pointer(released):
+    from tools.ppd_snapshot.package import promote_release
+
+    _, release = released
+    release.dist_dir.mkdir(parents=True, exist_ok=True)
+    (release.dist_dir / "current.json").write_text(
+        json.dumps({"current_manifest": "manifest-v1.json"}))
+    promoted = promote_release(release)
+    assert json.loads(promoted.current_path.read_text()) == {
+        "current_manifest": release.manifest_path.name}
+    assert not list(release.dist_dir.glob("*.tmp"))

--- a/tests/snapshot/test_snapshot_package.py
+++ b/tests/snapshot/test_snapshot_package.py
@@ -1,0 +1,192 @@
+"""Red-first tests for bundling and for the manifest the runtime will read.
+
+The published manifest is the narrowest interface in this PR: `SnapshotManifest`
+is frozen and `extra="forbid"`, so a build that publishes the prototype's richer
+manifest does not degrade -- it fails to parse at boot. These tests pin the
+shape, and the richer provenance is kept in a separate report the runtime never
+reads.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tarfile
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+zstandard = pytest.importorskip("zstandard",
+                                reason="needs the optional 'snapshot' extra")
+
+from property_core.snapshot.models import SnapshotManifest  # noqa: E402
+from tools.ppd_snapshot.build import BuildRequest, build_snapshot  # noqa: E402
+from tools.ppd_snapshot.package import (  # noqa: E402
+    BundleMismatch,
+    VersionAlreadyPublished,
+    package_release,
+    snapshot_version,
+    verify_bundle,
+)
+from tests.snapshot.build_fixtures import csv_row, write_source_csv  # noqa: E402
+
+COVERAGE_TO = date(2026, 6, 30)
+
+
+@pytest.fixture
+def released(tmp_path: Path):
+    csv_path = write_source_csv(tmp_path / "pp.csv", [
+        csv_row("{T-2024}", "B5 7AA", "2024-03-01 00:00", 210_000),
+        csv_row("{T-2026}", "M3 7AA", "2026-06-30 00:00", 250_000),
+    ])
+    built = build_snapshot(BuildRequest(
+        csv_path=csv_path, out_dir=tmp_path / "snapshot",
+        coverage_to=COVERAGE_TO, temp_dir=tmp_path / "tmp"))
+    release = package_release(
+        built, dist_dir=tmp_path / "dist",
+        version=snapshot_version(datetime(2026, 8, 28, 10, 15, tzinfo=timezone.utc)),
+        source={"file": "pp.csv", "sha256": "a" * 64, "etag": '"abc"'},
+        facts={"rows_per_year": {"2024": 1, "2026": 1}},
+    )
+    return built, release
+
+
+def members(bundle: Path) -> list[tarfile.TarInfo]:
+    with open(bundle, "rb") as fh:
+        with zstandard.ZstdDecompressor().stream_reader(fh) as reader:
+            with tarfile.open(fileobj=reader, mode="r|") as tar:
+                return list(tar)
+
+
+# -- version ----------------------------------------------------------------
+
+def test_version_is_the_utc_build_instant():
+    stamp = datetime(2026, 8, 28, 10, 15, 30, tzinfo=timezone.utc)
+    assert snapshot_version(stamp) == "v20260828T101530Z"
+
+
+def test_version_is_a_path_component_the_store_will_accept():
+    from property_core.snapshot.models import validate_component
+
+    version = snapshot_version(datetime(2026, 8, 28, tzinfo=timezone.utc))
+    assert validate_component(version, "snapshot_version") == version
+
+
+# -- bundle -----------------------------------------------------------------
+
+def test_bundle_holds_exactly_the_partition_files(released):
+    _, release = released
+    names = sorted(m.name for m in members(release.bundle_path))
+    assert names == [f"year={y}/data.parquet" for y in range(2016, 2027)]
+
+
+def test_bundle_holds_no_directory_or_special_members(released):
+    _, release = released
+    assert all(m.isreg() for m in members(release.bundle_path))
+
+
+def test_bundle_carries_no_manifest_of_its_own(released):
+    # The verification record is written by the store at activation. A manifest
+    # inside the archive would become part of the inventory and could disagree
+    # with the published one.
+    _, release = released
+    assert not any(m.name.endswith(".json") for m in members(release.bundle_path))
+
+
+def test_bundle_members_are_normalised_for_reproducibility(released):
+    _, release = released
+    for member in members(release.bundle_path):
+        assert member.uid == 0 and member.gid == 0
+        assert member.uname == "" and member.gname == ""
+        assert member.mtime == 0
+
+
+# -- published manifest -----------------------------------------------------
+
+def test_published_manifest_parses_as_the_runtime_manifest(released):
+    _, release = released
+    payload = json.loads(release.manifest_path.read_text())
+    manifest = SnapshotManifest(**payload)
+    assert manifest.snapshot_version == release.version
+    assert manifest.parquet_files == 11
+    assert manifest.layout == "year"
+
+
+def test_published_manifest_carries_only_the_fields_the_runtime_allows(released):
+    _, release = released
+    payload = json.loads(release.manifest_path.read_text())
+    assert set(payload) == {
+        "snapshot_version", "bundle_object", "bundle_sha256", "bundle_bytes",
+        "parquet_files", "rows", "coverage_from", "coverage_to",
+        "provisional_from", "layout", "duckdb_version",
+    }
+
+
+def test_published_manifest_declares_the_bundle_on_disk(released):
+    _, release = released
+    payload = json.loads(release.manifest_path.read_text())
+    blob = release.bundle_path.read_bytes()
+    assert payload["bundle_bytes"] == len(blob)
+    assert payload["bundle_sha256"] == hashlib.sha256(blob).hexdigest()
+    assert payload["bundle_object"] == release.bundle_path.name
+
+
+def test_published_manifest_declares_the_coverage_window(released):
+    built, release = released
+    payload = json.loads(release.manifest_path.read_text())
+    assert payload["coverage_from"] == built.coverage_from.isoformat()
+    assert payload["coverage_to"] == built.coverage_to.isoformat()
+    assert payload["provisional_from"] == built.provisional_from.isoformat()
+
+
+def test_current_json_names_the_manifest_object(released):
+    _, release = released
+    pointer = json.loads(release.current_path.read_text())
+    assert pointer == {"current_manifest": release.manifest_path.name}
+
+
+# -- build report -----------------------------------------------------------
+
+def test_build_report_keeps_the_provenance_the_manifest_may_not_carry(released):
+    _, release = released
+    report = json.loads(release.report_path.read_text())
+    assert report["source"]["sha256"] == "a" * 64
+    assert report["rows_per_year"] == {"2024": 1, "2026": 1}
+    assert report["snapshot_version"] == release.version
+    assert "timings_seconds" in report
+
+
+# -- digest verification ----------------------------------------------------
+
+def test_verify_bundle_accepts_the_bundle_it_published(released):
+    _, release = released
+    verify_bundle(release.bundle_path, expected_sha256=release.bundle_sha256,
+                  expected_bytes=release.bundle_bytes)
+
+
+def test_verify_bundle_rejects_a_flipped_byte(released):
+    _, release = released
+    blob = bytearray(release.bundle_path.read_bytes())
+    blob[len(blob) // 2] ^= 0x01
+    release.bundle_path.write_bytes(bytes(blob))
+    with pytest.raises(BundleMismatch, match="sha256"):
+        verify_bundle(release.bundle_path, expected_sha256=release.bundle_sha256,
+                      expected_bytes=release.bundle_bytes)
+
+
+def test_verify_bundle_rejects_a_length_that_disagrees(released):
+    _, release = released
+    with pytest.raises(BundleMismatch, match="bytes"):
+        verify_bundle(release.bundle_path, expected_sha256=release.bundle_sha256,
+                      expected_bytes=release.bundle_bytes + 1)
+
+
+# -- immutability -----------------------------------------------------------
+
+def test_publishing_the_same_version_twice_is_refused(released, tmp_path):
+    built, release = released
+    with pytest.raises(VersionAlreadyPublished):
+        package_release(built, dist_dir=release.dist_dir, version=release.version,
+                        source={}, facts={})

--- a/tests/snapshot/test_snapshot_package.py
+++ b/tests/snapshot/test_snapshot_package.py
@@ -190,3 +190,59 @@ def test_publishing_the_same_version_twice_is_refused(released, tmp_path):
     with pytest.raises(VersionAlreadyPublished):
         package_release(built, dist_dir=release.dist_dir, version=release.version,
                         source={}, facts={})
+
+
+# -- candidate, then promotion ----------------------------------------------
+
+def test_packaging_writes_into_a_candidate_directory(released):
+    _, release = released
+    assert release.candidate_dir.name == f"candidate-{release.version}"
+    assert release.candidate_dir.parent == release.dist_dir
+    assert release.bundle_path.parent == release.candidate_dir
+    assert release.manifest_path.parent == release.candidate_dir
+
+
+def test_packaging_leaves_the_dist_root_empty(released):
+    _, release = released
+    assert sorted(p.name for p in release.dist_dir.iterdir()) == [
+        release.candidate_dir.name]
+
+
+def test_the_candidate_carries_its_own_pointer_so_it_can_be_booted(released):
+    _, release = released
+    pointer = json.loads((release.candidate_dir / "current.json").read_text())
+    assert pointer == {"current_manifest": release.manifest_path.name}
+
+
+def test_promotion_moves_the_release_into_the_dist_root(released):
+    from tools.ppd_snapshot.package import promote_release
+
+    _, release = released
+    promoted = promote_release(release)
+    assert sorted(p.name for p in release.dist_dir.iterdir()) == sorted([
+        "current.json", release.manifest_path.name, release.bundle_path.name,
+        release.report_path.name])
+    assert promoted.bundle_path.parent == release.dist_dir
+    assert not release.candidate_dir.exists()
+
+
+def test_promotion_writes_the_pointer_last(released, monkeypatch):
+    """A pointer is a promise that what it names is there.
+
+    If promotion dies half way, the dist root may hold a partial release -- but
+    it must never hold a `current.json` naming a manifest that was not moved.
+    """
+    from tools.ppd_snapshot import package as pkg
+
+    _, release = released
+    real_move = pkg.shutil.move
+
+    def _fail_on_manifest(src, dst, *args, **kwargs):
+        if "manifest" in str(dst):
+            raise OSError("disk went away")
+        return real_move(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(pkg.shutil, "move", _fail_on_manifest)
+    with pytest.raises(OSError):
+        pkg.promote_release(release)
+    assert not (release.dist_dir / "current.json").exists()

--- a/tests/snapshot/test_snapshot_release_check.py
+++ b/tests/snapshot/test_snapshot_release_check.py
@@ -1,0 +1,236 @@
+"""Red-first tests for the HMLR release check (specification section 4.9).
+
+The check is a `HEAD`, never a download: comparing validators against the ones
+recorded for the current build is the whole mechanism, and reading 5.5 GB to
+learn a release has not changed would defeat it.
+
+**No request leaves this machine.** One test drives a loopback HTTP server so
+the method and the absence of a body are observed at a real HTTP boundary; the
+rest inject a recording opener.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import date, datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from tools.ppd_snapshot.release_check import (
+    UNINGESTED_ALERT_DAYS,
+    ReleaseObservation,
+    check_release,
+    record_ingested,
+)
+
+URL = "http://example.invalid/pp-complete.csv"
+NOW = datetime(2026, 8, 28, 9, 0, tzinfo=timezone.utc)
+
+HEADERS = {"ETag": '"333695120b2f0a82265a499df7682980-655"',
+           "Last-Modified": "Tue, 28 Jul 2026 05:16:16 GMT",
+           "Content-Length": "5494145759"}
+
+
+class _Opener:
+    """Stands in for `urlopen`, recording what it was asked to do."""
+
+    def __init__(self, headers=None, status=200):
+        self.headers = dict(HEADERS if headers is None else headers)
+        self.status = status
+        self.requests = []
+
+    def __call__(self, request, timeout=None):
+        self.requests.append(request)
+        opener = self
+
+        class _Response:
+            status = opener.status
+            headers = opener.headers
+
+            def read(self, *_args):  # pragma: no cover - must never be called
+                raise AssertionError("the release check must not read a body")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        return _Response()
+
+
+# -- the boundary -----------------------------------------------------------
+
+def test_the_check_issues_a_head_request_and_downloads_nothing(tmp_path: Path):
+    seen = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_HEAD(self):  # noqa: N802 - stdlib naming
+            seen.append(("HEAD", self.path))
+            self.send_response(200)
+            for key, value in HEADERS.items():
+                self.send_header(key, value)
+            self.end_headers()
+
+        def do_GET(self):  # noqa: N802 - stdlib naming
+            seen.append(("GET", self.path))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"body")
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/pp-complete.csv"
+        result = check_release(url, tmp_path / "state.json", now=NOW)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert seen == [("HEAD", "/pp-complete.csv")]
+    assert result.bytes_read == 0
+    assert result.observation.etag == HEADERS["ETag"]
+
+
+def test_the_check_never_issues_a_get(tmp_path: Path):
+    opener = _Opener()
+    check_release(URL, tmp_path / "state.json", opener=opener, now=NOW)
+    assert [r.get_method() for r in opener.requests] == ["HEAD"]
+
+
+# -- observation and change detection ---------------------------------------
+
+def test_a_first_observation_is_recorded_as_changed(tmp_path: Path):
+    result = check_release(URL, tmp_path / "state.json", opener=_Opener(), now=NOW)
+    assert result.changed is True
+    assert result.first_observed == NOW
+    assert result.previous is None
+
+
+def test_an_unchanged_release_is_reported_unchanged(tmp_path: Path):
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    later = check_release(URL, state, opener=_Opener(),
+                          now=NOW + timedelta(days=1))
+    assert later.changed is False
+    # The clock runs from first observation, not from the latest check.
+    assert later.first_observed == NOW
+
+
+def test_a_new_etag_is_reported_changed_and_restarts_the_clock(tmp_path: Path):
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    moved = check_release(
+        URL, state, now=NOW + timedelta(days=30),
+        opener=_Opener({**HEADERS, "ETag": '"a-different-etag"'}))
+    assert moved.changed is True
+    assert moved.first_observed == NOW + timedelta(days=30)
+    assert moved.previous.etag == HEADERS["ETag"]
+
+
+def test_a_response_with_no_validators_is_treated_as_changed(tmp_path: Path):
+    # Nothing to compare means the check cannot prove the release is the same
+    # one. Reporting "unchanged" would let a rebuild be skipped on no evidence.
+    result = check_release(URL, tmp_path / "state.json", opener=_Opener({}),
+                           now=NOW)
+    assert result.changed is True
+    assert "no validators" in result.reason
+
+
+# -- the uningested alert ---------------------------------------------------
+
+def test_an_uningested_release_alerts_after_seven_days(tmp_path: Path):
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    result = check_release(URL, state, opener=_Opener(),
+                           now=NOW + timedelta(days=UNINGESTED_ALERT_DAYS))
+    assert result.uningested_days == UNINGESTED_ALERT_DAYS
+    assert result.alert is True
+
+
+def test_a_release_observed_yesterday_does_not_alert(tmp_path: Path):
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    result = check_release(URL, state, opener=_Opener(),
+                           now=NOW + timedelta(days=1))
+    assert result.alert is False
+
+
+def test_recording_an_ingest_clears_the_alert(tmp_path: Path):
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    record_ingested(state, version="v20260828T101500Z", etag=HEADERS["ETag"],
+                    now=NOW + timedelta(hours=2))
+    result = check_release(URL, state, opener=_Opener(),
+                           now=NOW + timedelta(days=30))
+    assert result.alert is False
+    assert result.ingested is True
+    assert result.uningested_days is None
+
+
+def test_an_ingest_of_a_different_release_does_not_clear_the_alert(tmp_path: Path):
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    record_ingested(state, version="v20260101T000000Z", etag='"an-older-etag"',
+                    now=NOW)
+    result = check_release(URL, state, opener=_Opener(),
+                           now=NOW + timedelta(days=8))
+    assert result.ingested is False
+    assert result.alert is True
+
+
+# -- state ------------------------------------------------------------------
+
+def test_the_state_file_is_the_only_thing_written(tmp_path: Path):
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    assert [p.name for p in tmp_path.iterdir()] == ["state.json"]
+    assert json.loads(state.read_text())["etag"] == HEADERS["ETag"]
+
+
+def test_a_corrupt_state_file_is_treated_as_no_observation(tmp_path: Path):
+    state = tmp_path / "state.json"
+    state.write_text("{not json")
+    result = check_release(URL, state, opener=_Opener(), now=NOW)
+    assert result.changed is True
+    assert result.previous is None
+
+
+def test_an_observation_round_trips_through_the_state_file(tmp_path: Path):
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    stored = ReleaseObservation(**{
+        k: v for k, v in json.loads(state.read_text()).items()
+        if k in {"etag", "last_modified", "content_length"}})
+    assert stored.content_length == 5494145759
+
+
+# -- the release's declared coverage end ------------------------------------
+
+def test_the_declared_coverage_end_is_the_month_before_publication():
+    from tools.ppd_snapshot.release_check import declared_coverage_end
+
+    # The July 2026 publication carries data to the end of June 2026 -- which is
+    # exactly the maximum transfer date observed in that release.
+    assert declared_coverage_end("Tue, 28 Jul 2026 05:16:16 GMT") == date(2026, 6, 30)
+
+
+def test_the_declared_coverage_end_wraps_at_the_year_boundary():
+    from tools.ppd_snapshot.release_check import declared_coverage_end
+
+    assert declared_coverage_end("Thu, 15 Jan 2026 00:00:00 GMT") == date(2025, 12, 31)
+
+
+def test_an_unparseable_publication_date_yields_no_declared_end():
+    from tools.ppd_snapshot.release_check import declared_coverage_end
+
+    assert declared_coverage_end("not a date") is None
+    assert declared_coverage_end(None) is None

--- a/tests/snapshot/test_snapshot_release_check.py
+++ b/tests/snapshot/test_snapshot_release_check.py
@@ -234,3 +234,48 @@ def test_an_unparseable_publication_date_yields_no_declared_end():
 
     assert declared_coverage_end("not a date") is None
     assert declared_coverage_end(None) is None
+
+
+# -- the observation clock must survive a failed write ----------------------
+
+def test_a_failed_state_write_preserves_the_previous_observation(tmp_path,
+                                                                 monkeypatch):
+    """`write_text` truncates first, so an interrupted check would erase the
+    first-observed timestamp the seven-day alert is measured from."""
+    from tools.ppd_snapshot import atomic
+
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    before = state.read_bytes()
+
+    monkeypatch.setattr(atomic.os, "replace",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")))
+    with pytest.raises(OSError):
+        check_release(URL, state, opener=_Opener(),
+                      now=NOW + timedelta(days=1))
+
+    assert state.read_bytes() == before
+    assert json.loads(state.read_text())["first_observed_utc"] == NOW.isoformat()
+
+
+def test_a_failed_ingest_record_preserves_the_previous_state(tmp_path,
+                                                             monkeypatch):
+    from tools.ppd_snapshot import atomic
+
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    before = state.read_bytes()
+
+    monkeypatch.setattr(atomic.os, "replace",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")))
+    with pytest.raises(OSError):
+        record_ingested(state, version="v20260828T101500Z", etag=HEADERS["ETag"],
+                        now=NOW)
+    assert state.read_bytes() == before
+
+
+def test_a_state_write_leaves_no_temporary_files(tmp_path):
+    state = tmp_path / "state.json"
+    check_release(URL, state, opener=_Opener(), now=NOW)
+    record_ingested(state, version="v1", etag=HEADERS["ETag"], now=NOW)
+    assert [p.name for p in tmp_path.iterdir()] == ["state.json"]

--- a/tests/snapshot/test_snapshot_source_receipt.py
+++ b/tests/snapshot/test_snapshot_source_receipt.py
@@ -322,3 +322,119 @@ def test_a_streamed_download_digests_the_file_only_once(tmp_path, monkeypatch):
         download_with_receipt(url, tmp_path / "pp.csv",
                               tmp_path / "receipt.json", now=NOW)
     assert calls == []
+
+
+def test_a_failed_receipt_commit_preserves_the_previous_pair(tmp_path,
+                                                             monkeypatch):
+    """The CSV and its receipt are one fact in two files.
+
+    Replacing the CSV and then failing to write the receipt leaves the previous
+    valid pair destroyed: the old bytes are gone and the surviving receipt
+    describes a file that no longer exists.
+    """
+    from tools.ppd_snapshot import source_receipt as sr
+
+    csv_path, receipt_path, csv_before, receipt_before = _seed(tmp_path)
+    fresh = b"newer,release,rows\n" * 3
+    served = _serve(fresh, {"ETag": '"newer-etag"',
+                            "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+                            "Content-Length": str(len(fresh))})
+
+    def _boom(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(sr, "prepare_write_json", _boom)
+    with served as url:
+        with pytest.raises(OSError):
+            download_with_receipt(url, csv_path, receipt_path, now=NOW)
+
+    assert csv_path.read_bytes() == csv_before
+    assert receipt_path.read_bytes() == receipt_before
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["pp.csv", "receipt.json"]
+
+
+def test_a_failed_receipt_rename_rolls_the_csv_back(tmp_path, monkeypatch):
+    from tools.ppd_snapshot import source_receipt as sr
+
+    csv_path, receipt_path, csv_before, receipt_before = _seed(tmp_path)
+    fresh = b"newer,release,rows\n" * 3
+    served = _serve(fresh, {"ETag": '"newer-etag"',
+                            "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+                            "Content-Length": str(len(fresh))})
+
+    real = sr.os.replace
+
+    def _replace(src, dst, *args, **kwargs):
+        if str(dst).endswith("receipt.json"):
+            raise OSError("rename failed")
+        return real(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(sr.os, "replace", _replace)
+    with served as url:
+        with pytest.raises(OSError):
+            download_with_receipt(url, csv_path, receipt_path, now=NOW)
+
+    assert csv_path.read_bytes() == csv_before
+    assert receipt_path.read_bytes() == receipt_before
+
+
+def test_a_destination_that_is_also_the_receipt_is_refused_before_requesting(
+        tmp_path):
+    """Otherwise the download succeeds and the receipt JSON overwrites the CSV
+    it describes."""
+    requests = []
+
+    def _opener(request, timeout=None):  # pragma: no cover - must not run
+        requests.append(request)
+        raise AssertionError("no request may be made")
+
+    same = tmp_path / "pp.csv"
+    with pytest.raises(SourceMismatch, match="same path"):
+        download_with_receipt("http://example.invalid/pp.csv", same, same,
+                              opener=_opener, now=NOW)
+    assert requests == []
+    assert not same.exists()
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(),
+                    reason="needs /proc to count open descriptors")
+def test_a_failing_opener_does_not_leak_descriptors(tmp_path):
+    """`mkstemp` hands back a raw descriptor. If the request fails before it is
+    adopted by a file object, nothing ever closes it."""
+    def _opener(request, timeout=None):
+        raise OSError("connection refused")
+
+    def open_fds() -> int:
+        return len(list(Path("/proc/self/fd").iterdir()))
+
+    before = open_fds()
+    for _ in range(12):
+        with pytest.raises(OSError):
+            download_with_receipt("http://example.invalid/pp.csv",
+                                  tmp_path / "pp.csv", tmp_path / "receipt.json",
+                                  opener=_opener, now=NOW)
+    assert open_fds() <= before
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(),
+                    reason="needs /proc to count open descriptors")
+def test_repeated_successful_downloads_do_not_leak_descriptors(tmp_path):
+    """The success path allocates temporaries too -- including the backup of the
+    file being replaced."""
+    def open_fds() -> int:
+        return len(list(Path("/proc/self/fd").iterdir()))
+
+    fresh = b"newer,release\n"
+    headers = {"ETag": '"newer-etag"',
+               "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+               "Content-Length": str(len(fresh))}
+    before = None
+    for attempt in range(12):
+        with _serve(fresh, headers) as url:
+            download_with_receipt(url, tmp_path / "pp.csv",
+                                  tmp_path / "receipt.json", now=NOW)
+        if attempt == 1:
+            before = open_fds()
+    assert open_fds() <= before
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["pp.csv", "receipt.json"]

--- a/tests/snapshot/test_snapshot_source_receipt.py
+++ b/tests/snapshot/test_snapshot_source_receipt.py
@@ -438,3 +438,66 @@ def test_repeated_successful_downloads_do_not_leak_descriptors(tmp_path):
             before = open_fds()
     assert open_fds() <= before
     assert sorted(p.name for p in tmp_path.iterdir()) == ["pp.csv", "receipt.json"]
+
+
+def test_a_failed_rollback_retains_the_backup_and_names_it(tmp_path, monkeypatch):
+    """When the commit fails AND the restore fails, the backup is the only copy
+    of the previous release. Deleting it turns a recoverable half-commit into an
+    unrecoverable one."""
+    from tools.ppd_snapshot import source_receipt as sr
+    from tools.ppd_snapshot.source_receipt import ReceiptRollbackFailed
+
+    csv_path, receipt_path, csv_before, receipt_before = _seed(tmp_path)
+    fresh = b"newer,release,rows\n" * 3
+    served = _serve(fresh, {"ETag": '"newer-etag"',
+                            "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+                            "Content-Length": str(len(fresh))})
+
+    real = sr.os.replace
+    seen = {"dest": 0}
+
+    def _replace(src, dst, *args, **kwargs):
+        if str(dst).endswith("receipt.json"):
+            raise OSError("receipt commit failed")
+        if str(dst) == str(csv_path):
+            seen["dest"] += 1
+            # The first is publication; the second is the rollback.
+            if seen["dest"] > 1:
+                raise OSError("restore failed")
+        return real(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(sr.os, "replace", _replace)
+    with served as url:
+        with pytest.raises(ReceiptRollbackFailed) as caught:
+            download_with_receipt(url, csv_path, receipt_path, now=NOW)
+
+    backups = [p for p in tmp_path.iterdir() if p.name.endswith(".prev")]
+    assert len(backups) == 1, "the only copy of the previous release was deleted"
+    assert backups[0].read_bytes() == csv_before
+    assert str(backups[0]) in str(caught.value)
+    # The receipt was never replaced, so the previous pair is reconstructable.
+    assert receipt_path.read_bytes() == receipt_before
+
+
+def test_a_failed_backup_rename_leaves_no_staging_files(tmp_path, monkeypatch):
+    from tools.ppd_snapshot import source_receipt as sr
+
+    csv_path, receipt_path, csv_before, receipt_before = _seed(tmp_path)
+    fresh = b"newer,release,rows\n" * 3
+    served = _serve(fresh, {"ETag": '"newer-etag"',
+                            "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+                            "Content-Length": str(len(fresh))})
+
+    real = sr.os.replace
+    monkeypatch.setattr(sr.os, "replace", lambda src, dst, *a, **k: (
+        (_ for _ in ()).throw(OSError("backup rename failed"))
+        if str(dst).endswith(".prev") else real(src, dst, *a, **k)))
+
+    with served as url:
+        with pytest.raises(OSError):
+            download_with_receipt(url, csv_path, receipt_path, now=NOW)
+
+    assert csv_path.read_bytes() == csv_before
+    assert receipt_path.read_bytes() == receipt_before
+    # No data temp, no receipt temp, no empty backup left behind.
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["pp.csv", "receipt.json"]

--- a/tests/snapshot/test_snapshot_source_receipt.py
+++ b/tests/snapshot/test_snapshot_source_receipt.py
@@ -194,15 +194,24 @@ def test_a_download_that_does_not_match_its_declared_length_is_refused(tmp_path)
 
 
 @contextlib.contextmanager
-def _serve(body: bytes, headers: dict):
-    """A loopback HTTP server. Local only -- no external host is contacted."""
+def _serve(body: bytes, headers: dict, *, drop: bool = False):
+    """A loopback HTTP server. Local only -- no external host is contacted.
+
+    `drop` closes the connection after the body, modelling a transfer that dies
+    part way through rather than one that merely disagrees about its length.
+    """
     class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
         def do_GET(self):  # noqa: N802 - stdlib naming
             self.send_response(200)
             for key, value in headers.items():
                 self.send_header(key, value)
             self.end_headers()
             self.wfile.write(body)
+            if drop:
+                self.close_connection = True
+                self.wfile.flush()
 
         def log_message(self, *args):
             pass
@@ -216,3 +225,100 @@ def _serve(body: bytes, headers: dict):
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
+
+
+# -- a failed refresh must not destroy the release already held -------------
+
+def _seed(tmp_path: Path) -> tuple[Path, Path, bytes, bytes]:
+    """A known-good CSV and its receipt, as a previous run would leave them."""
+    csv_path = tmp_path / "pp.csv"
+    csv_path.write_bytes(BODY)
+    receipt_path = tmp_path / "receipt.json"
+    write_receipt(csv_path, observation(), receipt_path,
+                  expected_sha256=BODY_SHA, now=NOW)
+    return csv_path, receipt_path, csv_path.read_bytes(), receipt_path.read_bytes()
+
+
+def test_a_download_that_disagrees_with_its_length_preserves_what_was_held(
+        tmp_path):
+    csv_path, receipt_path, csv_before, receipt_before = _seed(tmp_path)
+    served = _serve(b"new but truncated\n", {
+        "ETag": '"newer-etag"',
+        "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+        "Content-Length": "999999"})
+    with served as url:
+        with pytest.raises(SourceMismatch):
+            download_with_receipt(url, csv_path, receipt_path, now=NOW)
+
+    assert csv_path.read_bytes() == csv_before
+    assert receipt_path.read_bytes() == receipt_before
+
+
+def test_a_download_dropped_mid_stream_preserves_what_was_held(tmp_path):
+    csv_path, receipt_path, csv_before, receipt_before = _seed(tmp_path)
+    served = _serve(b"x" * 32, {"ETag": '"newer-etag"',
+                                "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+                                "Content-Length": "100000"}, drop=True)
+    with served as url:
+        with pytest.raises(Exception):
+            download_with_receipt(url, csv_path, receipt_path, now=NOW)
+
+    assert csv_path.read_bytes() == csv_before
+    assert receipt_path.read_bytes() == receipt_before
+
+
+def test_a_failed_download_leaves_no_partial_file_behind(tmp_path):
+    csv_path, receipt_path, _, _ = _seed(tmp_path)
+    served = _serve(b"short", {"ETag": '"newer-etag"',
+                               "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+                               "Content-Length": "999999"})
+    with served as url:
+        with pytest.raises(SourceMismatch):
+            download_with_receipt(url, csv_path, receipt_path, now=NOW)
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["pp.csv", "receipt.json"]
+
+
+def test_a_successful_download_replaces_both_the_file_and_its_receipt(tmp_path):
+    csv_path, receipt_path, _, _ = _seed(tmp_path)
+    fresh = b"newer,release,rows\n" * 3
+    served = _serve(fresh, {"ETag": '"newer-etag"',
+                            "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+                            "Content-Length": str(len(fresh))})
+    with served as url:
+        receipt = download_with_receipt(url, csv_path, receipt_path, now=NOW)
+
+    assert csv_path.read_bytes() == fresh
+    assert receipt.sha256 == hashlib.sha256(fresh).hexdigest()
+    assert load_receipt(receipt_path).etag == '"newer-etag"'
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["pp.csv", "receipt.json"]
+
+
+def test_a_streamed_receipt_names_the_destination_not_the_temporary_file(
+        tmp_path):
+    fresh = b"newer,release\n"
+    served = _serve(fresh, {"ETag": '"newer-etag"',
+                            "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+                            "Content-Length": str(len(fresh))})
+    with served as url:
+        download_with_receipt(url, tmp_path / "pp-complete.csv",
+                              tmp_path / "receipt.json", now=NOW)
+    assert load_receipt(tmp_path / "receipt.json").file == "pp-complete.csv"
+
+
+def test_a_streamed_download_digests_the_file_only_once(tmp_path, monkeypatch):
+    """Re-reading to build the receipt would mean a second pass over 5.5 GB."""
+    from tools.ppd_snapshot import source_receipt as sr
+
+    calls = []
+    real = sr.digest_file
+    monkeypatch.setattr(sr, "digest_file",
+                        lambda path: (calls.append(path), real(path))[1])
+
+    fresh = b"newer,release\n"
+    served = _serve(fresh, {"ETag": '"newer-etag"',
+                            "Last-Modified": "Fri, 28 Aug 2026 05:16:16 GMT",
+                            "Content-Length": str(len(fresh))})
+    with served as url:
+        download_with_receipt(url, tmp_path / "pp.csv",
+                              tmp_path / "receipt.json", now=NOW)
+    assert calls == []

--- a/tests/snapshot/test_snapshot_source_receipt.py
+++ b/tests/snapshot/test_snapshot_source_receipt.py
@@ -13,9 +13,12 @@ still agree.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
+import threading
 from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
@@ -23,6 +26,7 @@ import pytest
 from tools.ppd_snapshot.release_check import ReleaseObservation
 from tools.ppd_snapshot.source_receipt import (
     SourceMismatch,
+    download_with_receipt,
     load_receipt,
     verify_source,
     write_receipt,
@@ -30,6 +34,7 @@ from tools.ppd_snapshot.source_receipt import (
 
 NOW = datetime(2026, 8, 28, 9, 0, tzinfo=timezone.utc)
 BODY = b"a,b,c\n" * 40
+BODY_SHA = hashlib.sha256(BODY).hexdigest()
 
 
 def observation(**over) -> ReleaseObservation:
@@ -48,7 +53,7 @@ def csv_path(tmp_path: Path) -> Path:
 
 def test_a_receipt_records_the_digest_and_length_it_computed(csv_path, tmp_path):
     receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
-                            now=NOW)
+                            expected_sha256=BODY_SHA, now=NOW)
     assert receipt.sha256 == hashlib.sha256(BODY).hexdigest()
     assert receipt.bytes == len(BODY)
     assert receipt.etag == '"an-etag"'
@@ -62,7 +67,8 @@ def test_writing_a_receipt_refuses_a_file_the_release_says_is_a_different_size(
     # something else entirely.
     with pytest.raises(SourceMismatch, match="999999999"):
         write_receipt(csv_path, observation(content_length=999_999_999),
-                      tmp_path / "receipt.json", now=NOW)
+                      tmp_path / "receipt.json", expected_sha256=BODY_SHA,
+                      now=NOW)
     assert not (tmp_path / "receipt.json").exists()
 
 
@@ -70,19 +76,20 @@ def test_writing_a_receipt_refuses_a_release_that_declares_no_length(
         csv_path, tmp_path):
     with pytest.raises(SourceMismatch, match="no Content-Length"):
         write_receipt(csv_path, observation(content_length=None),
-                      tmp_path / "receipt.json", now=NOW)
+                      tmp_path / "receipt.json", expected_sha256=BODY_SHA,
+                      now=NOW)
 
 
 def test_verification_accepts_a_file_that_still_matches(csv_path, tmp_path):
     receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
-                            now=NOW)
+                            expected_sha256=BODY_SHA, now=NOW)
     verify_source(csv_path, receipt, observation())
 
 
 def test_verification_refuses_a_file_that_changed_since_the_receipt(
         csv_path, tmp_path):
     receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
-                            now=NOW)
+                            expected_sha256=BODY_SHA, now=NOW)
     csv_path.write_bytes(BODY + b"one more row\n")
     with pytest.raises(SourceMismatch, match="bytes"):
         verify_source(csv_path, receipt, observation())
@@ -91,7 +98,7 @@ def test_verification_refuses_a_file_that_changed_since_the_receipt(
 def test_verification_refuses_a_file_edited_without_changing_its_length(
         csv_path, tmp_path):
     receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
-                            now=NOW)
+                            expected_sha256=BODY_SHA, now=NOW)
     edited = bytearray(BODY)
     edited[0] = ord("z")
     csv_path.write_bytes(bytes(edited))
@@ -101,7 +108,7 @@ def test_verification_refuses_a_file_edited_without_changing_its_length(
 
 def test_verification_refuses_when_the_release_has_moved_on(csv_path, tmp_path):
     receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
-                            now=NOW)
+                            expected_sha256=BODY_SHA, now=NOW)
     with pytest.raises(SourceMismatch, match="ETag"):
         verify_source(csv_path, receipt, observation(etag='"a-newer-etag"'))
 
@@ -109,7 +116,7 @@ def test_verification_refuses_when_the_release_has_moved_on(csv_path, tmp_path):
 def test_verification_refuses_when_the_publication_date_has_moved(
         csv_path, tmp_path):
     receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
-                            now=NOW)
+                            expected_sha256=BODY_SHA, now=NOW)
     with pytest.raises(SourceMismatch, match="Last-Modified"):
         verify_source(csv_path, receipt,
                       observation(last_modified="Fri, 28 Aug 2026 05:16:16 GMT"))
@@ -128,5 +135,84 @@ def test_a_corrupt_receipt_is_refused(tmp_path):
 
 def test_a_receipt_round_trips(csv_path, tmp_path):
     written = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
-                            now=NOW)
+                            expected_sha256=BODY_SHA, now=NOW)
     assert load_receipt(tmp_path / "receipt.json") == written
+
+
+# -- a receipt must be grounded in independent download evidence ------------
+
+def test_minting_a_receipt_requires_the_digest_recorded_at_download(
+        csv_path, tmp_path):
+    """Same length, any ETag: without a recorded digest the receipt binds
+    whatever happens to be on disk to whatever the release claims to be."""
+    with pytest.raises(SourceMismatch, match="sha256"):
+        write_receipt(csv_path, observation(), tmp_path / "receipt.json",
+                      expected_sha256="0" * 64, now=NOW)
+    assert not (tmp_path / "receipt.json").exists()
+
+
+def test_a_receipt_records_where_its_digest_came_from(csv_path, tmp_path):
+    receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
+                            expected_sha256=BODY_SHA, now=NOW)
+    assert receipt.evidence == "recorded-checksum"
+
+
+def test_swapping_the_file_for_same_length_bytes_is_refused(csv_path, tmp_path):
+    swapped = bytearray(BODY)
+    swapped[0] = ord("z")
+    csv_path.write_bytes(bytes(swapped))
+    with pytest.raises(SourceMismatch, match="sha256"):
+        write_receipt(csv_path, observation(), tmp_path / "receipt.json",
+                      expected_sha256=BODY_SHA, now=NOW)
+
+
+def test_a_streamed_download_mints_its_own_receipt(tmp_path):
+    """The intended way to obtain a receipt: digest the bytes as they arrive,
+    from the same response the validators come from."""
+    served = _serve(BODY, {"ETag": '"served-etag"',
+                           "Last-Modified": "Tue, 28 Jul 2026 05:16:16 GMT",
+                           "Content-Length": str(len(BODY))})
+    with served as url:
+        receipt = download_with_receipt(url, tmp_path / "pp.csv",
+                                        tmp_path / "receipt.json", now=NOW)
+    assert (tmp_path / "pp.csv").read_bytes() == BODY
+    assert receipt.sha256 == BODY_SHA
+    assert receipt.etag == '"served-etag"'
+    assert receipt.evidence == "streamed-download"
+
+
+def test_a_download_that_does_not_match_its_declared_length_is_refused(tmp_path):
+    served = _serve(BODY, {"ETag": '"served-etag"',
+                           "Last-Modified": "Tue, 28 Jul 2026 05:16:16 GMT",
+                           "Content-Length": str(len(BODY) + 10)})
+    with served as url:
+        with pytest.raises(SourceMismatch, match="Content-Length"):
+            download_with_receipt(url, tmp_path / "pp.csv",
+                                  tmp_path / "receipt.json", now=NOW)
+    assert not (tmp_path / "pp.csv").exists()
+    assert not (tmp_path / "receipt.json").exists()
+
+
+@contextlib.contextmanager
+def _serve(body: bytes, headers: dict):
+    """A loopback HTTP server. Local only -- no external host is contacted."""
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - stdlib naming
+            self.send_response(200)
+            for key, value in headers.items():
+                self.send_header(key, value)
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/pp-complete.csv"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/tests/snapshot/test_snapshot_source_receipt.py
+++ b/tests/snapshot/test_snapshot_source_receipt.py
@@ -1,0 +1,132 @@
+"""Red-first tests binding the local CSV to the release it claims to be.
+
+The defect this closes: a 131-byte stale CSV built cleanly while the release
+record claimed 999,999,999 bytes under a new ETag, and the result booted READY.
+Nothing compared the file with the release, so every downstream gate was
+checking an artifact that was internally consistent and about the wrong data.
+
+A receipt is the binding: it records the digest and length **computed from the
+file** alongside the validators of the release it was fetched for, and the build
+refuses unless the receipt, the file on disk and the latest observation all
+still agree.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tools.ppd_snapshot.release_check import ReleaseObservation
+from tools.ppd_snapshot.source_receipt import (
+    SourceMismatch,
+    load_receipt,
+    verify_source,
+    write_receipt,
+)
+
+NOW = datetime(2026, 8, 28, 9, 0, tzinfo=timezone.utc)
+BODY = b"a,b,c\n" * 40
+
+
+def observation(**over) -> ReleaseObservation:
+    fields = {"etag": '"an-etag"', "last_modified": "Tue, 28 Jul 2026 05:16:16 GMT",
+              "content_length": len(BODY)}
+    fields.update(over)
+    return ReleaseObservation(**fields)
+
+
+@pytest.fixture
+def csv_path(tmp_path: Path) -> Path:
+    path = tmp_path / "pp-complete.csv"
+    path.write_bytes(BODY)
+    return path
+
+
+def test_a_receipt_records_the_digest_and_length_it_computed(csv_path, tmp_path):
+    receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
+                            now=NOW)
+    assert receipt.sha256 == hashlib.sha256(BODY).hexdigest()
+    assert receipt.bytes == len(BODY)
+    assert receipt.etag == '"an-etag"'
+    assert json.loads((tmp_path / "receipt.json").read_text())["sha256"] == \
+        receipt.sha256
+
+
+def test_writing_a_receipt_refuses_a_file_the_release_says_is_a_different_size(
+        csv_path, tmp_path):
+    # The reproduction: a stale local file under a release that describes
+    # something else entirely.
+    with pytest.raises(SourceMismatch, match="999999999"):
+        write_receipt(csv_path, observation(content_length=999_999_999),
+                      tmp_path / "receipt.json", now=NOW)
+    assert not (tmp_path / "receipt.json").exists()
+
+
+def test_writing_a_receipt_refuses_a_release_that_declares_no_length(
+        csv_path, tmp_path):
+    with pytest.raises(SourceMismatch, match="no Content-Length"):
+        write_receipt(csv_path, observation(content_length=None),
+                      tmp_path / "receipt.json", now=NOW)
+
+
+def test_verification_accepts_a_file_that_still_matches(csv_path, tmp_path):
+    receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
+                            now=NOW)
+    verify_source(csv_path, receipt, observation())
+
+
+def test_verification_refuses_a_file_that_changed_since_the_receipt(
+        csv_path, tmp_path):
+    receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
+                            now=NOW)
+    csv_path.write_bytes(BODY + b"one more row\n")
+    with pytest.raises(SourceMismatch, match="bytes"):
+        verify_source(csv_path, receipt, observation())
+
+
+def test_verification_refuses_a_file_edited_without_changing_its_length(
+        csv_path, tmp_path):
+    receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
+                            now=NOW)
+    edited = bytearray(BODY)
+    edited[0] = ord("z")
+    csv_path.write_bytes(bytes(edited))
+    with pytest.raises(SourceMismatch, match="sha256"):
+        verify_source(csv_path, receipt, observation())
+
+
+def test_verification_refuses_when_the_release_has_moved_on(csv_path, tmp_path):
+    receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
+                            now=NOW)
+    with pytest.raises(SourceMismatch, match="ETag"):
+        verify_source(csv_path, receipt, observation(etag='"a-newer-etag"'))
+
+
+def test_verification_refuses_when_the_publication_date_has_moved(
+        csv_path, tmp_path):
+    receipt = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
+                            now=NOW)
+    with pytest.raises(SourceMismatch, match="Last-Modified"):
+        verify_source(csv_path, receipt,
+                      observation(last_modified="Fri, 28 Aug 2026 05:16:16 GMT"))
+
+
+def test_a_missing_receipt_is_refused_rather_than_defaulted(tmp_path):
+    with pytest.raises(SourceMismatch, match="no source receipt"):
+        load_receipt(tmp_path / "absent.json")
+
+
+def test_a_corrupt_receipt_is_refused(tmp_path):
+    (tmp_path / "receipt.json").write_text("{not json")
+    with pytest.raises(SourceMismatch):
+        load_receipt(tmp_path / "receipt.json")
+
+
+def test_a_receipt_round_trips(csv_path, tmp_path):
+    written = write_receipt(csv_path, observation(), tmp_path / "receipt.json",
+                            now=NOW)
+    assert load_receipt(tmp_path / "receipt.json") == written

--- a/tools/ppd_snapshot/__init__.py
+++ b/tools/ppd_snapshot/__init__.py
@@ -1,0 +1,20 @@
+"""Local build and validation pipeline for the PPD snapshot.
+
+**Local only.** Nothing here uploads, publishes, creates a bucket, reads a
+secret or touches a deployed system: governing specification section 4.8 limits
+this stage to building and validating an artifact on a workstation, and artifact
+distribution is a separately approved decision.
+
+Deliberately outside the published wheel (`[tool.hatch.build.targets.wheel]`
+lists `property_core`, `app`, `property_cli`, `property_app` and not this
+package): the pipeline needs DuckDB and a 5.5 GB CSV, and no library consumer
+should carry either.
+
+The division of labour with `property_core.snapshot` is the point of the design:
+this package *declares* what it built, and the merged runtime -- fetch, digest
+verification, member-validated extraction, activation, then
+`SnapshotAdapter.open` -- is what *judges* it. Validation here re-uses the
+repository's own contracts (`property_core.snapshot.schema.REQUIRED_COLUMNS`,
+`SnapshotManifest`) rather than restating them, so the build cannot drift from
+the thing that has to read it.
+"""

--- a/tools/ppd_snapshot/__main__.py
+++ b/tools/ppd_snapshot/__main__.py
@@ -173,15 +173,36 @@ def load_receipt_or_none(args):
     return receipt
 
 
+def _checked_window(args, receipt) -> Optional[date]:
+    """The declared window end, checked against the bound release. Or nothing.
+
+    Checked HERE, before anything is written. The coverage gate would catch a
+    mismatch afterwards, but only after a snapshot had been built from it, and a
+    directory of Parquet files that failed validation is still a directory
+    someone can point `validate` at.
+
+    Takes the already-verified receipt rather than loading it again: verifying
+    digests the whole CSV, and a second pass over 5.5 GB buys no more evidence.
+    """
+    expected = _expected_end(receipt)
+    if expected is None:
+        print("refusing to build: the bound release carries no usable "
+              "publication date, so its coverage end cannot be derived")
+        return None
+    declared = _iso(args.coverage_to)
+    if declared != expected:
+        print(f"refusing to build: --coverage-to {declared} is not the coverage "
+              f"end the bound release implies ({expected}); the release was "
+              f"published on {receipt.last_modified}")
+        return None
+    return expected
+
+
 def _cmd_build(args) -> int:
     # The same binding as `all`: this writes the artifact `validate` then
     # blesses, so it is not a way around the source check.
     receipt = load_receipt_or_none(args)
-    if receipt is None:
-        return 2
-    if _expected_end(receipt) is None:
-        print("refusing to build: the bound release carries no usable "
-              "publication date, so its coverage end cannot be derived")
+    if receipt is None or _checked_window(args, receipt) is None:
         return 2
     built = _build(args)
     print(f"built {built.rows} row(s) into {built.parquet_files} partition(s) "
@@ -301,12 +322,11 @@ def _cmd_all(args) -> int:
     receipt = load_receipt_or_none(args)
     if receipt is None:
         return 2
-    source_end = _expected_end(receipt)
+    source_end = _checked_window(args, receipt)
     if source_end is None:
-        print("refusing to build: the bound release carries no usable "
-              "publication date, so its coverage end cannot be derived")
         return 2
-    print(f"the bound release implies a coverage end of {source_end}")
+    print(f"the bound release implies a coverage end of {source_end}, matching "
+          f"the declared window")
     print(f"source verified: {Path(args.csv).name} matches its receipt and the "
           f"observed release")
 

--- a/tools/ppd_snapshot/__main__.py
+++ b/tools/ppd_snapshot/__main__.py
@@ -26,6 +26,7 @@ from datetime import date
 from pathlib import Path
 from typing import Optional, Sequence
 
+from tools.ppd_snapshot.atomic import atomic_write_json
 from tools.ppd_snapshot.build import (
     BuildRequest,
     BuildResult,
@@ -367,7 +368,9 @@ def _cmd_all(args) -> int:
 
     stored = json.loads(release.report_path.read_text())
     stored["boot_check"] = outcome
-    release.report_path.write_text(json.dumps(stored, indent=2) + "\n")
+    # Rewritten, so it goes through the same replace-by-rename path as every
+    # other document this pipeline overwrites.
+    atomic_write_json(release.report_path, stored)
 
     if outcome["readiness"] != "ready":
         print(f"not promoted; the candidate is left at "

--- a/tools/ppd_snapshot/__main__.py
+++ b/tools/ppd_snapshot/__main__.py
@@ -49,6 +49,7 @@ from tools.ppd_snapshot.release_check import (
     record_ingested,
 )
 from tools.ppd_snapshot.source_receipt import (
+    ReceiptRollbackFailed,
     SourceMismatch,
     download_with_receipt,
     load_receipt,
@@ -149,6 +150,12 @@ def _cmd_download(args) -> int:
     try:
         receipt = download_with_receipt(args.url, Path(args.dest),
                                         Path(args.receipt))
+    except ReceiptRollbackFailed as exc:
+        # The path is the whole recovery instruction; it must not be buried in
+        # a traceback.
+        print(f"DOWNLOAD LEFT A HALF-COMMITTED PAIR: {exc}")
+        print(f"the previous release is retained at {exc.backup_path}")
+        return 3
     except SourceMismatch as exc:
         print(f"download refused: {exc}")
         return 2

--- a/tools/ppd_snapshot/__main__.py
+++ b/tools/ppd_snapshot/__main__.py
@@ -49,6 +49,7 @@ from tools.ppd_snapshot.release_check import (
 )
 from tools.ppd_snapshot.source_receipt import (
     SourceMismatch,
+    download_with_receipt,
     load_receipt,
     verify_source,
     write_receipt,
@@ -102,17 +103,18 @@ def _observed(state: dict) -> Optional[ReleaseObservation]:
         content_length=state.get("content_length"))
 
 
-def _source_end(args) -> Optional[date]:
-    """The release's declared coverage end, from the release record if not given.
+def _expected_end(receipt) -> Optional[date]:
+    """The coverage end the bound release implies. Not an argument.
 
-    Kept independent of `--coverage-to` on purpose: the two agreeing is the
-    check. Deriving one from the other would make the gate say nothing.
+    There is deliberately no override on `build`/`all`. `--coverage-to` is the
+    operator's declaration and this is the evidence it is checked against, so a
+    flag that sets the evidence too makes the check compare a claim with itself:
+    a 28 July release was published as covering 31 July by setting both.
+
+    It is derived from the RECEIPT rather than the release-state file because
+    the receipt is the document bound to the bytes that were actually read.
     """
-    explicit = _iso(getattr(args, "source_coverage_end", None))
-    if explicit:
-        return explicit
-    return declared_coverage_end(
-        _release_state(getattr(args, "release_state", None)).get("last_modified"))
+    return declared_coverage_end(receipt.last_modified)
 
 
 # -- commands ----------------------------------------------------------------
@@ -130,12 +132,27 @@ def _cmd_receipt(args) -> int:
               "first so the file can be bound to a release")
         return 2
     try:
-        receipt = write_receipt(Path(args.csv), observation, Path(args.receipt))
+        receipt = write_receipt(Path(args.csv), observation, Path(args.receipt),
+                                expected_sha256=args.expected_sha256)
     except SourceMismatch as exc:
         print(f"refusing to write a receipt: {exc}")
         return 2
     print(f"receipt written for {receipt.file}: {receipt.bytes} bytes, "
-          f"sha256 {receipt.sha256}, ETag {receipt.etag}")
+          f"sha256 {receipt.sha256}, ETag {receipt.etag} "
+          f"(evidence: {receipt.evidence})")
+    return 0
+
+
+def _cmd_download(args) -> int:
+    """Stream a release and mint its receipt from the same response."""
+    try:
+        receipt = download_with_receipt(args.url, Path(args.dest),
+                                        Path(args.receipt))
+    except SourceMismatch as exc:
+        print(f"download refused: {exc}")
+        return 2
+    print(f"downloaded {receipt.bytes} bytes to {args.dest}; receipt sha256 "
+          f"{receipt.sha256} (evidence: {receipt.evidence})")
     return 0
 
 
@@ -159,7 +176,12 @@ def load_receipt_or_none(args):
 def _cmd_build(args) -> int:
     # The same binding as `all`: this writes the artifact `validate` then
     # blesses, so it is not a way around the source check.
-    if load_receipt_or_none(args) is None:
+    receipt = load_receipt_or_none(args)
+    if receipt is None:
+        return 2
+    if _expected_end(receipt) is None:
+        print("refusing to build: the bound release carries no usable "
+              "publication date, so its coverage end cannot be derived")
         return 2
     built = _build(args)
     print(f"built {built.rows} row(s) into {built.parquet_files} partition(s) "
@@ -181,7 +203,14 @@ def _build(args) -> BuildResult:
 def _cmd_validate(args) -> int:
     directory = Path(args.snapshot)
     coverage_to = date.fromisoformat(args.coverage_to)
-    source_end = _source_end(args)
+    source_end = _iso(args.source_coverage_end)
+    if source_end is not None:
+        print("note: --source-coverage-end was supplied, so the coverage gate "
+              "is comparing two operator-stated dates; build/all derive it from "
+              "the bound release instead")
+    else:
+        source_end = declared_coverage_end(
+            _release_state(args.release_state).get("last_modified"))
     if source_end is None:
         print("refusing to validate: the source release's declared coverage end "
               "is unknown; pass --source-coverage-end or --release-state")
@@ -268,15 +297,16 @@ def _boot_check(dist_dir: Path, cache_dir: Path) -> dict:
 def _cmd_all(args) -> int:
     work = Path(args.work)
     dist = Path(args.dist)
-    source_end = _source_end(args)
-    if source_end is None:
-        print("refusing to build: the source release's declared coverage end is "
-              "unknown; pass --source-coverage-end or --release-state")
-        return 2
 
     receipt = load_receipt_or_none(args)
     if receipt is None:
         return 2
+    source_end = _expected_end(receipt)
+    if source_end is None:
+        print("refusing to build: the bound release carries no usable "
+              "publication date, so its coverage end cannot be derived")
+        return 2
+    print(f"the bound release implies a coverage end of {source_end}")
     print(f"source verified: {Path(args.csv).name} matches its receipt and the "
           f"observed release")
 
@@ -295,12 +325,13 @@ def _cmd_all(args) -> int:
     version = args.version or snapshot_version()
     state = _release_state(args.release_state)
     source = {"file": Path(args.csv).name, "sha256": receipt.sha256,
-              "bytes": receipt.bytes}
+              "bytes": receipt.bytes, "digest_evidence": receipt.evidence}
     source.update({k: state.get(k) for k in
                    ("url", "etag", "last_modified", "content_length")})
 
-    release = package_release(built, dist_dir=dist, version=version,
-                              source=source,
+    release = package_release(built, dist_dir=dist,
+                              candidate_root=work / "candidates",
+                              version=version, source=source,
                               facts={"gates": "passed", **report.facts})
     verify_bundle(release.bundle_path, expected_sha256=release.bundle_sha256,
                   expected_bytes=release.bundle_bytes)
@@ -354,7 +385,6 @@ def build_parser() -> argparse.ArgumentParser:
     build = sub.add_parser("build", help="build the partitions")
     _add_build_arguments(build)
     build.add_argument("--dist")
-    build.add_argument("--source-coverage-end")
     build.add_argument("--release-state", required=True,
                        help="the observed-release state written by check-release")
     build.add_argument("--today")
@@ -368,7 +398,16 @@ def build_parser() -> argparse.ArgumentParser:
     receipt.add_argument("--csv", required=True)
     receipt.add_argument("--release-state", required=True)
     receipt.add_argument("--receipt", required=True)
+    receipt.add_argument("--expected-sha256", required=True,
+                         help="the digest recorded when this file was fetched")
     receipt.set_defaults(handler=_cmd_receipt)
+
+    download = sub.add_parser(
+        "download", help="stream a release and mint its receipt in one pass")
+    download.add_argument("--url", default=DEFAULT_URL)
+    download.add_argument("--dest", required=True)
+    download.add_argument("--receipt", required=True)
+    download.set_defaults(handler=_cmd_download)
 
     validate = sub.add_parser("validate", help="run the gates on a built snapshot")
     validate.add_argument("--snapshot", required=True)
@@ -383,7 +422,6 @@ def build_parser() -> argparse.ArgumentParser:
     every = sub.add_parser("all", help="build, validate, package, verify, boot")
     _add_build_arguments(every)
     every.add_argument("--dist", required=True)
-    every.add_argument("--source-coverage-end")
     every.add_argument("--release-state", required=True,
                        help="the observed-release state written by check-release")
     every.add_argument("--today")

--- a/tools/ppd_snapshot/__main__.py
+++ b/tools/ppd_snapshot/__main__.py
@@ -35,15 +35,23 @@ from tools.ppd_snapshot.build import (
 )
 from tools.ppd_snapshot.package import (
     package_release,
+    promote_release,
     snapshot_version,
     verify_bundle,
 )
 from tools.ppd_snapshot.release_check import (
     DEFAULT_URL,
+    ReleaseObservation,
     check_release,
     declared_coverage_end,
     describe,
     record_ingested,
+)
+from tools.ppd_snapshot.source_receipt import (
+    SourceMismatch,
+    load_receipt,
+    verify_source,
+    write_receipt,
 )
 from tools.ppd_snapshot.validate import DeclaredSnapshot, validate_snapshot
 
@@ -60,6 +68,7 @@ def _declared(built: BuildResult) -> DeclaredSnapshot:
         provisional_from=built.provisional_from,
         rows=built.rows,
         parquet_files=built.parquet_files,
+        eligible_source_rows=built.eligible_source_rows,
     )
 
 
@@ -68,6 +77,29 @@ def _print_report(report) -> None:
         mark = {"pass": "ok  ", "fail": "FAIL", "skipped": "skip"}[gate.status]
         line = f"  [{mark}] {gate.name}"
         print(line if not gate.detail else f"{line} -- {gate.detail}")
+
+
+def _release_state(path: Optional[str]) -> dict:
+    if not path or not Path(path).is_file():
+        return {}
+    try:
+        state = json.loads(Path(path).read_text())
+    except (OSError, ValueError):
+        return {}
+    return state if isinstance(state, dict) else {}
+
+
+def _observed(state: dict) -> Optional[ReleaseObservation]:
+    """The release as most recently observed, or nothing.
+
+    Nothing is a refusal upstream, never a default: a build that cannot say
+    which release is published now cannot claim the file it holds is that one.
+    """
+    if not state:
+        return None
+    return ReleaseObservation(
+        etag=state.get("etag"), last_modified=state.get("last_modified"),
+        content_length=state.get("content_length"))
 
 
 def _source_end(args) -> Optional[date]:
@@ -79,14 +111,8 @@ def _source_end(args) -> Optional[date]:
     explicit = _iso(getattr(args, "source_coverage_end", None))
     if explicit:
         return explicit
-    state_path = getattr(args, "release_state", None)
-    if not state_path or not Path(state_path).is_file():
-        return None
-    try:
-        state = json.loads(Path(state_path).read_text())
-    except (OSError, ValueError):
-        return None
-    return declared_coverage_end(state.get("last_modified"))
+    return declared_coverage_end(
+        _release_state(getattr(args, "release_state", None)).get("last_modified"))
 
 
 # -- commands ----------------------------------------------------------------
@@ -95,6 +121,39 @@ def _cmd_check_release(args) -> int:
     check = check_release(args.url, args.state)
     print(describe(check))
     return 0
+
+
+def _cmd_receipt(args) -> int:
+    observation = _observed(_release_state(args.release_state))
+    if observation is None:
+        print("refusing: no release observation is recorded; run check-release "
+              "first so the file can be bound to a release")
+        return 2
+    try:
+        receipt = write_receipt(Path(args.csv), observation, Path(args.receipt))
+    except SourceMismatch as exc:
+        print(f"refusing to write a receipt: {exc}")
+        return 2
+    print(f"receipt written for {receipt.file}: {receipt.bytes} bytes, "
+          f"sha256 {receipt.sha256}, ETag {receipt.etag}")
+    return 0
+
+
+def load_receipt_or_none(args):
+    """Refuse unless the CSV, its receipt and the observed release agree.
+
+    Every gate after this point checks the snapshot against itself, so an
+    internally consistent snapshot of the wrong file passes all of them. This is
+    the only check that looks at what was read.
+    """
+    try:
+        receipt = load_receipt(args.source_receipt)
+        verify_source(Path(args.csv), receipt,
+                      _observed(_release_state(args.release_state)))
+    except SourceMismatch as exc:
+        print(f"refusing to build: {exc}")
+        return None
+    return receipt
 
 
 def _cmd_build(args) -> int:
@@ -137,6 +196,7 @@ def _cmd_validate(args) -> int:
         provisional_from=provisional_boundary(coverage_to),
         rows=args.rows if args.rows is not None else _count(directory),
         parquet_files=len(list(directory.glob("year=*/data.parquet"))),
+        eligible_source_rows=args.eligible_source_rows,
     )
     report = validate_snapshot(declared, source_coverage_end=source_end,
                                today=_iso(args.today) or date.today())
@@ -210,9 +270,16 @@ def _cmd_all(args) -> int:
               "unknown; pass --source-coverage-end or --release-state")
         return 2
 
+    receipt = load_receipt_or_none(args)
+    if receipt is None:
+        return 2
+    print(f"source verified: {Path(args.csv).name} matches its receipt and the "
+          f"observed release")
+
     built = _build(args)
     print(f"built {built.rows} row(s) into {built.parquet_files} partition(s) "
-          f"at {built.snapshot_dir}")
+          f"at {built.snapshot_dir} ({built.eligible_source_rows} eligible "
+          f"source row(s))")
 
     report = validate_snapshot(_declared(built), source_coverage_end=source_end,
                                today=_iso(args.today) or date.today())
@@ -222,16 +289,11 @@ def _cmd_all(args) -> int:
         return 1
 
     version = args.version or snapshot_version()
-    source = {"file": Path(args.csv).name}
-    if args.release_state and Path(args.release_state).is_file():
-        try:
-            state = json.loads(Path(args.release_state).read_text())
-            source.update({k: state.get(k) for k in
-                           ("url", "etag", "last_modified", "content_length")})
-        except (OSError, ValueError):
-            pass
-    if args.source_sha256:
-        source["sha256"] = args.source_sha256
+    state = _release_state(args.release_state)
+    source = {"file": Path(args.csv).name, "sha256": receipt.sha256,
+              "bytes": receipt.bytes}
+    source.update({k: state.get(k) for k in
+                   ("url", "etag", "last_modified", "content_length")})
 
     release = package_release(built, dist_dir=dist, version=version,
                               source=source,
@@ -239,22 +301,27 @@ def _cmd_all(args) -> int:
     verify_bundle(release.bundle_path, expected_sha256=release.bundle_sha256,
                   expected_bytes=release.bundle_bytes)
     print(f"packaged {release.bundle_path.name} "
-          f"({release.bundle_bytes} bytes, sha256 {release.bundle_sha256})")
+          f"({release.bundle_bytes} bytes, sha256 {release.bundle_sha256}) "
+          f"into {release.candidate_dir.name}")
 
-    outcome = _boot_check(dist, work / "boot-cache")
+    # Booted from the CANDIDATE. Nothing reaches the dist root until this
+    # passes, so a failed boot cannot leave a publishable release behind.
+    outcome = _boot_check(release.candidate_dir, work / "boot-cache")
     print(f"boot check: {outcome['readiness'].upper()} "
           f"({outcome.get('source_error') or 'validated through the adapter'})")
 
-    # The report is rewritten once the boot check has run, so the recorded
-    # evidence covers the whole pipeline rather than stopping at packaging.
     stored = json.loads(release.report_path.read_text())
     stored["boot_check"] = outcome
     release.report_path.write_text(json.dumps(stored, indent=2) + "\n")
 
     if outcome["readiness"] != "ready":
+        print(f"not promoted; the candidate is left at "
+              f"{release.candidate_dir} for diagnosis")
         return 1
-    if args.release_state and Path(args.release_state).is_file():
-        state = json.loads(Path(args.release_state).read_text())
+
+    promoted = promote_release(release)
+    print(f"promoted to {promoted.bundle_path.parent}")
+    if state:
         record_ingested(args.release_state, version=version,
                         etag=state.get("etag"))
     return 0
@@ -287,8 +354,15 @@ def build_parser() -> argparse.ArgumentParser:
     build.add_argument("--release-state")
     build.add_argument("--today")
     build.add_argument("--version")
-    build.add_argument("--source-sha256")
+    build.add_argument("--source-receipt")
     build.set_defaults(handler=_cmd_build)
+
+    receipt = sub.add_parser(
+        "receipt", help="bind a local CSV to the observed release")
+    receipt.add_argument("--csv", required=True)
+    receipt.add_argument("--release-state", required=True)
+    receipt.add_argument("--receipt", required=True)
+    receipt.set_defaults(handler=_cmd_receipt)
 
     validate = sub.add_parser("validate", help="run the gates on a built snapshot")
     validate.add_argument("--snapshot", required=True)
@@ -297,16 +371,19 @@ def build_parser() -> argparse.ArgumentParser:
     validate.add_argument("--release-state")
     validate.add_argument("--today")
     validate.add_argument("--rows", type=int)
+    validate.add_argument("--eligible-source-rows", type=int)
     validate.set_defaults(handler=_cmd_validate)
 
     every = sub.add_parser("all", help="build, validate, package, verify, boot")
     _add_build_arguments(every)
     every.add_argument("--dist", required=True)
     every.add_argument("--source-coverage-end")
-    every.add_argument("--release-state")
+    every.add_argument("--release-state", required=True,
+                       help="the observed-release state written by check-release")
     every.add_argument("--today")
     every.add_argument("--version")
-    every.add_argument("--source-sha256")
+    every.add_argument("--source-receipt", required=True,
+                       help="the receipt binding the CSV to a release")
     every.set_defaults(handler=_cmd_all)
     return parser
 

--- a/tools/ppd_snapshot/__main__.py
+++ b/tools/ppd_snapshot/__main__.py
@@ -157,6 +157,10 @@ def load_receipt_or_none(args):
 
 
 def _cmd_build(args) -> int:
+    # The same binding as `all`: this writes the artifact `validate` then
+    # blesses, so it is not a way around the source check.
+    if load_receipt_or_none(args) is None:
+        return 2
     built = _build(args)
     print(f"built {built.rows} row(s) into {built.parquet_files} partition(s) "
           f"at {built.snapshot_dir}")
@@ -351,10 +355,12 @@ def build_parser() -> argparse.ArgumentParser:
     _add_build_arguments(build)
     build.add_argument("--dist")
     build.add_argument("--source-coverage-end")
-    build.add_argument("--release-state")
+    build.add_argument("--release-state", required=True,
+                       help="the observed-release state written by check-release")
     build.add_argument("--today")
     build.add_argument("--version")
-    build.add_argument("--source-receipt")
+    build.add_argument("--source-receipt", required=True,
+                       help="the receipt binding the CSV to a release")
     build.set_defaults(handler=_cmd_build)
 
     receipt = sub.add_parser(

--- a/tools/ppd_snapshot/__main__.py
+++ b/tools/ppd_snapshot/__main__.py
@@ -1,0 +1,320 @@
+"""Operator entry point for the local snapshot build.
+
+    uv run --extra snapshot python -m tools.ppd_snapshot all \
+        --csv  /path/to/pp-complete.csv \
+        --work /path/to/scratch \
+        --dist /path/to/dist \
+        --coverage-to 2026-06-30
+
+Ordering is the control this command exists to enforce: **validate before
+packaging.** A bundle that exists is a bundle someone can publish, so a snapshot
+that fails a gate must never become one. `all` stops at the first failure and
+leaves the dist directory empty.
+
+**Local only, and deliberately so** (specification section 4.8). `--dist` is a
+directory on this machine. Nothing here uploads, creates a bucket, reads a
+secret or touches a deployed system; artifact distribution is separately
+approved and is not part of this pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Optional, Sequence
+
+from tools.ppd_snapshot.build import (
+    BuildRequest,
+    BuildResult,
+    build_snapshot,
+    coverage_start,
+    provisional_boundary,
+)
+from tools.ppd_snapshot.package import (
+    package_release,
+    snapshot_version,
+    verify_bundle,
+)
+from tools.ppd_snapshot.release_check import (
+    DEFAULT_URL,
+    check_release,
+    declared_coverage_end,
+    describe,
+    record_ingested,
+)
+from tools.ppd_snapshot.validate import DeclaredSnapshot, validate_snapshot
+
+
+def _iso(value: Optional[str]) -> Optional[date]:
+    return date.fromisoformat(value) if value else None
+
+
+def _declared(built: BuildResult) -> DeclaredSnapshot:
+    return DeclaredSnapshot(
+        directory=built.snapshot_dir,
+        coverage_from=built.coverage_from,
+        coverage_to=built.coverage_to,
+        provisional_from=built.provisional_from,
+        rows=built.rows,
+        parquet_files=built.parquet_files,
+    )
+
+
+def _print_report(report) -> None:
+    for gate in report.gates:
+        mark = {"pass": "ok  ", "fail": "FAIL", "skipped": "skip"}[gate.status]
+        line = f"  [{mark}] {gate.name}"
+        print(line if not gate.detail else f"{line} -- {gate.detail}")
+
+
+def _source_end(args) -> Optional[date]:
+    """The release's declared coverage end, from the release record if not given.
+
+    Kept independent of `--coverage-to` on purpose: the two agreeing is the
+    check. Deriving one from the other would make the gate say nothing.
+    """
+    explicit = _iso(getattr(args, "source_coverage_end", None))
+    if explicit:
+        return explicit
+    state_path = getattr(args, "release_state", None)
+    if not state_path or not Path(state_path).is_file():
+        return None
+    try:
+        state = json.loads(Path(state_path).read_text())
+    except (OSError, ValueError):
+        return None
+    return declared_coverage_end(state.get("last_modified"))
+
+
+# -- commands ----------------------------------------------------------------
+
+def _cmd_check_release(args) -> int:
+    check = check_release(args.url, args.state)
+    print(describe(check))
+    return 0
+
+
+def _cmd_build(args) -> int:
+    built = _build(args)
+    print(f"built {built.rows} row(s) into {built.parquet_files} partition(s) "
+          f"at {built.snapshot_dir}")
+    return 0
+
+
+def _build(args) -> BuildResult:
+    work = Path(args.work)
+    return build_snapshot(BuildRequest(
+        csv_path=Path(args.csv),
+        out_dir=work / "snapshot",
+        coverage_to=date.fromisoformat(args.coverage_to),
+        temp_dir=work / "tmp",
+        memory_limit=args.memory,
+    ))
+
+
+def _cmd_validate(args) -> int:
+    directory = Path(args.snapshot)
+    coverage_to = date.fromisoformat(args.coverage_to)
+    source_end = _source_end(args)
+    if source_end is None:
+        print("refusing to validate: the source release's declared coverage end "
+              "is unknown; pass --source-coverage-end or --release-state")
+        return 2
+    if args.rows is None:
+        # Said out loud: with no independently declared count, the rows gate is
+        # comparing the artifact with itself and cannot fail. In the `all` path
+        # the count comes from the build, before a single file was written.
+        print("note: --rows not given, so the row count is read back from the "
+              "artifact and the rows gate cannot fail")
+
+    declared = DeclaredSnapshot(
+        directory=directory,
+        coverage_from=coverage_start(coverage_to),
+        coverage_to=coverage_to,
+        provisional_from=provisional_boundary(coverage_to),
+        rows=args.rows if args.rows is not None else _count(directory),
+        parquet_files=len(list(directory.glob("year=*/data.parquet"))),
+    )
+    report = validate_snapshot(declared, source_coverage_end=source_end,
+                               today=_iso(args.today) or date.today())
+    _print_report(report)
+    return 0 if report.passed else 1
+
+
+def _count(directory: Path) -> int:
+    """Row count read back from the artifact, for a standalone validate run."""
+    import duckdb
+
+    files = sorted(directory.glob("year=*/data.parquet"))
+    if not files:
+        return 0
+    listed = ", ".join("'" + str(p).replace("'", "''") + "'" for p in files)
+    con = duckdb.connect()
+    try:
+        return int(con.execute(
+            f"SELECT count(*) FROM read_parquet([{listed}], "
+            f"union_by_name=true)").fetchone()[0])
+    finally:
+        con.close()
+
+
+def _boot_check(dist_dir: Path, cache_dir: Path) -> dict:
+    """Boot the published bundle through the merged runtime and open it.
+
+    This is the acceptance that matters: the gates above are this pipeline
+    marking its own work, while `SnapshotRuntime` plus `SnapshotAdapter` is the
+    code that has to serve it.
+    """
+    from property_core.snapshot.adapter import SnapshotAdapter
+    from property_core.snapshot.runtime import SnapshotRuntime
+    from property_core.snapshot.source import LocalDirectorySource
+    from property_core.snapshot.store import SnapshotStore
+
+    store = SnapshotStore(cache_dir)
+    runtime = SnapshotRuntime(source=LocalDirectorySource(dist_dir), store=store)
+    report = runtime.boot()
+    outcome = {
+        "readiness": report.readiness.value,
+        "version": report.version,
+        "activated": report.activated,
+        "bytes_downloaded": report.bytes_downloaded,
+        "source_error": report.source_error,
+        "timings_ms": report.timings_ms,
+    }
+    if not report.ready:
+        return outcome
+
+    record = store.verified_record(report.version)
+    with SnapshotAdapter.open(Path(report.snapshot_dir), record) as adapter:
+        outcome["adapter"] = {
+            "coverage_from": adapter.coverage_from,
+            "coverage_to": adapter.coverage_to,
+            "provisional_from": adapter.provisional_from,
+            "validated": True,
+        }
+    outcome["extracted_bytes"] = sum(
+        p.stat().st_size for p in Path(report.snapshot_dir).rglob("*")
+        if p.is_file())
+    return outcome
+
+
+def _cmd_all(args) -> int:
+    work = Path(args.work)
+    dist = Path(args.dist)
+    source_end = _source_end(args)
+    if source_end is None:
+        print("refusing to build: the source release's declared coverage end is "
+              "unknown; pass --source-coverage-end or --release-state")
+        return 2
+
+    built = _build(args)
+    print(f"built {built.rows} row(s) into {built.parquet_files} partition(s) "
+          f"at {built.snapshot_dir}")
+
+    report = validate_snapshot(_declared(built), source_coverage_end=source_end,
+                               today=_iso(args.today) or date.today())
+    _print_report(report)
+    if not report.passed:
+        print("validation failed; nothing was packaged")
+        return 1
+
+    version = args.version or snapshot_version()
+    source = {"file": Path(args.csv).name}
+    if args.release_state and Path(args.release_state).is_file():
+        try:
+            state = json.loads(Path(args.release_state).read_text())
+            source.update({k: state.get(k) for k in
+                           ("url", "etag", "last_modified", "content_length")})
+        except (OSError, ValueError):
+            pass
+    if args.source_sha256:
+        source["sha256"] = args.source_sha256
+
+    release = package_release(built, dist_dir=dist, version=version,
+                              source=source,
+                              facts={"gates": "passed", **report.facts})
+    verify_bundle(release.bundle_path, expected_sha256=release.bundle_sha256,
+                  expected_bytes=release.bundle_bytes)
+    print(f"packaged {release.bundle_path.name} "
+          f"({release.bundle_bytes} bytes, sha256 {release.bundle_sha256})")
+
+    outcome = _boot_check(dist, work / "boot-cache")
+    print(f"boot check: {outcome['readiness'].upper()} "
+          f"({outcome.get('source_error') or 'validated through the adapter'})")
+
+    # The report is rewritten once the boot check has run, so the recorded
+    # evidence covers the whole pipeline rather than stopping at packaging.
+    stored = json.loads(release.report_path.read_text())
+    stored["boot_check"] = outcome
+    release.report_path.write_text(json.dumps(stored, indent=2) + "\n")
+
+    if outcome["readiness"] != "ready":
+        return 1
+    if args.release_state and Path(args.release_state).is_file():
+        state = json.loads(Path(args.release_state).read_text())
+        record_ingested(args.release_state, version=version,
+                        etag=state.get("etag"))
+    return 0
+
+
+# -- wiring ------------------------------------------------------------------
+
+def _add_build_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--csv", required=True, help="source pp-complete.csv")
+    parser.add_argument("--work", required=True, help="scratch directory")
+    parser.add_argument("--coverage-to", required=True,
+                        help="the source release's coverage end (YYYY-MM-DD)")
+    parser.add_argument("--memory", default="4GB", help="DuckDB memory limit")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m tools.ppd_snapshot",
+                                     description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    check = sub.add_parser("check-release", help="HEAD the source; download nothing")
+    check.add_argument("--url", default=DEFAULT_URL)
+    check.add_argument("--state", required=True)
+    check.set_defaults(handler=_cmd_check_release)
+
+    build = sub.add_parser("build", help="build the partitions")
+    _add_build_arguments(build)
+    build.add_argument("--dist")
+    build.add_argument("--source-coverage-end")
+    build.add_argument("--release-state")
+    build.add_argument("--today")
+    build.add_argument("--version")
+    build.add_argument("--source-sha256")
+    build.set_defaults(handler=_cmd_build)
+
+    validate = sub.add_parser("validate", help="run the gates on a built snapshot")
+    validate.add_argument("--snapshot", required=True)
+    validate.add_argument("--coverage-to", required=True)
+    validate.add_argument("--source-coverage-end")
+    validate.add_argument("--release-state")
+    validate.add_argument("--today")
+    validate.add_argument("--rows", type=int)
+    validate.set_defaults(handler=_cmd_validate)
+
+    every = sub.add_parser("all", help="build, validate, package, verify, boot")
+    _add_build_arguments(every)
+    every.add_argument("--dist", required=True)
+    every.add_argument("--source-coverage-end")
+    every.add_argument("--release-state")
+    every.add_argument("--today")
+    every.add_argument("--version")
+    every.add_argument("--source-sha256")
+    every.set_defaults(handler=_cmd_all)
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/ppd_snapshot/atomic.py
+++ b/tools/ppd_snapshot/atomic.py
@@ -16,11 +16,15 @@ from pathlib import Path
 from typing import Any
 
 
-def atomic_write_text(path: Path | str, text: str) -> None:
-    """Replace `path` with `text`, or leave `path` exactly as it was.
+def prepare_write_text(path: Path | str, text: str) -> Path:
+    """Write `text` to a sibling temporary file and return it, unpublished.
+
+    Split from the rename so a caller replacing SEVERAL files can get all the
+    writing -- the part that runs out of disk -- done before any of the renames.
+    Nothing the caller had is touched until it commits.
 
     The temporary file is a sibling so the rename stays within one filesystem
-    (`os.replace` cannot cross devices), and it is uniquely named so two writers
+    (`os.replace` cannot cross devices), and uniquely named so two writers
     cannot collide on it.
     """
     path = Path(path)
@@ -29,14 +33,39 @@ def atomic_write_text(path: Path | str, text: str) -> None:
                                         prefix=f".{path.name}.", suffix=".tmp")
     tmp = Path(tmp_name)
     try:
+        # fdopen immediately: until a file object owns the descriptor, nothing
+        # closes it on an error path.
         with os.fdopen(handle, "w") as fh:
             fh.write(text)
             fh.flush()
             os.fsync(fh.fileno())
-        os.replace(tmp, path)
     except BaseException:
+        try:
+            os.close(handle)
+        except OSError:
+            pass
         tmp.unlink(missing_ok=True)
         raise
+    return tmp
+
+
+def commit_prepared(tmp: Path | str, path: Path | str) -> None:
+    """Rename a prepared file over its target."""
+    os.replace(tmp, path)
+
+
+def atomic_write_text(path: Path | str, text: str) -> None:
+    """Replace `path` with `text`, or leave `path` exactly as it was."""
+    tmp = prepare_write_text(path, text)
+    try:
+        commit_prepared(tmp, path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def prepare_write_json(path: Path | str, payload: Any) -> Path:
+    return prepare_write_text(path, json.dumps(payload, indent=2) + "\n")
 
 
 def atomic_write_json(path: Path | str, payload: Any) -> None:

--- a/tools/ppd_snapshot/atomic.py
+++ b/tools/ppd_snapshot/atomic.py
@@ -1,0 +1,43 @@
+"""Write a file without destroying the one already there.
+
+`write_text` truncates before it writes. Interrupted, it leaves an empty or
+half-written file where a valid one used to be -- which for a published pointer
+or a source receipt is worse than never having tried, because it takes down what
+was already working. Every write in this package that replaces an existing
+document goes through here: write a unique sibling, then rename over the target.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_text(path: Path | str, text: str) -> None:
+    """Replace `path` with `text`, or leave `path` exactly as it was.
+
+    The temporary file is a sibling so the rename stays within one filesystem
+    (`os.replace` cannot cross devices), and it is uniquely named so two writers
+    cannot collide on it.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle, tmp_name = tempfile.mkstemp(dir=path.parent,
+                                        prefix=f".{path.name}.", suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(handle, "w") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def atomic_write_json(path: Path | str, payload: Any) -> None:
+    atomic_write_text(path, json.dumps(payload, indent=2) + "\n")

--- a/tools/ppd_snapshot/build.py
+++ b/tools/ppd_snapshot/build.py
@@ -1,0 +1,252 @@
+"""`pp-complete.csv` -> eleven year-only Parquet partitions.
+
+Layout and window are fixed by the governing specification:
+
+* **Eleven calendar-year partitions** (section 1.1). Ten would silently
+  under-serve a legal 120-month request for most of the year, because
+  `PPDService.comps` measures its window from today rather than from a year
+  boundary.
+* **Year only, one file per year** (section 1.2). The adapter filters on
+  `postcode`/`sector`/`outcode` and never on `area`, so a year+area layout
+  charges thousands of files of Parquet metadata and prunes nothing.
+* **`provisional_from` is recorded, never inferred at query time** (section 1.3).
+
+Two things are derived here and stored as materialized columns rather than
+computed per query:
+
+* `outcode` / `sector`, which is what makes membership an equality test in the
+  adapter and puts the `B5`-matching-`B50` class of bug out of reach; and
+* `year`, which the adapter relies on being a real column -- it opens the
+  partitions with `hive_partitioning=false` precisely so a synthesised
+  directory-name column cannot collide with this one.
+
+`transaction_id` is stored **without** the source's surrounding braces, so one
+id means the same thing on every source: the bulk CSV wraps ids in `{...}`,
+while the Linked Data and SPARQL paths do not. The adapter strips them too, and
+that stays as a defensive no-op for snapshots built elsewhere.
+"""
+
+from __future__ import annotations
+
+import resource
+import time
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+
+#: Section 1.1. Not a tunable: ten partitions cannot serve a 120-month request
+#: made in December, and twelve buys coverage nothing asks for.
+PARTITION_YEARS = 11
+
+#: Section 1.3. HMLR revises recent months after first publication, so the tail
+#: of the window is declared provisional in the manifest.
+PROVISIONAL_MONTHS = 3
+
+#: The largest window any surface may request, from `app/api/v1/ppd.py`'s
+#: `months le=120` ceiling, expressed the way `PPDService.comps` computes it:
+#: `date.today() - timedelta(days=months * 30)`.
+MAX_REQUEST_DAYS = 120 * 30
+
+COMPRESSION = "zstd"
+ROW_GROUP_SIZE = 122_880
+
+#: The published column order of the source feed. Headerless, sixteen columns.
+SOURCE_COLUMNS: tuple[str, ...] = (
+    "transaction_id", "price", "transfer_date", "postcode", "property_type",
+    "new_build", "duration", "paon", "saon", "street", "locality", "town",
+    "district", "county", "ppd_category", "record_status",
+)
+
+#: One file per partition. The name is part of the bundle contract: the runtime
+#: counts `*.parquet` and the adapter globs for them.
+PARTITION_FILE = "data.parquet"
+
+
+def expected_years(coverage_to: date) -> tuple[int, ...]:
+    """The exact set of calendar years a snapshot for this release must hold."""
+    return tuple(range(coverage_to.year - PARTITION_YEARS + 1, coverage_to.year + 1))
+
+
+def coverage_start(coverage_to: date) -> date:
+    """The declared window start: 1 January of the earliest partition year.
+
+    A partition boundary, not the earliest transaction that happens to be in the
+    data. Coverage is a statement about what the snapshot was built to hold.
+    """
+    return date(coverage_to.year - PARTITION_YEARS + 1, 1, 1)
+
+
+def provisional_boundary(coverage_to: date,
+                         months: int = PROVISIONAL_MONTHS) -> date:
+    """First day of the month `months` before the month of `coverage_to`."""
+    if months < 0:
+        raise ValueError("months must not be negative")
+    index = coverage_to.year * 12 + (coverage_to.month - 1) - months
+    return date(index // 12, index % 12 + 1, 1)
+
+
+def covers_maximum_request(coverage_from: date, today: date) -> bool:
+    """Whether the window still serves the largest request a surface permits."""
+    return (today - coverage_from).days >= MAX_REQUEST_DAYS
+
+
+@dataclass(frozen=True)
+class BuildRequest:
+    """Everything the build needs, stated rather than discovered.
+
+    `coverage_to` is an **input**, not a measurement: it is the source release's
+    declared coverage end, taken from the release the CSV came from. Deriving it
+    from `max(transfer_date)` would let a truncated download declare a window it
+    has data for, which is exactly the claim coverage must not be able to make.
+    """
+
+    csv_path: Path
+    out_dir: Path
+    coverage_to: date
+    temp_dir: Path
+    memory_limit: str = "4GB"
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    snapshot_dir: Path
+    coverage_from: date
+    coverage_to: date
+    provisional_from: date
+    years: tuple[int, ...]
+    parquet_files: int
+    rows: int
+    source_rows: int
+    rows_outside_window: int
+    rows_without_date: int
+    duckdb_version: str
+    #: Peak resident memory of the build process, in MB. Recorded so a future
+    #: build on a smaller machine can be sized rather than guessed at.
+    peak_rss_mb: float = 0.0
+    timings_seconds: dict[str, float] = field(default_factory=dict)
+
+
+def _sql_literal(path: Path | str) -> str:
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+def _clear_database(db_path: Path) -> None:
+    for suffix in ("", ".wal", ".tmp"):
+        candidate = Path(str(db_path) + suffix)
+        if candidate.is_file():
+            candidate.unlink()
+
+
+_DERIVE = """
+CREATE OR REPLACE TABLE ppd AS
+SELECT
+  trim(transaction_id, '{{}} ')                   AS transaction_id,
+  TRY_CAST(price AS BIGINT)                       AS price,
+  TRY_CAST(transfer_date AS TIMESTAMP)::DATE      AS transfer_date,
+  nullif(trim(postcode), '')                      AS postcode,
+  CASE WHEN nullif(trim(postcode), '') IS NULL THEN NULL
+       ELSE split_part(trim(postcode), ' ', 1) END AS outcode,
+  CASE WHEN nullif(trim(postcode), '') IS NULL
+         OR split_part(trim(postcode), ' ', 2) = '' THEN NULL
+       ELSE split_part(trim(postcode), ' ', 1) || ' '
+            || substr(split_part(trim(postcode), ' ', 2), 1, 1)
+  END                                             AS sector,
+  property_type,
+  new_build = 'Y'                                 AS new_build,
+  duration, paon, saon, street, locality, town, district, county, ppd_category,
+  CAST(EXTRACT(year FROM TRY_CAST(transfer_date AS TIMESTAMP)) AS INTEGER) AS year
+FROM staged
+WHERE TRY_CAST(transfer_date AS TIMESTAMP)::DATE BETWEEN DATE {coverage_from}
+                                                     AND DATE {coverage_to}
+"""
+
+
+def build_snapshot(request: BuildRequest) -> BuildResult:
+    """Build the partitions and report what was written. Validation is separate.
+
+    This function does not judge its own output: `validate.py` runs the gates,
+    and the merged runtime is the final arbiter. Keeping the two apart is what
+    lets a gate fail on an artifact this code was perfectly happy with.
+    """
+    import duckdb
+
+    coverage_from = coverage_start(request.coverage_to)
+    provisional_from = provisional_boundary(request.coverage_to)
+    years = expected_years(request.coverage_to)
+
+    temp_dir = Path(request.temp_dir)
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_dir = Path(request.out_dir)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    db_path = temp_dir / "build.duckdb"
+    _clear_database(db_path)
+
+    timings: dict[str, float] = {}
+    con = duckdb.connect(str(db_path))
+    try:
+        con.execute(f"SET temp_directory={_sql_literal(temp_dir)}")
+        con.execute(f"SET memory_limit='{request.memory_limit}'")
+        duckdb_version = con.execute("SELECT version()").fetchone()[0]
+
+        started = time.perf_counter()
+        columns = ", ".join(f"'{name}': 'VARCHAR'" for name in SOURCE_COLUMNS)
+        con.execute(
+            f"CREATE OR REPLACE TABLE staged AS SELECT * FROM read_csv("
+            f"{_sql_literal(request.csv_path)}, header=false, "
+            f"columns={{{columns}}}, ignore_errors=false)"
+        )
+        source_rows = con.execute("SELECT count(*) FROM staged").fetchone()[0]
+        timings["ingest"] = time.perf_counter() - started
+
+        started = time.perf_counter()
+        con.execute(_DERIVE.format(
+            coverage_from=_sql_literal(coverage_from.isoformat()),
+            coverage_to=_sql_literal(request.coverage_to.isoformat()),
+        ))
+        rows = con.execute("SELECT count(*) FROM ppd").fetchone()[0]
+        # Accounted for explicitly rather than left as a silent difference: a
+        # row the window excluded and a row with no parseable date are different
+        # facts, and only one of them is expected.
+        without_date = con.execute(
+            "SELECT count(*) FROM staged "
+            "WHERE TRY_CAST(transfer_date AS TIMESTAMP) IS NULL").fetchone()[0]
+        timings["derive"] = time.perf_counter() - started
+
+        started = time.perf_counter()
+        for year in years:
+            partition = snapshot_dir / f"year={year}"
+            partition.mkdir(parents=True, exist_ok=True)
+            # Written a year at a time, ORDER BY inside the COPY: the ordering is
+            # part of the artifact, asserted by the ordering gate rather than
+            # assumed. `preserve_insertion_order` is deliberately left at its
+            # default -- turning it off lets the writer emit rows in any order,
+            # which would quietly make the declared sort order a fiction.
+            con.execute(
+                f"COPY (SELECT * FROM ppd WHERE year = {year} "
+                f"      ORDER BY transfer_date DESC, transaction_id ASC) "
+                f"TO {_sql_literal(partition / PARTITION_FILE)} "
+                f"(FORMAT parquet, COMPRESSION '{COMPRESSION}', "
+                f" ROW_GROUP_SIZE {ROW_GROUP_SIZE})"
+            )
+        timings["write"] = time.perf_counter() - started
+    finally:
+        con.close()
+        _clear_database(db_path)
+
+    return BuildResult(
+        snapshot_dir=snapshot_dir,
+        coverage_from=coverage_from,
+        coverage_to=request.coverage_to,
+        provisional_from=provisional_from,
+        years=years,
+        parquet_files=sum(1 for _ in snapshot_dir.rglob("*.parquet")),
+        rows=int(rows),
+        source_rows=int(source_rows),
+        rows_outside_window=int(source_rows) - int(rows) - int(without_date),
+        rows_without_date=int(without_date),
+        duckdb_version=str(duckdb_version),
+        peak_rss_mb=round(
+            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0, 1),
+        timings_seconds={k: round(v, 3) for k, v in timings.items()},
+    )

--- a/tools/ppd_snapshot/build.py
+++ b/tools/ppd_snapshot/build.py
@@ -90,6 +90,16 @@ def covers_maximum_request(coverage_from: date, today: date) -> bool:
     return (today - coverage_from).days >= MAX_REQUEST_DAYS
 
 
+class MalformedSourceRows(RuntimeError):
+    """The source holds rows the snapshot cannot honestly represent.
+
+    `TRY_CAST` makes silence the default: an unparseable price becomes NULL and
+    the row is published as a sale with no price, while an unparseable date
+    cannot be placed in a partition at all and would simply vanish. Neither is a
+    judgement this pipeline gets to make quietly, so both stop the build.
+    """
+
+
 @dataclass(frozen=True)
 class BuildRequest:
     """Everything the build needs, stated rather than discovered.
@@ -116,6 +126,10 @@ class BuildResult:
     years: tuple[int, ...]
     parquet_files: int
     rows: int
+    #: Rows the SOURCE holds for this window, counted from the staged source
+    #: table with its own predicate -- independent of the derivation and of the
+    #: write, so a row lost between them is visible.
+    eligible_source_rows: int
     source_rows: int
     rows_outside_window: int
     rows_without_date: int
@@ -158,7 +172,56 @@ SELECT
 FROM staged
 WHERE TRY_CAST(transfer_date AS TIMESTAMP)::DATE BETWEEN DATE {coverage_from}
                                                      AND DATE {coverage_to}
+  AND TRY_CAST(price AS BIGINT) IS NOT NULL
+  AND trim(coalesce(transaction_id, ''), '{{}} ') <> ''
 """
+
+#: Counted from the staged source rows, deliberately written out separately from
+#: the derivation above rather than sharing a predicate with it.
+_ELIGIBLE = """
+SELECT count(*) FROM staged
+WHERE TRY_CAST(transfer_date AS TIMESTAMP)::DATE >= DATE {coverage_from}
+  AND TRY_CAST(transfer_date AS TIMESTAMP)::DATE <= DATE {coverage_to}
+  AND TRY_CAST(price AS BIGINT) IS NOT NULL
+  AND length(trim(coalesce(transaction_id, ''), '{{}} ')) > 0
+"""
+
+
+def _refuse_malformed(con, coverage_from: date, coverage_to: date) -> None:
+    """Stop the build on any source row the snapshot cannot represent honestly.
+
+    The date check is deliberately over the WHOLE source rather than the window:
+    a row whose date does not parse cannot be shown to be outside the window, so
+    excluding it would be deciding that it is. Price and id are checked only
+    inside the window, because rows the snapshot never serves are not its
+    problem.
+    """
+    undated = int(con.execute(
+        "SELECT count(*) FROM staged "
+        "WHERE TRY_CAST(transfer_date AS TIMESTAMP) IS NULL").fetchone()[0])
+    if undated:
+        raise MalformedSourceRows(
+            f"{undated} source row(s) have an unparseable transfer_date; they "
+            f"cannot be placed in or excluded from the window, so the build "
+            f"stops rather than deciding silently")
+
+    window = (f"WHERE TRY_CAST(transfer_date AS TIMESTAMP)::DATE "
+              f"      BETWEEN DATE {_sql_literal(coverage_from.isoformat())} "
+              f"          AND DATE {_sql_literal(coverage_to.isoformat())}")
+    bad_price, bad_id = con.execute(
+        f"SELECT count(*) FILTER (WHERE TRY_CAST(price AS BIGINT) IS NULL), "
+        f"       count(*) FILTER (WHERE length(trim(coalesce(transaction_id, ''), "
+        f"                                          '{{}} ')) = 0) "
+        f"FROM staged {window}").fetchone()
+    problems = []
+    if int(bad_price):
+        problems.append(f"{int(bad_price)} row(s) have an unparseable price")
+    if int(bad_id):
+        problems.append(f"{int(bad_id)} row(s) have no transaction_id")
+    if problems:
+        raise MalformedSourceRows(
+            "; ".join(problems) + " inside the declared window; a required "
+            "value cannot be published as NULL")
 
 
 def build_snapshot(request: BuildRequest) -> BuildResult:
@@ -200,14 +263,19 @@ def build_snapshot(request: BuildRequest) -> BuildResult:
         timings["ingest"] = time.perf_counter() - started
 
         started = time.perf_counter()
+        _refuse_malformed(con, coverage_from, request.coverage_to)
+        eligible = int(con.execute(_ELIGIBLE.format(
+            coverage_from=_sql_literal(coverage_from.isoformat()),
+            coverage_to=_sql_literal(request.coverage_to.isoformat()),
+        )).fetchone()[0])
         con.execute(_DERIVE.format(
             coverage_from=_sql_literal(coverage_from.isoformat()),
             coverage_to=_sql_literal(request.coverage_to.isoformat()),
         ))
         rows = con.execute("SELECT count(*) FROM ppd").fetchone()[0]
-        # Accounted for explicitly rather than left as a silent difference: a
-        # row the window excluded and a row with no parseable date are different
-        # facts, and only one of them is expected.
+        # Zero by construction now -- `_refuse_malformed` has already stopped a
+        # build with any unplaceable row. Kept as a recorded fact rather than an
+        # assumption.
         without_date = con.execute(
             "SELECT count(*) FROM staged "
             "WHERE TRY_CAST(transfer_date AS TIMESTAMP) IS NULL").fetchone()[0]
@@ -242,6 +310,7 @@ def build_snapshot(request: BuildRequest) -> BuildResult:
         years=years,
         parquet_files=sum(1 for _ in snapshot_dir.rglob("*.parquet")),
         rows=int(rows),
+        eligible_source_rows=eligible,
         source_rows=int(source_rows),
         rows_outside_window=int(source_rows) - int(rows) - int(without_date),
         rows_without_date=int(without_date),

--- a/tools/ppd_snapshot/build.py
+++ b/tools/ppd_snapshot/build.py
@@ -57,6 +57,17 @@ SOURCE_COLUMNS: tuple[str, ...] = (
     "district", "county", "ppd_category", "record_status",
 )
 
+#: A price is an integer number of pounds, written as digits and nothing else.
+#:
+#: `TRY_CAST` is not that test. It accepts and silently *changes* far more than
+#: an integer: "1.5" becomes 2, "2.5" becomes 3, ".5" becomes 1, "1e3" becomes
+#: 1000, "0x10" becomes 16 and "1_000" becomes 1000. Each of those lands in the
+#: snapshot as a plausible integer, so no gate reading the artifact can tell
+#: anything went wrong. Signed forms are rejected too: a negative or explicitly
+#: positive price is not a shape this feed uses, and guessing at intent is how
+#: the rounding got in.
+CANONICAL_PRICE = "^[0-9]+$"
+
 #: One file per partition. The name is part of the bundle contract: the runtime
 #: counts `*.parquet` and the adapter globs for them.
 PARTITION_FILE = "data.parquet"
@@ -172,7 +183,7 @@ SELECT
 FROM staged
 WHERE TRY_CAST(transfer_date AS TIMESTAMP)::DATE BETWEEN DATE {coverage_from}
                                                      AND DATE {coverage_to}
-  AND TRY_CAST(price AS BIGINT) IS NOT NULL
+  AND regexp_full_match(trim(coalesce(price, '')), '{price}')
   AND trim(coalesce(transaction_id, ''), '{{}} ') <> ''
 """
 
@@ -182,7 +193,7 @@ _ELIGIBLE = """
 SELECT count(*) FROM staged
 WHERE TRY_CAST(transfer_date AS TIMESTAMP)::DATE >= DATE {coverage_from}
   AND TRY_CAST(transfer_date AS TIMESTAMP)::DATE <= DATE {coverage_to}
-  AND TRY_CAST(price AS BIGINT) IS NOT NULL
+  AND regexp_full_match(trim(coalesce(price, '')), '{price}')
   AND length(trim(coalesce(transaction_id, ''), '{{}} ')) > 0
 """
 
@@ -209,19 +220,22 @@ def _refuse_malformed(con, coverage_from: date, coverage_to: date) -> None:
               f"      BETWEEN DATE {_sql_literal(coverage_from.isoformat())} "
               f"          AND DATE {_sql_literal(coverage_to.isoformat())}")
     bad_price, bad_id = con.execute(
-        f"SELECT count(*) FILTER (WHERE TRY_CAST(price AS BIGINT) IS NULL), "
+        f"SELECT count(*) FILTER (WHERE NOT regexp_full_match("
+        f"           trim(coalesce(price, '')), '{CANONICAL_PRICE}')), "
         f"       count(*) FILTER (WHERE length(trim(coalesce(transaction_id, ''), "
         f"                                          '{{}} ')) = 0) "
         f"FROM staged {window}").fetchone()
     problems = []
     if int(bad_price):
-        problems.append(f"{int(bad_price)} row(s) have an unparseable price")
+        problems.append(f"{int(bad_price)} row(s) have a price that is not a "
+                        f"canonical integer")
     if int(bad_id):
         problems.append(f"{int(bad_id)} row(s) have no transaction_id")
     if problems:
         raise MalformedSourceRows(
             "; ".join(problems) + " inside the declared window; a required "
-            "value cannot be published as NULL")
+            "value cannot be published as NULL, and a price that is not "
+            "written as digits would be silently rounded or reinterpreted")
 
 
 def build_snapshot(request: BuildRequest) -> BuildResult:
@@ -267,10 +281,12 @@ def build_snapshot(request: BuildRequest) -> BuildResult:
         eligible = int(con.execute(_ELIGIBLE.format(
             coverage_from=_sql_literal(coverage_from.isoformat()),
             coverage_to=_sql_literal(request.coverage_to.isoformat()),
+            price=CANONICAL_PRICE,
         )).fetchone()[0])
         con.execute(_DERIVE.format(
             coverage_from=_sql_literal(coverage_from.isoformat()),
             coverage_to=_sql_literal(request.coverage_to.isoformat()),
+            price=CANONICAL_PRICE,
         ))
         rows = con.execute("SELECT count(*) FROM ppd").fetchone()[0]
         # Zero by construction now -- `_refuse_malformed` has already stopped a

--- a/tools/ppd_snapshot/package.py
+++ b/tools/ppd_snapshot/package.py
@@ -1,0 +1,223 @@
+"""Bundle the partitions and publish the manifest the runtime will read.
+
+Two documents come out of this, and keeping them apart is the point:
+
+* **`manifest-<version>.json`** -- exactly the eleven fields
+  `property_core.snapshot.models.SnapshotManifest` declares, no more. That model
+  is frozen and `extra="forbid"`, so a manifest carrying the build's own
+  provenance does not degrade gracefully: it fails to parse at boot and the
+  Machine falls back to the live source. The prototype's richer manifest
+  (`source_sha256`, `compression`, `row_group_size`, `logical_sort_order`) is
+  exactly that shape and is not portable.
+* **`build-report-<version>.json`** -- everything else worth keeping: source
+  provenance, timings, per-year row counts, measured sizes. Nothing reads it at
+  runtime; it exists so a build can be explained afterwards.
+
+**Local only.** This writes files into a directory on this machine. There is no
+upload, no bucket, no credential, and `current.json` is published beside the
+manifest purely so the whole boot path can be exercised offline through
+`LocalDirectorySource`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tarfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from property_core.snapshot.models import SnapshotManifest, validate_component
+
+from tools.ppd_snapshot.build import COMPRESSION, PARTITION_FILE, BuildResult
+
+#: Read in fixed chunks so a full-history bundle is never held in memory --
+#: the same discipline the boot fetch applies on the way in.
+CHUNK_BYTES = 1024 * 1024
+
+#: zstd level. 10 is the knee of the curve for already-zstd-compressed Parquet:
+#: higher levels cost minutes and save single-digit MiB.
+ZSTD_LEVEL = 10
+
+LAYOUT = "year"
+
+
+class BundleMismatch(RuntimeError):
+    """The bundle on disk is not what the manifest says it is."""
+
+
+class VersionAlreadyPublished(RuntimeError):
+    """A published version names one set of bytes, for ever.
+
+    The store refuses to materialise a second bundle under a version it already
+    holds, so publishing over one here would create an artifact the runtime can
+    never install. Republishing requires a new version.
+    """
+
+
+@dataclass(frozen=True)
+class PackagedRelease:
+    version: str
+    dist_dir: Path
+    bundle_path: Path
+    manifest_path: Path
+    current_path: Path
+    report_path: Path
+    bundle_bytes: int
+    bundle_sha256: str
+    parquet_files: int
+    rows: int
+
+
+def snapshot_version(built_at: Optional[datetime] = None) -> str:
+    """A version name from the build instant, in UTC.
+
+    Sortable, unambiguous, and a single safe path component -- the store turns
+    it straight into a directory name.
+    """
+    stamp = built_at or datetime.now(timezone.utc)
+    if stamp.tzinfo is None:
+        raise ValueError("built_at must be timezone-aware")
+    return "v" + stamp.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _normalise(info: tarfile.TarInfo) -> tarfile.TarInfo:
+    """Strip everything that is about this machine rather than the data.
+
+    Ownership, names and timestamps vary between builds of identical content and
+    would otherwise make two byte-identical snapshots produce different bundles.
+    """
+    info.uid = info.gid = 0
+    info.uname = info.gname = ""
+    info.mtime = 0
+    info.mode = 0o644
+    return info
+
+
+def _partition_members(snapshot_dir: Path) -> list[tuple[Path, str]]:
+    members = []
+    for path in sorted(snapshot_dir.glob(f"year=*/{PARTITION_FILE}")):
+        members.append((path, path.relative_to(snapshot_dir).as_posix()))
+    if not members:
+        raise ValueError(f"no partitions found under {snapshot_dir}")
+    return members
+
+
+def write_bundle(snapshot_dir: Path, bundle_path: Path) -> tuple[int, str]:
+    """Write the `.tar.zst` and return its length and digest.
+
+    The digest is computed by reading the finished file back, not from the bytes
+    on the way out: what the runtime verifies is what landed on disk.
+    """
+    import zstandard
+
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    compressor = zstandard.ZstdCompressor(level=ZSTD_LEVEL)
+    with open(bundle_path, "wb") as raw:
+        with compressor.stream_writer(raw) as stream:
+            # A stream mode ("w|"), so nothing seeks back over the archive.
+            with tarfile.open(fileobj=stream, mode="w|") as tar:
+                for path, arcname in _partition_members(snapshot_dir):
+                    tar.add(path, arcname=arcname, filter=_normalise)
+    return _measure(bundle_path)
+
+
+def _measure(path: Path) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    length = 0
+    with open(path, "rb") as fh:
+        while chunk := fh.read(CHUNK_BYTES):
+            digest.update(chunk)
+            length += len(chunk)
+    return length, digest.hexdigest()
+
+
+def verify_bundle(bundle_path: Path, *, expected_sha256: str,
+                  expected_bytes: int) -> None:
+    """Re-verify a published bundle exactly as the runtime will."""
+    length, digest = _measure(Path(bundle_path))
+    if length != expected_bytes:
+        raise BundleMismatch(
+            f"{bundle_path.name} is {length} bytes, manifest declares "
+            f"{expected_bytes}")
+    if digest != expected_sha256:
+        raise BundleMismatch(
+            f"{bundle_path.name} sha256 is {digest}, manifest declares "
+            f"{expected_sha256}")
+
+
+def package_release(built: BuildResult, *, dist_dir: Path, version: str,
+                    source: Mapping[str, Any],
+                    facts: Mapping[str, Any]) -> PackagedRelease:
+    """Bundle, publish the manifest, and record the build report."""
+    validate_component(version, "snapshot_version")
+    dist_dir = Path(dist_dir)
+    dist_dir.mkdir(parents=True, exist_ok=True)
+
+    bundle_path = dist_dir / f"snapshot-{version}.tar.zst"
+    manifest_path = dist_dir / f"manifest-{version}.json"
+    report_path = dist_dir / f"build-report-{version}.json"
+    for existing in (bundle_path, manifest_path):
+        if existing.exists():
+            raise VersionAlreadyPublished(
+                f"{existing.name} already exists; a changed snapshot requires a "
+                f"new version, never a rewritten one")
+
+    bundle_bytes, bundle_sha256 = write_bundle(built.snapshot_dir, bundle_path)
+
+    # Constructed through the runtime's own model, so an unpublishable manifest
+    # fails here rather than at someone else's boot.
+    manifest = SnapshotManifest(
+        snapshot_version=version,
+        bundle_object=bundle_path.name,
+        bundle_sha256=bundle_sha256,
+        bundle_bytes=bundle_bytes,
+        parquet_files=built.parquet_files,
+        rows=built.rows,
+        coverage_from=built.coverage_from.isoformat(),
+        coverage_to=built.coverage_to.isoformat(),
+        provisional_from=built.provisional_from.isoformat(),
+        layout=LAYOUT,
+        duckdb_version=built.duckdb_version,
+    )
+    manifest_path.write_text(json.dumps(manifest.model_dump(), indent=2) + "\n")
+
+    current_path = dist_dir / "current.json"
+    current_path.write_text(
+        json.dumps({"current_manifest": manifest_path.name}, indent=2) + "\n")
+
+    report = {
+        "snapshot_version": version,
+        "built_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source": dict(source),
+        "layout": LAYOUT,
+        "compression": COMPRESSION,
+        "logical_sort_order": "transfer_date DESC, transaction_id ASC",
+        "duckdb_version": built.duckdb_version,
+        "coverage_from": built.coverage_from.isoformat(),
+        "coverage_to": built.coverage_to.isoformat(),
+        "provisional_from": built.provisional_from.isoformat(),
+        "years": list(built.years),
+        "parquet_files": built.parquet_files,
+        "rows": built.rows,
+        "source_rows": built.source_rows,
+        "rows_outside_window": built.rows_outside_window,
+        "rows_without_date": built.rows_without_date,
+        "bundle_bytes": bundle_bytes,
+        "bundle_sha256": bundle_sha256,
+        "snapshot_bytes": sum(p.stat().st_size
+                              for p in built.snapshot_dir.rglob("*.parquet")),
+        "timings_seconds": dict(built.timings_seconds),
+        "peak_rss_mb": built.peak_rss_mb,
+        **dict(facts),
+    }
+    report_path.write_text(json.dumps(report, indent=2) + "\n")
+
+    return PackagedRelease(
+        version=version, dist_dir=dist_dir, bundle_path=bundle_path,
+        manifest_path=manifest_path, current_path=current_path,
+        report_path=report_path, bundle_bytes=bundle_bytes,
+        bundle_sha256=bundle_sha256, parquet_files=built.parquet_files,
+        rows=built.rows)

--- a/tools/ppd_snapshot/package.py
+++ b/tools/ppd_snapshot/package.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
+import os
 import shutil
 import tarfile
 from dataclasses import dataclass
@@ -63,8 +64,10 @@ class VersionAlreadyPublished(RuntimeError):
 class PackagedRelease:
     version: str
     dist_dir: Path
-    #: Where the release is assembled. A bundle sitting in the dist root is a
-    #: bundle someone can publish, so nothing arrives there until it has booted.
+    #: Where the release is assembled -- deliberately OUTSIDE the dist root.
+    #: A candidate inside it is still inside the directory something else may
+    #: sync, mirror or serve, and "ignore the subdirectory" is a convention, not
+    #: a boundary. Nothing enters the dist root until it has booted.
     candidate_dir: Path
     bundle_path: Path
     manifest_path: Path
@@ -153,14 +156,40 @@ def verify_bundle(bundle_path: Path, *, expected_sha256: str,
             f"{expected_sha256}")
 
 
-def package_release(built: BuildResult, *, dist_dir: Path, version: str,
-                    source: Mapping[str, Any],
+def _write_json_atomically(path: Path, payload: Any) -> None:
+    """Write beside the target, then rename over it.
+
+    `write_text` truncates first: interrupted, it leaves an empty or half-written
+    file where a valid one used to be. For `current.json` that is the difference
+    between a failed publish and taking down the release that was already
+    published, because the pointer is the first thing a booting Machine reads.
+    """
+    path = Path(path)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2) + "\n")
+    try:
+        os.replace(tmp, path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def package_release(built: BuildResult, *, dist_dir: Path, candidate_root: Path,
+                    version: str, source: Mapping[str, Any],
                     facts: Mapping[str, Any]) -> PackagedRelease:
-    """Bundle, publish the manifest, and record the build report."""
+    """Bundle, write the manifest, and record the build report -- as a candidate.
+
+    Nothing is published here. `candidate_root` is a working directory outside
+    `dist_dir`; `promote_release` is what publishes.
+    """
     validate_component(version, "snapshot_version")
     dist_dir = Path(dist_dir)
-    dist_dir.mkdir(parents=True, exist_ok=True)
-    candidate_dir = dist_dir / f"candidate-{version}"
+    candidate_dir = Path(candidate_root) / f"candidate-{version}"
+    if dist_dir.resolve() in candidate_dir.resolve().parents:
+        raise ValueError(
+            f"the candidate directory {candidate_dir} is inside the dist root "
+            f"{dist_dir}; a candidate must not sit in the directory releases "
+            f"are published from")
 
     bundle_path = candidate_dir / f"snapshot-{version}.tar.zst"
     manifest_path = candidate_dir / f"manifest-{version}.json"
@@ -196,8 +225,7 @@ def package_release(built: BuildResult, *, dist_dir: Path, version: str,
     # exercised against it. The pointer in the dist root is written only at
     # promotion, and only last.
     current_path = candidate_dir / "current.json"
-    current_path.write_text(
-        json.dumps({"current_manifest": manifest_path.name}, indent=2) + "\n")
+    _write_json_atomically(current_path, {"current_manifest": manifest_path.name})
 
     report = {
         "snapshot_version": version,
@@ -245,6 +273,7 @@ def promote_release(release: PackagedRelease) -> PackagedRelease:
     honest state to be in.
     """
     dist_dir = release.dist_dir
+    dist_dir.mkdir(parents=True, exist_ok=True)
     moved: dict[str, Path] = {}
     for path in (release.bundle_path, release.manifest_path, release.report_path):
         target = dist_dir / path.name
@@ -256,9 +285,8 @@ def promote_release(release: PackagedRelease) -> PackagedRelease:
         moved[path.name] = target
 
     current_path = dist_dir / "current.json"
-    current_path.write_text(
-        json.dumps({"current_manifest": release.manifest_path.name},
-                   indent=2) + "\n")
+    _write_json_atomically(
+        current_path, {"current_manifest": release.manifest_path.name})
     shutil.rmtree(release.candidate_dir, ignore_errors=True)
 
     return dataclasses.replace(

--- a/tools/ppd_snapshot/package.py
+++ b/tools/ppd_snapshot/package.py
@@ -21,8 +21,10 @@ manifest purely so the whole boot path can be exercised offline through
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import json
+import shutil
 import tarfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -61,6 +63,9 @@ class VersionAlreadyPublished(RuntimeError):
 class PackagedRelease:
     version: str
     dist_dir: Path
+    #: Where the release is assembled. A bundle sitting in the dist root is a
+    #: bundle someone can publish, so nothing arrives there until it has booted.
+    candidate_dir: Path
     bundle_path: Path
     manifest_path: Path
     current_path: Path
@@ -155,15 +160,18 @@ def package_release(built: BuildResult, *, dist_dir: Path, version: str,
     validate_component(version, "snapshot_version")
     dist_dir = Path(dist_dir)
     dist_dir.mkdir(parents=True, exist_ok=True)
+    candidate_dir = dist_dir / f"candidate-{version}"
 
-    bundle_path = dist_dir / f"snapshot-{version}.tar.zst"
-    manifest_path = dist_dir / f"manifest-{version}.json"
-    report_path = dist_dir / f"build-report-{version}.json"
-    for existing in (bundle_path, manifest_path):
+    bundle_path = candidate_dir / f"snapshot-{version}.tar.zst"
+    manifest_path = candidate_dir / f"manifest-{version}.json"
+    report_path = candidate_dir / f"build-report-{version}.json"
+    for existing in (bundle_path, manifest_path,
+                     dist_dir / bundle_path.name, dist_dir / manifest_path.name):
         if existing.exists():
             raise VersionAlreadyPublished(
                 f"{existing.name} already exists; a changed snapshot requires a "
                 f"new version, never a rewritten one")
+    candidate_dir.mkdir(parents=True, exist_ok=True)
 
     bundle_bytes, bundle_sha256 = write_bundle(built.snapshot_dir, bundle_path)
 
@@ -184,7 +192,10 @@ def package_release(built: BuildResult, *, dist_dir: Path, version: str,
     )
     manifest_path.write_text(json.dumps(manifest.model_dump(), indent=2) + "\n")
 
-    current_path = dist_dir / "current.json"
+    # The candidate gets its own pointer so the whole boot path can be
+    # exercised against it. The pointer in the dist root is written only at
+    # promotion, and only last.
+    current_path = candidate_dir / "current.json"
     current_path.write_text(
         json.dumps({"current_manifest": manifest_path.name}, indent=2) + "\n")
 
@@ -216,8 +227,43 @@ def package_release(built: BuildResult, *, dist_dir: Path, version: str,
     report_path.write_text(json.dumps(report, indent=2) + "\n")
 
     return PackagedRelease(
-        version=version, dist_dir=dist_dir, bundle_path=bundle_path,
+        version=version, dist_dir=dist_dir, candidate_dir=candidate_dir,
+        bundle_path=bundle_path,
         manifest_path=manifest_path, current_path=current_path,
         report_path=report_path, bundle_bytes=bundle_bytes,
         bundle_sha256=bundle_sha256, parquet_files=built.parquet_files,
         rows=built.rows)
+
+
+def promote_release(release: PackagedRelease) -> PackagedRelease:
+    """Move a booted candidate into the dist root, writing the pointer last.
+
+    `current.json` is a promise that what it names is present. Writing it before
+    the manifest and bundle have landed would publish that promise ahead of the
+    thing it describes, so a promotion interrupted half way leaves a partial
+    directory and **no pointer** -- which reads as "nothing published", the only
+    honest state to be in.
+    """
+    dist_dir = release.dist_dir
+    moved: dict[str, Path] = {}
+    for path in (release.bundle_path, release.manifest_path, release.report_path):
+        target = dist_dir / path.name
+        if target.exists():
+            raise VersionAlreadyPublished(
+                f"{target.name} is already published; a changed snapshot "
+                f"requires a new version")
+        shutil.move(str(path), str(target))
+        moved[path.name] = target
+
+    current_path = dist_dir / "current.json"
+    current_path.write_text(
+        json.dumps({"current_manifest": release.manifest_path.name},
+                   indent=2) + "\n")
+    shutil.rmtree(release.candidate_dir, ignore_errors=True)
+
+    return dataclasses.replace(
+        release,
+        bundle_path=moved[release.bundle_path.name],
+        manifest_path=moved[release.manifest_path.name],
+        report_path=moved[release.report_path.name],
+        current_path=current_path)

--- a/tools/ppd_snapshot/package.py
+++ b/tools/ppd_snapshot/package.py
@@ -34,7 +34,7 @@ from typing import Any, Mapping, Optional
 
 from property_core.snapshot.models import SnapshotManifest, validate_component
 
-from tools.ppd_snapshot.atomic import atomic_write_json
+from tools.ppd_snapshot.atomic import atomic_write_json, atomic_write_text
 
 from tools.ppd_snapshot.build import COMPRESSION, PARTITION_FILE, BuildResult
 
@@ -219,7 +219,8 @@ def package_release(built: BuildResult, *, dist_dir: Path, candidate_root: Path,
         layout=LAYOUT,
         duckdb_version=built.duckdb_version,
     )
-    manifest_path.write_text(json.dumps(manifest.model_dump(), indent=2) + "\n")
+    atomic_write_text(manifest_path,
+                      json.dumps(manifest.model_dump(), indent=2) + "\n")
 
     # The candidate gets its own pointer so the whole boot path can be
     # exercised against it. The pointer in the dist root is written only at
@@ -252,7 +253,7 @@ def package_release(built: BuildResult, *, dist_dir: Path, candidate_root: Path,
         "peak_rss_mb": built.peak_rss_mb,
         **dict(facts),
     }
-    report_path.write_text(json.dumps(report, indent=2) + "\n")
+    atomic_write_json(report_path, report)
 
     return PackagedRelease(
         version=version, dist_dir=dist_dir, candidate_dir=candidate_dir,

--- a/tools/ppd_snapshot/package.py
+++ b/tools/ppd_snapshot/package.py
@@ -34,6 +34,8 @@ from typing import Any, Mapping, Optional
 
 from property_core.snapshot.models import SnapshotManifest, validate_component
 
+from tools.ppd_snapshot.atomic import atomic_write_json
+
 from tools.ppd_snapshot.build import COMPRESSION, PARTITION_FILE, BuildResult
 
 #: Read in fixed chunks so a full-history bundle is never held in memory --
@@ -49,6 +51,17 @@ LAYOUT = "year"
 
 class BundleMismatch(RuntimeError):
     """The bundle on disk is not what the manifest says it is."""
+
+
+class CrossFilesystemPromotion(RuntimeError):
+    """The candidate and the dist root are on different filesystems.
+
+    `os.replace` cannot cross devices and `shutil.move` silently degrades to a
+    copy, which is neither atomic nor free: it doubles the transient disk and
+    the wall time that the G1 model was measured against, and leaves a window
+    where a half-copied bundle sits in the publishing directory. Refused before
+    anything moves.
+    """
 
 
 class VersionAlreadyPublished(RuntimeError):
@@ -156,22 +169,9 @@ def verify_bundle(bundle_path: Path, *, expected_sha256: str,
             f"{expected_sha256}")
 
 
-def _write_json_atomically(path: Path, payload: Any) -> None:
-    """Write beside the target, then rename over it.
-
-    `write_text` truncates first: interrupted, it leaves an empty or half-written
-    file where a valid one used to be. For `current.json` that is the difference
-    between a failed publish and taking down the release that was already
-    published, because the pointer is the first thing a booting Machine reads.
-    """
-    path = Path(path)
-    tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(json.dumps(payload, indent=2) + "\n")
-    try:
-        os.replace(tmp, path)
-    except Exception:
-        tmp.unlink(missing_ok=True)
-        raise
+def _device_of(path: Path) -> int:
+    """The filesystem a path lives on. A seam, so the check is testable."""
+    return os.stat(path).st_dev
 
 
 def package_release(built: BuildResult, *, dist_dir: Path, candidate_root: Path,
@@ -225,7 +225,7 @@ def package_release(built: BuildResult, *, dist_dir: Path, candidate_root: Path,
     # exercised against it. The pointer in the dist root is written only at
     # promotion, and only last.
     current_path = candidate_dir / "current.json"
-    _write_json_atomically(current_path, {"current_manifest": manifest_path.name})
+    atomic_write_json(current_path, {"current_manifest": manifest_path.name})
 
     report = {
         "snapshot_version": version,
@@ -274,6 +274,16 @@ def promote_release(release: PackagedRelease) -> PackagedRelease:
     """
     dist_dir = release.dist_dir
     dist_dir.mkdir(parents=True, exist_ok=True)
+
+    # Checked BEFORE anything moves, so a cross-device layout is a refusal
+    # rather than a half-published directory.
+    if _device_of(release.candidate_dir) != _device_of(dist_dir):
+        raise CrossFilesystemPromotion(
+            f"the candidate at {release.candidate_dir} and the dist root at "
+            f"{dist_dir} are on different filesystems; promotion must be a "
+            f"rename, not a copy -- put the work and dist directories on one "
+            f"filesystem")
+
     moved: dict[str, Path] = {}
     for path in (release.bundle_path, release.manifest_path, release.report_path):
         target = dist_dir / path.name
@@ -281,11 +291,13 @@ def promote_release(release: PackagedRelease) -> PackagedRelease:
             raise VersionAlreadyPublished(
                 f"{target.name} is already published; a changed snapshot "
                 f"requires a new version")
-        shutil.move(str(path), str(target))
+        # `os.replace`, never `shutil.move`: a rename within one filesystem, or
+        # an error. `move` would quietly copy 266 MiB across a device boundary.
+        os.replace(path, target)
         moved[path.name] = target
 
     current_path = dist_dir / "current.json"
-    _write_json_atomically(
+    atomic_write_json(
         current_path, {"current_manifest": release.manifest_path.name})
     shutil.rmtree(release.candidate_dir, ignore_errors=True)
 

--- a/tools/ppd_snapshot/release_check.py
+++ b/tools/ppd_snapshot/release_check.py
@@ -23,9 +23,16 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-#: The public open-data object. No credentials; nothing is created or mutated.
-DEFAULT_URL = ("http://prod.publicdata.landregistry.gov.uk.s3-website-eu-west-1"
-               ".amazonaws.com/pp-complete.csv")
+#: The official HTTPS endpoint published by HM Land Registry on the GOV.UK
+#: "Price Paid Data single file" page. Public open data: no credentials, and
+#: nothing is created or mutated.
+#:
+#: HTTPS on purpose. The S3 *website* endpoint the lab used
+#: (`http://prod.publicdata.landregistry.gov.uk.s3-website-eu-west-1...`) is
+#: plaintext, so both the validators this pipeline trusts and the 5.5 GB body
+#: itself are open to tampering in transit -- and the receipt would then bind
+#: the build to whatever arrived.
+DEFAULT_URL = "https://price-paid-data.publicdata.landregistry.gov.uk/pp-complete.csv"
 
 #: Section 4.9: an observed release still uningested after this many days is an
 #: operational alert -- the pipeline is failing, which is a different fact from

--- a/tools/ppd_snapshot/release_check.py
+++ b/tools/ppd_snapshot/release_check.py
@@ -1,0 +1,223 @@
+"""Daily check for a new HM Land Registry release (specification section 4.9).
+
+Cadence follows the observed release, not the calendar: rebuild monthly *after*
+HMLR publishes. Detecting that cheaply is the whole job here -- a `HEAD` against
+`pp-complete.csv`, comparing `ETag` / `Last-Modified` / `Content-Length` with the
+values recorded when the current snapshot was built. **Nothing is downloaded.**
+
+The state file also carries *when a release was first observed*, because the
+seven-day alert is a statement about the pipeline, not about HMLR: it means an
+available release has not been ingested, and it has to be measured from
+observation rather than from build time to mean that.
+
+**No request is issued by this module during PR 5.** It is exercised against a
+loopback server and a recording opener; pointing it at the real host is an
+operator action, documented in the runbook.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+#: The public open-data object. No credentials; nothing is created or mutated.
+DEFAULT_URL = ("http://prod.publicdata.landregistry.gov.uk.s3-website-eu-west-1"
+               ".amazonaws.com/pp-complete.csv")
+
+#: Section 4.9: an observed release still uningested after this many days is an
+#: operational alert -- the pipeline is failing, which is a different fact from
+#: the snapshot merely being old.
+UNINGESTED_ALERT_DAYS = 7
+
+DEFAULT_TIMEOUT = 30.0
+USER_AGENT = "property-shared-snapshot-build/1"
+
+
+def declared_coverage_end(last_modified: Optional[str]) -> Optional[date]:
+    """The coverage end a release publication implies.
+
+    HMLR publishes `pp-complete.csv` after a month closes, so a file published
+    in July covers to the end of June. Deriving the window end this way keeps it
+    a statement about the *release*: taking `max(transfer_date)` instead would
+    let a truncated download declare whatever window its rows happened to reach,
+    which is the one thing coverage must not be able to do.
+
+    Returns None when the publication date cannot be read, so the caller has to
+    supply the end explicitly rather than proceed on a guess.
+    """
+    from email.utils import parsedate_to_datetime
+
+    if not last_modified:
+        return None
+    try:
+        published = parsedate_to_datetime(last_modified)
+    except (TypeError, ValueError):
+        return None
+    if published is None:
+        return None
+    return date(published.year, published.month, 1) - timedelta(days=1)
+
+
+@dataclass(frozen=True)
+class ReleaseObservation:
+    """The validators that identify one published release."""
+
+    etag: Optional[str] = None
+    last_modified: Optional[str] = None
+    content_length: Optional[int] = None
+
+    @property
+    def has_validators(self) -> bool:
+        return any((self.etag, self.last_modified, self.content_length))
+
+
+@dataclass(frozen=True)
+class ReleaseCheck:
+    url: str
+    observation: ReleaseObservation
+    previous: Optional[ReleaseObservation]
+    changed: bool
+    reason: str
+    first_observed: datetime
+    #: None once the observed release has been ingested; otherwise how long it
+    #: has been sitting there.
+    uningested_days: Optional[float]
+    ingested: bool
+    alert: bool
+    #: Always zero. Asserted by test rather than promised in a comment.
+    bytes_read: int = 0
+
+
+def _parse_length(value: Any) -> Optional[int]:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _read_state(path: Path) -> dict[str, Any]:
+    """The recorded state, or an empty one.
+
+    A corrupt state file means "nothing observed", never an exception: this runs
+    unattended, and a check that crashes reports nothing at all.
+    """
+    try:
+        state = json.loads(Path(path).read_text())
+    except (OSError, ValueError):
+        return {}
+    return state if isinstance(state, dict) else {}
+
+
+def _observation_from(state: dict[str, Any]) -> Optional[ReleaseObservation]:
+    if not state or "first_observed_utc" not in state:
+        return None
+    return ReleaseObservation(
+        etag=state.get("etag"),
+        last_modified=state.get("last_modified"),
+        content_length=_parse_length(state.get("content_length")))
+
+
+def _head(url: str, opener: Callable[..., Any], timeout: float
+          ) -> ReleaseObservation:
+    import urllib.request
+
+    request = urllib.request.Request(
+        url, method="HEAD", headers={"User-Agent": USER_AGENT})
+    with opener(request, timeout=timeout) as response:
+        headers = response.headers
+        return ReleaseObservation(
+            etag=headers.get("ETag"),
+            last_modified=headers.get("Last-Modified"),
+            content_length=_parse_length(headers.get("Content-Length")))
+
+
+def check_release(url: str = DEFAULT_URL, state_path: Path | str = "release.json",
+                  *, opener: Optional[Callable[..., Any]] = None,
+                  now: Optional[datetime] = None,
+                  timeout: float = DEFAULT_TIMEOUT) -> ReleaseCheck:
+    """Compare the published release with the recorded one. HEAD only."""
+    import urllib.request
+
+    state_path = Path(state_path)
+    now = now or datetime.now(timezone.utc)
+    observation = _head(url, opener or urllib.request.urlopen, timeout)
+    previous = _observation_from(_read_state(state_path))
+    state = _read_state(state_path)
+
+    if not observation.has_validators:
+        # Fail towards doing the work: an unverifiable response must not be the
+        # reason a real release is skipped.
+        changed, reason = True, ("the response carried no validators, so the "
+                                 "release cannot be shown to be unchanged")
+    elif previous is None:
+        changed, reason = True, "no release has been observed before"
+    elif observation != previous:
+        changed, reason = True, "the published validators have moved"
+    else:
+        changed, reason = False, "the published validators are unchanged"
+
+    first_observed = now
+    if not changed:
+        recorded = state.get("first_observed_utc")
+        if recorded:
+            try:
+                first_observed = datetime.fromisoformat(recorded)
+            except ValueError:
+                first_observed = now
+
+    ingested = bool(observation.etag) and (
+        state.get("last_ingested", {}).get("etag") == observation.etag)
+    uningested_days = None if ingested else round(
+        (now - first_observed).total_seconds() / 86400.0, 4)
+    alert = uningested_days is not None and uningested_days >= UNINGESTED_ALERT_DAYS
+
+    state.update({
+        "url": url,
+        "etag": observation.etag,
+        "last_modified": observation.last_modified,
+        "content_length": observation.content_length,
+        "first_observed_utc": first_observed.isoformat(),
+        "last_checked_utc": now.isoformat(),
+    })
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state, indent=2) + "\n")
+
+    return ReleaseCheck(
+        url=url, observation=observation, previous=previous, changed=changed,
+        reason=reason, first_observed=first_observed,
+        uningested_days=uningested_days, ingested=ingested, alert=alert)
+
+
+def record_ingested(state_path: Path | str, *, version: str, etag: Optional[str],
+                    now: Optional[datetime] = None) -> None:
+    """Record which observed release a build consumed, stopping its alert clock."""
+    state_path = Path(state_path)
+    state = _read_state(state_path)
+    state["last_ingested"] = {
+        "version": version,
+        "etag": etag,
+        "at_utc": (now or datetime.now(timezone.utc)).isoformat(),
+    }
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state, indent=2) + "\n")
+
+
+def describe(check: ReleaseCheck) -> str:  # pragma: no cover - operator output
+    lines = [
+        f"url:            {check.url}",
+        f"etag:           {check.observation.etag}",
+        f"last-modified:  {check.observation.last_modified}",
+        f"content-length: {check.observation.content_length}",
+        f"changed:        {check.changed} ({check.reason})",
+        f"first observed: {check.first_observed.isoformat()}",
+        f"ingested:       {check.ingested}",
+    ]
+    if check.uningested_days is not None:
+        lines.append(f"uningested for: {check.uningested_days} day(s)")
+    if check.alert:
+        lines.append(f"ALERT: an observed release has been uningested for "
+                     f"{UNINGESTED_ALERT_DAYS}+ days; the pipeline is failing")
+    return "\n".join(lines)

--- a/tools/ppd_snapshot/release_check.py
+++ b/tools/ppd_snapshot/release_check.py
@@ -23,6 +23,8 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from tools.ppd_snapshot.atomic import atomic_write_json
+
 #: The official HTTPS endpoint published by HM Land Registry on the GOV.UK
 #: "Price Paid Data single file" page. Public open data: no credentials, and
 #: nothing is created or mutated.
@@ -189,8 +191,10 @@ def check_release(url: str = DEFAULT_URL, state_path: Path | str = "release.json
         "first_observed_utc": first_observed.isoformat(),
         "last_checked_utc": now.isoformat(),
     })
-    state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text(json.dumps(state, indent=2) + "\n")
+    # Atomic: `write_text` truncates first, and this file carries the
+    # first-observed timestamp the seven-day alert is measured from. An
+    # interrupted check must not be able to reset that clock.
+    atomic_write_json(state_path, state)
 
     return ReleaseCheck(
         url=url, observation=observation, previous=previous, changed=changed,
@@ -208,8 +212,7 @@ def record_ingested(state_path: Path | str, *, version: str, etag: Optional[str]
         "etag": etag,
         "at_utc": (now or datetime.now(timezone.utc)).isoformat(),
     }
-    state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text(json.dumps(state, indent=2) + "\n")
+    atomic_write_json(state_path, state)
 
 
 def describe(check: ReleaseCheck) -> str:  # pragma: no cover - operator output

--- a/tools/ppd_snapshot/source_receipt.py
+++ b/tools/ppd_snapshot/source_receipt.py
@@ -36,13 +36,17 @@ from has no provenance, whatever its gates say.
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import json
+import os
+import tempfile
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from tools.ppd_snapshot.atomic import atomic_write_json
 from tools.ppd_snapshot.release_check import ReleaseObservation
 
 CHUNK_BYTES = 1024 * 1024
@@ -119,8 +123,7 @@ def write_receipt(csv_path: Path | str, observation: ReleaseObservation,
         content_length=observation.content_length,
         recorded_at=(now or datetime.now(timezone.utc)).isoformat(),
         evidence=evidence)
-    receipt_path.parent.mkdir(parents=True, exist_ok=True)
-    receipt_path.write_text(json.dumps(asdict(receipt), indent=2) + "\n")
+    atomic_write_json(receipt_path, asdict(receipt))
     return receipt
 
 
@@ -192,10 +195,14 @@ def download_with_receipt(url: str, dest: Path | str, receipt_path: Path | str,
     describe. Minting a receipt for a file that is merely sitting on disk is the
     fallback, and it is recorded as the weaker evidence it is.
 
-    The body is streamed in fixed chunks and never held in memory, and a
-    transfer whose length disagrees with `Content-Length` is an interrupted
-    download rather than a release: the partial file and the receipt are both
-    discarded.
+    The body is streamed in fixed chunks and never held in memory, and it is
+    streamed into a **unique sibling temporary file**, never into the
+    destination. Writing the destination directly makes every refresh
+    destructive: opening it truncates the release already held, so a transfer
+    that dies half way leaves nothing where a working CSV was, next to a receipt
+    that still describes it. The destination is replaced only once the length
+    and digest have been checked, and a failure leaves the previous file and its
+    receipt byte-for-byte intact.
 
     **Not exercised against the real host in this PR.** No download of the
     5.5 GB object is authorised here; the mechanism is tested against a loopback
@@ -210,6 +217,9 @@ def download_with_receipt(url: str, dest: Path | str, receipt_path: Path | str,
     request = urllib.request.Request(
         url, headers={"User-Agent": "property-shared-snapshot-build/1"})
 
+    handle, tmp_name = tempfile.mkstemp(dir=dest.parent,
+                                        prefix=f".{dest.name}.", suffix=".part")
+    tmp = Path(tmp_name)
     digest = hashlib.sha256()
     length = 0
     try:
@@ -221,11 +231,13 @@ def download_with_receipt(url: str, dest: Path | str, receipt_path: Path | str,
                 last_modified=headers.get("Last-Modified"),
                 content_length=int(declared) if declared and declared.isdigit()
                 else None)
-            with open(dest, "wb") as out:
+            with os.fdopen(handle, "wb") as out:
                 while chunk := response.read(CHUNK_BYTES):
                     out.write(chunk)
                     digest.update(chunk)
                     length += len(chunk)
+                out.flush()
+                os.fsync(out.fileno())
 
         if observation.content_length is None:
             raise SourceMismatch(
@@ -235,10 +247,28 @@ def download_with_receipt(url: str, dest: Path | str, receipt_path: Path | str,
             raise SourceMismatch(
                 f"{url} declared Content-Length {observation.content_length} "
                 f"but {length} bytes arrived; the transfer was interrupted")
-    except Exception:
-        dest.unlink(missing_ok=True)
+    except BaseException:
+        # The destination was never opened, so whatever was there is untouched.
+        tmp.unlink(missing_ok=True)
         raise
 
-    return write_receipt(dest, observation, receipt_path,
-                         expected_sha256=digest.hexdigest(),
-                         evidence="streamed-download", now=now)
+    # Committed only now: the transfer is complete and its length agrees with
+    # what was declared. The receipt is built from the digest computed AS THE
+    # BYTES ARRIVED rather than by re-reading the file -- re-reading would mean
+    # a second full pass over 5.5 GB, and would digest a file that is no longer
+    # provably the one that was received.
+    receipt = SourceReceipt(
+        file=dest.name, sha256=digest.hexdigest(), bytes=length,
+        etag=observation.etag, last_modified=observation.last_modified,
+        content_length=observation.content_length,
+        recorded_at=(now or datetime.now(timezone.utc)).isoformat(),
+        evidence="streamed-download")
+    try:
+        os.replace(tmp, dest)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    # If this fails, the new file sits beside the previous receipt and every
+    # later build refuses on the mismatch -- which is the safe direction.
+    atomic_write_json(receipt_path, dataclasses.asdict(receipt))
+    return receipt

--- a/tools/ppd_snapshot/source_receipt.py
+++ b/tools/ppd_snapshot/source_receipt.py
@@ -60,6 +60,20 @@ class SourceMismatch(RuntimeError):
     """The file, its receipt and the observed release do not describe one thing."""
 
 
+class ReceiptRollbackFailed(RuntimeError):
+    """A commit failed and the previous release could not be put back.
+
+    The backup is the only copy of it at that moment, so it is **kept** and its
+    path is reported. Deleting it to tidy up turns a recoverable half-commit
+    into an unrecoverable one: the destination holds the new bytes, the receipt
+    still describes the old ones, and nothing on disk can reconcile them.
+    """
+
+    def __init__(self, message: str, *, backup_path: Path):
+        super().__init__(message)
+        self.backup_path = backup_path
+
+
 @dataclass(frozen=True)
 class SourceReceipt:
     file: str
@@ -296,30 +310,74 @@ def download_with_receipt(url: str, dest: Path | str, receipt_path: Path | str,
         tmp.unlink(missing_ok=True)
         raise
 
-    backup = None
-    if dest.exists():
-        # The previous release is renamed aside rather than overwritten, so the
-        # commit below can put it back. `mkstemp` hands back a descriptor with
-        # the name; close it before the file is renamed over.
-        backup_handle, backup_name = tempfile.mkstemp(
-            dir=dest.parent, prefix=f".{dest.name}.", suffix=".prev")
-        os.close(backup_handle)
-        backup = Path(backup_name)
-        os.replace(dest, backup)
-    try:
-        commit_prepared(tmp, dest)
-        commit_prepared(tmp_receipt, receipt_path)
-    except BaseException:
-        # Put back exactly what was there. A half-committed pair is worse than
-        # a refused refresh, because nothing downstream can tell it happened.
-        if backup is not None:
-            os.replace(backup, dest)
-        else:
-            dest.unlink(missing_ok=True)
-        tmp.unlink(missing_ok=True)
-        Path(tmp_receipt).unlink(missing_ok=True)
-        raise
-    finally:
-        if backup is not None:
-            Path(backup).unlink(missing_ok=True)
+    _publish_pair(tmp, dest, tmp_receipt, receipt_path)
     return receipt
+
+
+def _discard(*paths: Optional[Path]) -> None:
+    for path in paths:
+        if path is not None:
+            Path(path).unlink(missing_ok=True)
+
+
+def _publish_pair(tmp_data: Path, dest: Path, tmp_receipt: Path,
+                  receipt_path: Path) -> None:
+    """Publish two staged files together, or leave the previous pair in place.
+
+    An explicit transaction, because the interesting cases are all in the middle
+    of it. The stages, in order:
+
+        staged          both temporaries written; nothing on disk touched
+        backed_up       the previous release renamed aside -- the backup is now
+                        the ONLY copy of it
+        dest_published  the new release is in place, the receipt is not
+        published       both in place
+
+    The backup is removed at exactly two points: after `published`, and after a
+    restoration that was **confirmed to have worked**. Anywhere else it is what
+    the previous release is recovered from, so it is kept -- including, and
+    especially, when the restoration itself failed.
+    """
+    stage = "staged"
+    backup: Optional[Path] = None
+    try:
+        if dest.exists():
+            handle, name = tempfile.mkstemp(dir=dest.parent,
+                                            prefix=f".{dest.name}.",
+                                            suffix=".prev")
+            os.close(handle)
+            backup = Path(name)
+            os.replace(dest, backup)
+            stage = "backed_up"
+        os.replace(tmp_data, dest)
+        stage = "dest_published"
+        os.replace(tmp_receipt, receipt_path)
+        stage = "published"
+    except BaseException as failure:
+        if stage == "staged":
+            # Nothing was moved. Any backup here is the empty placeholder
+            # `mkstemp` made, not the previous release, so all three staging
+            # files go.
+            _discard(tmp_data, tmp_receipt, backup)
+            raise
+        try:
+            if backup is not None:
+                os.replace(backup, dest)
+            else:
+                # There was no previous release; the new one is withdrawn.
+                Path(dest).unlink(missing_ok=True)
+        except BaseException as restore_failure:
+            _discard(tmp_data, tmp_receipt)
+            raise ReceiptRollbackFailed(
+                f"the download could not be committed ({failure}) and the "
+                f"previous release could not be restored "
+                f"({restore_failure}). {dest} now holds the NEW bytes while "
+                f"{receipt_path} still describes the old ones. The previous "
+                f"release has been RETAINED at {backup} -- move it back to "
+                f"{dest}, or re-run the download.",
+                backup_path=backup) from restore_failure
+        # Restoration confirmed: the backup is redundant.
+        _discard(tmp_data, tmp_receipt, backup)
+        raise
+    # Published: the backup is redundant.
+    _discard(backup)

--- a/tools/ppd_snapshot/source_receipt.py
+++ b/tools/ppd_snapshot/source_receipt.py
@@ -46,7 +46,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-from tools.ppd_snapshot.atomic import atomic_write_json
+from tools.ppd_snapshot.atomic import (
+    atomic_write_json,
+    commit_prepared,
+    prepare_write_json,
+)
 from tools.ppd_snapshot.release_check import ReleaseObservation
 
 CHUNK_BYTES = 1024 * 1024
@@ -212,7 +216,15 @@ def download_with_receipt(url: str, dest: Path | str, receipt_path: Path | str,
 
     dest = Path(dest)
     receipt_path = Path(receipt_path)
+    if dest.resolve() == receipt_path.resolve():
+        # Checked before anything is requested: otherwise the download succeeds
+        # and the receipt is then written over the very file it describes.
+        raise SourceMismatch(
+            f"the destination and the receipt resolve to the same path "
+            f"({dest}); the receipt would overwrite the release it describes")
     dest.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+
     opener = opener or urllib.request.urlopen
     request = urllib.request.Request(
         url, headers={"User-Agent": "property-shared-snapshot-build/1"})
@@ -220,24 +232,35 @@ def download_with_receipt(url: str, dest: Path | str, receipt_path: Path | str,
     handle, tmp_name = tempfile.mkstemp(dir=dest.parent,
                                         prefix=f".{dest.name}.", suffix=".part")
     tmp = Path(tmp_name)
+    try:
+        # The descriptor is adopted by a file object IMMEDIATELY. Anything that
+        # fails between `mkstemp` and `fdopen` -- an opener that refuses to
+        # connect, a header that will not parse -- leaves a raw descriptor that
+        # nothing ever closes, and a daily check would leak one per attempt.
+        out = os.fdopen(handle, "wb")
+    except BaseException:
+        os.close(handle)
+        tmp.unlink(missing_ok=True)
+        raise
+
     digest = hashlib.sha256()
     length = 0
     try:
-        with opener(request, timeout=timeout) as response:
-            headers = response.headers
-            declared = headers.get("Content-Length")
-            observation = ReleaseObservation(
-                etag=headers.get("ETag"),
-                last_modified=headers.get("Last-Modified"),
-                content_length=int(declared) if declared and declared.isdigit()
-                else None)
-            with os.fdopen(handle, "wb") as out:
+        with out:
+            with opener(request, timeout=timeout) as response:
+                headers = response.headers
+                declared = headers.get("Content-Length")
+                observation = ReleaseObservation(
+                    etag=headers.get("ETag"),
+                    last_modified=headers.get("Last-Modified"),
+                    content_length=int(declared)
+                    if declared and declared.isdigit() else None)
                 while chunk := response.read(CHUNK_BYTES):
                     out.write(chunk)
                     digest.update(chunk)
                     length += len(chunk)
-                out.flush()
-                os.fsync(out.fileno())
+            out.flush()
+            os.fsync(out.fileno())
 
         if observation.content_length is None:
             raise SourceMismatch(
@@ -252,23 +275,51 @@ def download_with_receipt(url: str, dest: Path | str, receipt_path: Path | str,
         tmp.unlink(missing_ok=True)
         raise
 
-    # Committed only now: the transfer is complete and its length agrees with
-    # what was declared. The receipt is built from the digest computed AS THE
-    # BYTES ARRIVED rather than by re-reading the file -- re-reading would mean
-    # a second full pass over 5.5 GB, and would digest a file that is no longer
-    # provably the one that was received.
+    # The receipt is built from the digest computed AS THE BYTES ARRIVED rather
+    # than by re-reading the file: re-reading would mean a second full pass over
+    # 5.5 GB, and would digest a file that is no longer provably the one
+    # received.
     receipt = SourceReceipt(
         file=dest.name, sha256=digest.hexdigest(), bytes=length,
         etag=observation.etag, last_modified=observation.last_modified,
         content_length=observation.content_length,
         recorded_at=(now or datetime.now(timezone.utc)).isoformat(),
         evidence="streamed-download")
+
+    # The CSV and its receipt are ONE fact in two files, so both are written
+    # before either is published. Replacing the CSV and then failing to write
+    # the receipt destroys the previous valid pair: the old bytes are gone and
+    # the surviving receipt describes a file that no longer exists.
     try:
-        os.replace(tmp, dest)
+        tmp_receipt = prepare_write_json(receipt_path, dataclasses.asdict(receipt))
     except BaseException:
         tmp.unlink(missing_ok=True)
         raise
-    # If this fails, the new file sits beside the previous receipt and every
-    # later build refuses on the mismatch -- which is the safe direction.
-    atomic_write_json(receipt_path, dataclasses.asdict(receipt))
+
+    backup = None
+    if dest.exists():
+        # The previous release is renamed aside rather than overwritten, so the
+        # commit below can put it back. `mkstemp` hands back a descriptor with
+        # the name; close it before the file is renamed over.
+        backup_handle, backup_name = tempfile.mkstemp(
+            dir=dest.parent, prefix=f".{dest.name}.", suffix=".prev")
+        os.close(backup_handle)
+        backup = Path(backup_name)
+        os.replace(dest, backup)
+    try:
+        commit_prepared(tmp, dest)
+        commit_prepared(tmp_receipt, receipt_path)
+    except BaseException:
+        # Put back exactly what was there. A half-committed pair is worse than
+        # a refused refresh, because nothing downstream can tell it happened.
+        if backup is not None:
+            os.replace(backup, dest)
+        else:
+            dest.unlink(missing_ok=True)
+        tmp.unlink(missing_ok=True)
+        Path(tmp_receipt).unlink(missing_ok=True)
+        raise
+    finally:
+        if backup is not None:
+            Path(backup).unlink(missing_ok=True)
     return receipt

--- a/tools/ppd_snapshot/source_receipt.py
+++ b/tools/ppd_snapshot/source_receipt.py
@@ -1,0 +1,155 @@
+"""Bind the local CSV to the release it claims to be.
+
+Without this the pipeline validated an artifact and never asked what it was
+built from. A 131-byte stale CSV built cleanly while the release record claimed
+999,999,999 bytes under a different ETag, and the result booted READY: every
+gate downstream checks the snapshot against itself, so an internally consistent
+snapshot of the wrong data passes all of them.
+
+A receipt is the binding, and it is deliberately made of two different kinds of
+evidence:
+
+* **computed from the file** -- SHA-256 and byte length, read off the bytes on
+  disk;
+* **observed from the release** -- `ETag`, `Last-Modified`, `Content-Length`, as
+  the source reported them.
+
+Writing a receipt refuses unless those agree, and every build re-checks the file
+against its receipt and the receipt against the latest observation. Any
+disagreement stops the build: a snapshot that cannot say which release it came
+from has no provenance, whatever its gates say.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from tools.ppd_snapshot.release_check import ReleaseObservation
+
+CHUNK_BYTES = 1024 * 1024
+
+
+class SourceMismatch(RuntimeError):
+    """The file, its receipt and the observed release do not describe one thing."""
+
+
+@dataclass(frozen=True)
+class SourceReceipt:
+    file: str
+    sha256: str
+    bytes: int
+    etag: Optional[str]
+    last_modified: Optional[str]
+    content_length: Optional[int]
+    recorded_at: str
+
+    def observation(self) -> ReleaseObservation:
+        return ReleaseObservation(etag=self.etag,
+                                  last_modified=self.last_modified,
+                                  content_length=self.content_length)
+
+
+def digest_file(path: Path | str) -> tuple[int, str]:
+    """Length and SHA-256, streamed. A 5.5 GB file is never held in memory."""
+    digest = hashlib.sha256()
+    length = 0
+    with open(path, "rb") as fh:
+        while chunk := fh.read(CHUNK_BYTES):
+            digest.update(chunk)
+            length += len(chunk)
+    return length, digest.hexdigest()
+
+
+def write_receipt(csv_path: Path | str, observation: ReleaseObservation,
+                  receipt_path: Path | str, *,
+                  now: Optional[datetime] = None) -> SourceReceipt:
+    """Record what this file is, refusing if it is not what the release says.
+
+    The length comparison is the one that catches a stale download: a file that
+    is not the size the release declares is not that release, whatever it is
+    named.
+    """
+    csv_path = Path(csv_path)
+    receipt_path = Path(receipt_path)
+    if observation.content_length is None:
+        raise SourceMismatch(
+            "the release observation carries no Content-Length, so the local "
+            "file cannot be shown to be that release")
+
+    length, digest = digest_file(csv_path)
+    if length != observation.content_length:
+        raise SourceMismatch(
+            f"{csv_path.name} is {length} bytes but the observed release "
+            f"declares {observation.content_length}; this file is not that "
+            f"release")
+
+    receipt = SourceReceipt(
+        file=csv_path.name, sha256=digest, bytes=length,
+        etag=observation.etag, last_modified=observation.last_modified,
+        content_length=observation.content_length,
+        recorded_at=(now or datetime.now(timezone.utc)).isoformat())
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(asdict(receipt), indent=2) + "\n")
+    return receipt
+
+
+def load_receipt(receipt_path: Path | str) -> SourceReceipt:
+    """The receipt, or a refusal. There is no implied default."""
+    receipt_path = Path(receipt_path)
+    if not receipt_path.is_file():
+        raise SourceMismatch(
+            f"no source receipt at {receipt_path}; the CSV cannot be shown to "
+            f"be any particular release, so the build stops")
+    try:
+        payload = json.loads(receipt_path.read_text())
+        return SourceReceipt(**payload)
+    except (OSError, ValueError, TypeError) as exc:
+        raise SourceMismatch(
+            f"the source receipt at {receipt_path} is unreadable: {exc}") from exc
+
+
+def verify_source(csv_path: Path | str, receipt: SourceReceipt,
+                  observation: Optional[ReleaseObservation]) -> None:
+    """Refuse unless the file, its receipt and the latest observation agree.
+
+    All three, not two: the file matching its receipt says the download has not
+    rotted, and the receipt matching the observation says the release has not
+    moved on since. Either alone leaves the build able to publish the wrong data
+    under the right name.
+    """
+    csv_path = Path(csv_path)
+    length, digest = digest_file(csv_path)
+    if length != receipt.bytes:
+        raise SourceMismatch(
+            f"{csv_path.name} is {length} bytes; its receipt records "
+            f"{receipt.bytes}")
+    if digest != receipt.sha256:
+        raise SourceMismatch(
+            f"{csv_path.name} sha256 is {digest}; its receipt records "
+            f"{receipt.sha256}")
+    if receipt.content_length is not None and receipt.content_length != length:
+        raise SourceMismatch(
+            f"the receipt records a release Content-Length of "
+            f"{receipt.content_length} for a file of {length} bytes")
+
+    if observation is None:
+        raise SourceMismatch(
+            "no current release observation was supplied, so the receipt cannot "
+            "be shown to describe the release that is published now")
+    if observation.etag != receipt.etag:
+        raise SourceMismatch(
+            f"the published ETag {observation.etag!r} is not the one this file "
+            f"was fetched under ({receipt.etag!r}); the release has moved")
+    if observation.last_modified != receipt.last_modified:
+        raise SourceMismatch(
+            f"the published Last-Modified {observation.last_modified!r} is not "
+            f"the one this file was fetched under ({receipt.last_modified!r})")
+    if observation.content_length != receipt.content_length:
+        raise SourceMismatch(
+            f"the published Content-Length {observation.content_length} is not "
+            f"the one this file was fetched under ({receipt.content_length})")

--- a/tools/ppd_snapshot/source_receipt.py
+++ b/tools/ppd_snapshot/source_receipt.py
@@ -14,6 +14,20 @@ evidence:
 * **observed from the release** -- `ETag`, `Last-Modified`, `Content-Length`, as
   the source reported them.
 
+Those two alone are not enough, and the gap is worth stating plainly: a receipt
+minted from a file and a set of validators binds *whatever bytes are on disk* to
+*whatever release is claimed*, provided only that the lengths agree. Same-length
+substitution passes. So minting also requires a digest captured **independently
+of the file being read now**:
+
+* `download_with_receipt` is the intended path -- it digests the bytes as they
+  stream in, from the same response the validators come from, so the file, its
+  digest and its release provenance all originate in one observation
+  (`evidence: "streamed-download"`);
+* for a file that already exists, the digest recorded when it was fetched must
+  be supplied and must match (`evidence: "recorded-checksum"`). That is weaker,
+  because it trusts a record made elsewhere, and the receipt says so.
+
 Writing a receipt refuses unless those agree, and every build re-checks the file
 against its receipt and the receipt against the latest observation. Any
 disagreement stops the build: a snapshot that cannot say which release it came
@@ -47,6 +61,10 @@ class SourceReceipt:
     last_modified: Optional[str]
     content_length: Optional[int]
     recorded_at: str
+    #: Where the digest came from. "streamed-download" means it was computed
+    #: from the response that also carried the validators; "recorded-checksum"
+    #: means it was taken on trust from a record made at some earlier fetch.
+    evidence: str = "recorded-checksum"
 
     def observation(self) -> ReleaseObservation:
         return ReleaseObservation(etag=self.etag,
@@ -66,13 +84,15 @@ def digest_file(path: Path | str) -> tuple[int, str]:
 
 
 def write_receipt(csv_path: Path | str, observation: ReleaseObservation,
-                  receipt_path: Path | str, *,
+                  receipt_path: Path | str, *, expected_sha256: str,
+                  evidence: str = "recorded-checksum",
                   now: Optional[datetime] = None) -> SourceReceipt:
     """Record what this file is, refusing if it is not what the release says.
 
-    The length comparison is the one that catches a stale download: a file that
-    is not the size the release declares is not that release, whatever it is
-    named.
+    `expected_sha256` is required, and is the point of the function: the length
+    comparison catches a stale download, but only the digest catches a file of
+    the right size holding different bytes. Without it a receipt would bind any
+    same-length content to any release.
     """
     csv_path = Path(csv_path)
     receipt_path = Path(receipt_path)
@@ -87,12 +107,18 @@ def write_receipt(csv_path: Path | str, observation: ReleaseObservation,
             f"{csv_path.name} is {length} bytes but the observed release "
             f"declares {observation.content_length}; this file is not that "
             f"release")
+    if digest != expected_sha256:
+        raise SourceMismatch(
+            f"{csv_path.name} has sha256 {digest}, but the digest recorded when "
+            f"this release was downloaded is {expected_sha256}; the file on "
+            f"disk is not the one that was fetched")
 
     receipt = SourceReceipt(
         file=csv_path.name, sha256=digest, bytes=length,
         etag=observation.etag, last_modified=observation.last_modified,
         content_length=observation.content_length,
-        recorded_at=(now or datetime.now(timezone.utc)).isoformat())
+        recorded_at=(now or datetime.now(timezone.utc)).isoformat(),
+        evidence=evidence)
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     receipt_path.write_text(json.dumps(asdict(receipt), indent=2) + "\n")
     return receipt
@@ -153,3 +179,66 @@ def verify_source(csv_path: Path | str, receipt: SourceReceipt,
         raise SourceMismatch(
             f"the published Content-Length {observation.content_length} is not "
             f"the one this file was fetched under ({receipt.content_length})")
+
+
+def download_with_receipt(url: str, dest: Path | str, receipt_path: Path | str,
+                          *, opener=None, now: Optional[datetime] = None,
+                          timeout: float = 300.0) -> SourceReceipt:
+    """Stream a release to disk, digesting it as it arrives, and mint a receipt.
+
+    This is the receipt path the pipeline is designed around: the bytes, the
+    digest and the validators all come from **one** response, so there is no
+    window in which the file could be something other than what the headers
+    describe. Minting a receipt for a file that is merely sitting on disk is the
+    fallback, and it is recorded as the weaker evidence it is.
+
+    The body is streamed in fixed chunks and never held in memory, and a
+    transfer whose length disagrees with `Content-Length` is an interrupted
+    download rather than a release: the partial file and the receipt are both
+    discarded.
+
+    **Not exercised against the real host in this PR.** No download of the
+    5.5 GB object is authorised here; the mechanism is tested against a loopback
+    server.
+    """
+    import urllib.request
+
+    dest = Path(dest)
+    receipt_path = Path(receipt_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    opener = opener or urllib.request.urlopen
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "property-shared-snapshot-build/1"})
+
+    digest = hashlib.sha256()
+    length = 0
+    try:
+        with opener(request, timeout=timeout) as response:
+            headers = response.headers
+            declared = headers.get("Content-Length")
+            observation = ReleaseObservation(
+                etag=headers.get("ETag"),
+                last_modified=headers.get("Last-Modified"),
+                content_length=int(declared) if declared and declared.isdigit()
+                else None)
+            with open(dest, "wb") as out:
+                while chunk := response.read(CHUNK_BYTES):
+                    out.write(chunk)
+                    digest.update(chunk)
+                    length += len(chunk)
+
+        if observation.content_length is None:
+            raise SourceMismatch(
+                f"{url} returned no Content-Length, so the transfer cannot be "
+                f"shown to be complete")
+        if length != observation.content_length:
+            raise SourceMismatch(
+                f"{url} declared Content-Length {observation.content_length} "
+                f"but {length} bytes arrived; the transfer was interrupted")
+    except Exception:
+        dest.unlink(missing_ok=True)
+        raise
+
+    return write_receipt(dest, observation, receipt_path,
+                         expected_sha256=digest.hexdigest(),
+                         evidence="streamed-download", now=now)

--- a/tools/ppd_snapshot/validate.py
+++ b/tools/ppd_snapshot/validate.py
@@ -54,9 +54,15 @@ from tools.ppd_snapshot.build import (
 #: The order gates run in. Data gates are skipped when the schema gate fails,
 #: because a query over a defective partition reports a defect of its own and
 #: would bury the real one.
-GATE_ORDER = ("partitions", "schema", "rows", "uniqueness", "coverage",
-              "guarantee", "provisional", "ordering")
-_DATA_GATES = frozenset({"rows", "uniqueness", "coverage", "ordering"})
+GATE_ORDER = ("partitions", "schema", "required_values", "rows",
+              "reconciliation", "uniqueness", "coverage", "guarantee",
+              "provisional", "ordering")
+_DATA_GATES = frozenset({"required_values", "rows", "reconciliation",
+                         "uniqueness", "coverage", "ordering"})
+
+
+class _Skip(str):
+    """A gate that could not run. Not a pass -- the report says so."""
 
 
 @dataclass(frozen=True)
@@ -106,6 +112,10 @@ class DeclaredSnapshot:
     provisional_from: date
     rows: int
     parquet_files: int
+    #: Eligible rows counted from the source, independently of what was written.
+    #: None means the source was not available to compare against, which is a
+    #: skipped gate rather than a passing one.
+    eligible_source_rows: Optional[int] = None
 
     def replace(self, **changes: Any) -> "DeclaredSnapshot":
         return dataclasses.replace(self, **changes)
@@ -195,6 +205,49 @@ def _gate_schema(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
     return "; ".join(problems) or None
 
 
+def _gate_required_values(declared: DeclaredSnapshot,
+                          ctx: _Context) -> Optional[str]:
+    """No row may be missing a value the service has to have.
+
+    `TRY_CAST` turns an unparseable price or date into NULL, which every other
+    gate then waves through: the row count is right, the schema is right, and
+    the snapshot serves a sale with no price. Required means required.
+    """
+    total, no_id, no_price, no_date = ctx.connection.execute(
+        f"SELECT count(*), "
+        f"       count(*) FILTER (WHERE transaction_id IS NULL "
+        f"                           OR trim(transaction_id) = ''), "
+        f"       count(*) FILTER (WHERE price IS NULL), "
+        f"       count(*) FILTER (WHERE transfer_date IS NULL) "
+        f"FROM {_scan(ctx.files.values())}").fetchone()
+    problems = []
+    for count, column in ((no_id, "transaction_id"), (no_price, "price"),
+                          (no_date, "transfer_date")):
+        if int(count):
+            problems.append(f"{int(count)} of {int(total)} row(s) have no "
+                            f"{column}")
+    return "; ".join(problems) or None
+
+
+def _gate_reconciliation(declared: DeclaredSnapshot,
+                         ctx: _Context) -> Optional[str]:
+    """What the source held against what the snapshot wrote.
+
+    Every other count is taken from the artifact, so a row lost between reading
+    the CSV and writing the Parquet is invisible to all of them: the snapshot is
+    perfectly consistent with itself and quietly short.
+    """
+    if declared.eligible_source_rows is None:
+        return _Skip("no source row count was supplied, so the snapshot cannot "
+                     "be reconciled with what it was built from")
+    written = int(ctx.connection.execute(
+        f"SELECT count(*) FROM {_scan(ctx.files.values())}").fetchone()[0])
+    if written != declared.eligible_source_rows:
+        return (f"the source held {declared.eligible_source_rows} eligible "
+                f"row(s) but the snapshot holds {written}")
+    return None
+
+
 def _gate_rows(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
     total = int(ctx.connection.execute(
         f"SELECT count(*) FROM {_scan(ctx.files.values())}").fetchone()[0])
@@ -212,13 +265,12 @@ def _gate_rows(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
 
 
 def _gate_uniqueness(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
-    total, distinct, blank = ctx.connection.execute(
-        f"SELECT count(*), count(DISTINCT transaction_id), "
-        f"count(*) FILTER (WHERE transaction_id IS NULL OR transaction_id = '') "
+    # A missing id is the required-values gate's business; this one is only
+    # about the id being a key.
+    total, distinct = ctx.connection.execute(
+        f"SELECT count(*), count(DISTINCT transaction_id) "
         f"FROM {_scan(ctx.files.values())}").fetchone()
     problems = []
-    if int(blank):
-        problems.append(f"{int(blank)} row(s) carry no transaction_id")
     if int(total) != int(distinct):
         problems.append(f"{int(total)} row(s) carry only {int(distinct)} distinct "
                         f"transaction_id(s)")
@@ -237,8 +289,7 @@ def _gate_coverage(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
 
     outside = int(ctx.connection.execute(
         f"SELECT count(*) FROM {_scan(ctx.files.values())} "
-        f"WHERE transfer_date IS NULL "
-        f"   OR transfer_date < DATE {_quote(declared.coverage_from)} "
+        f"WHERE transfer_date < DATE {_quote(declared.coverage_from)} "
         f"   OR transfer_date > DATE {_quote(declared.coverage_to)}").fetchone()[0])
     if outside:
         problems.append(f"{outside} row(s) fall outside the declared window "
@@ -248,8 +299,11 @@ def _gate_coverage(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
         path = ctx.files[year]
         misfiled = int(ctx.connection.execute(
             f"SELECT count(*) FROM read_parquet({_quote(path)}) "
+            # A NULL date is the required-values gate's business, so it is not
+            # counted here as well: one fault, one gate.
             f"WHERE year IS DISTINCT FROM {year} "
-            f"   OR EXTRACT(year FROM transfer_date) IS DISTINCT FROM {year}"
+            f"   OR (transfer_date IS NOT NULL "
+            f"       AND EXTRACT(year FROM transfer_date) IS DISTINCT FROM {year})"
         ).fetchone()[0])
         if misfiled:
             problems.append(
@@ -329,15 +383,21 @@ def content_digests(directory: Path | str,
             year = path.parent.name[len("year="):]
             columns = [str(row[0]) for row in con.execute(
                 f"DESCRIBE SELECT * FROM read_parquet({_quote(path)})").fetchall()]
-            # NULL is rendered explicitly: `concat_ws` skips NULLs, so without
-            # this a row of (a, NULL, b) and one of (a, b, NULL) would digest
-            # identically.
+            # Length-prefixed, so the encoding is injective. Joining fields
+            # with a separator is not: `paon="A|B", saon="C"` and
+            # `paon="A", saon="B|C"` are different properties that a delimiter
+            # join renders as the same string, and the digest then stops
+            # distinguishing them. A NULL gets its own marker for the same
+            # reason -- it is a distinct value, not an empty one.
             rendered = ", ".join(
-                f"coalesce(CAST({name} AS VARCHAR), '~NULL~')" for name in columns)
+                f"CASE WHEN {name} IS NULL THEN 'N:' ELSE concat("
+                f"  CAST(length(CAST({name} AS VARCHAR)) AS VARCHAR), ':', "
+                f"  CAST({name} AS VARCHAR)) END"
+                for name in columns)
             digests[year] = str(con.execute(
                 f"SELECT coalesce(md5(string_agg(row_text, chr(10) "
                 f"                              ORDER BY rn)), '') FROM ("
-                f"  SELECT file_row_number AS rn, concat_ws('|', {rendered}) "
+                f"  SELECT file_row_number AS rn, concat({rendered}) "
                 f"         AS row_text "
                 f"  FROM read_parquet({_quote(path)}, file_row_number=true))"
             ).fetchone()[0])
@@ -398,8 +458,11 @@ def validate_snapshot(declared: DeclaredSnapshot, *, source_coverage_end: date,
             detail = globals()[f"_gate_{name}"](declared, ctx)
             if name == "schema" and detail:
                 schema_failed = True
-            results.append(GateResult(name, "fail" if detail else "pass",
-                                      detail or ""))
+            if isinstance(detail, _Skip):
+                results.append(GateResult(name, "skipped", str(detail)))
+            else:
+                results.append(GateResult(name, "fail" if detail else "pass",
+                                          detail or ""))
         facts = {} if schema_failed else _facts(ctx, declared)
     finally:
         ctx.connection.close()

--- a/tools/ppd_snapshot/validate.py
+++ b/tools/ppd_snapshot/validate.py
@@ -1,0 +1,407 @@
+"""The gates a built snapshot must clear before anything is packaged from it.
+
+**These gates do not decide the snapshot is servable.** They check what the
+build declared against what it wrote. The merged runtime is the arbiter: digest
+and length verification, member-validated extraction, an exact Parquet-file
+count and a full file inventory, and then `SnapshotAdapter.open`, which runs its
+own schema, row-count and queryability validation before routing. Running the
+real thing end to end is part of acceptance for exactly that reason.
+
+What is checked here, and why each one exists rather than being assumed:
+
+* **schema** -- every partition on its own terms, against
+  `property_core.snapshot.schema.REQUIRED_COLUMNS`. Per file, never over the
+  union: the adapter's `union_by_name` fills a column one partition lacks with
+  NULLs, so a defective partition passes a combined check while contributing no
+  rows to any outcode search.
+* **partitions** -- exactly the expected years, one `data.parquet` each, and
+  nothing else in the tree.
+* **rows** -- the declared count, the union count and the sum of the parts all
+  agree.
+* **uniqueness** -- `transaction_id` is a key across the whole window.
+* **coverage** -- coverage is a *declaration about the source release*, not a
+  measurement of the rows. So the bounds are checked for being the intended
+  partition boundary and the release's declared end, and the data is checked for
+  falling *inside* them. `min(transfer_date) == coverage_from` is deliberately
+  NOT required: a window with no sale on its first day is normal, and demanding
+  it would make the declaration follow the data instead of the other way round.
+* **guarantee** -- the window still answers the largest request any surface
+  accepts (`months le=120`). This is what makes eleven partitions load-bearing.
+* **provisional** -- the boundary is the computed month and lies inside the
+  window, which is the precondition the adapter's coverage validation applies.
+* **ordering** -- each partition is in the declared logical order. Checked by
+  physical row number, not by trusting scan order.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from property_core.snapshot.schema import REQUIRED_COLUMNS, normalise_type
+
+from tools.ppd_snapshot.build import (
+    PARTITION_FILE,
+    expected_years,
+    coverage_start,
+    covers_maximum_request,
+    provisional_boundary,
+)
+
+#: The order gates run in. Data gates are skipped when the schema gate fails,
+#: because a query over a defective partition reports a defect of its own and
+#: would bury the real one.
+GATE_ORDER = ("partitions", "schema", "rows", "uniqueness", "coverage",
+              "guarantee", "provisional", "ordering")
+_DATA_GATES = frozenset({"rows", "uniqueness", "coverage", "ordering"})
+
+
+@dataclass(frozen=True)
+class GateFailure:
+    gate: str
+    detail: str
+
+    def __str__(self) -> str:  # pragma: no cover - operator output
+        return f"{self.gate}: {self.detail}"
+
+
+@dataclass(frozen=True)
+class GateResult:
+    name: str
+    #: "pass", "fail" or "skipped". A skipped gate is not a passing gate, and
+    #: the report refuses to call itself passed while one is present.
+    status: str
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    gates: tuple[GateResult, ...]
+    facts: dict[str, Any]
+
+    @property
+    def failures(self) -> tuple[GateFailure, ...]:
+        return tuple(GateFailure(g.name, g.detail)
+                     for g in self.gates if g.status == "fail")
+
+    @property
+    def skipped(self) -> tuple[str, ...]:
+        return tuple(g.name for g in self.gates if g.status == "skipped")
+
+    @property
+    def passed(self) -> bool:
+        return not self.failures and not self.skipped
+
+
+@dataclass(frozen=True)
+class DeclaredSnapshot:
+    """What the build says it produced. Every field here is a claim under test."""
+
+    directory: Path
+    coverage_from: date
+    coverage_to: date
+    provisional_from: date
+    rows: int
+    parquet_files: int
+
+    def replace(self, **changes: Any) -> "DeclaredSnapshot":
+        return dataclasses.replace(self, **changes)
+
+
+@dataclass
+class _Context:
+    """Everything the gates share, resolved once."""
+
+    files: dict[int, Path]
+    strays: tuple[str, ...]
+    today: date
+    source_coverage_end: date
+    connection: Any = None
+
+    def relative(self, path: Path, root: Path) -> str:
+        return path.relative_to(root).as_posix()
+
+
+def _quote(value: Any) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _scan(paths: Iterable[Path]) -> str:
+    listed = ", ".join(_quote(p) for p in paths)
+    return (f"read_parquet([{listed}], hive_partitioning=false, "
+            f"union_by_name=true)")
+
+
+def _discover(directory: Path) -> tuple[dict[int, Path], tuple[str, ...]]:
+    """Partition files by year, plus anything in the tree that is not one."""
+    files: dict[int, Path] = {}
+    strays: list[str] = []
+    for path in sorted(directory.rglob("*")):
+        if path.is_dir():
+            continue
+        relative = path.relative_to(directory)
+        parts = relative.parts
+        if (len(parts) == 2 and parts[0].startswith("year=")
+                and parts[1] == PARTITION_FILE):
+            try:
+                files[int(parts[0][len("year="):])] = path
+            except ValueError:
+                strays.append(relative.as_posix())
+            continue
+        strays.append(relative.as_posix())
+    return files, tuple(strays)
+
+
+# -- gates -------------------------------------------------------------------
+
+def _gate_partitions(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
+    expected = set(expected_years(declared.coverage_to))
+    found = set(ctx.files)
+    problems = []
+    if missing := sorted(expected - found):
+        problems.append(f"missing partition(s) for {missing}")
+    if extra := sorted(found - expected):
+        problems.append(f"unexpected partition(s) for {extra}")
+    if ctx.strays:
+        problems.append(f"files that are not partitions: {list(ctx.strays)}")
+    if declared.parquet_files != len(ctx.files):
+        problems.append(f"declared {declared.parquet_files} parquet file(s), "
+                        f"found {len(ctx.files)}")
+    return "; ".join(problems) or None
+
+
+def _gate_schema(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
+    problems = []
+    for year in sorted(ctx.files):
+        path = ctx.files[year]
+        name = ctx.relative(path, declared.directory)
+        try:
+            described = ctx.connection.execute(
+                f"DESCRIBE SELECT * FROM read_parquet({_quote(path)})").fetchall()
+        except Exception as exc:
+            problems.append(f"{name} is not readable: {type(exc).__name__}: {exc}")
+            continue
+        found = {str(r[0]): normalise_type(str(r[1])) for r in described}
+        for column, accepted in REQUIRED_COLUMNS.items():
+            if column not in found:
+                problems.append(f"{name} is missing required column {column!r}")
+            elif found[column] not in accepted:
+                problems.append(
+                    f"{name} column {column!r} has type {found[column]}, "
+                    f"expected one of {sorted(accepted)}")
+    return "; ".join(problems) or None
+
+
+def _gate_rows(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
+    total = int(ctx.connection.execute(
+        f"SELECT count(*) FROM {_scan(ctx.files.values())}").fetchone()[0])
+    parts = 0
+    for path in ctx.files.values():
+        parts += int(ctx.connection.execute(
+            f"SELECT count(*) FROM read_parquet({_quote(path)})").fetchone()[0])
+    problems = []
+    if declared.rows != total:
+        problems.append(f"declared {declared.rows} row(s), the snapshot holds {total}")
+    if parts != total:
+        problems.append(f"partitions sum to {parts} but the combined view "
+                        f"reports {total}")
+    return "; ".join(problems) or None
+
+
+def _gate_uniqueness(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
+    total, distinct, blank = ctx.connection.execute(
+        f"SELECT count(*), count(DISTINCT transaction_id), "
+        f"count(*) FILTER (WHERE transaction_id IS NULL OR transaction_id = '') "
+        f"FROM {_scan(ctx.files.values())}").fetchone()
+    problems = []
+    if int(blank):
+        problems.append(f"{int(blank)} row(s) carry no transaction_id")
+    if int(total) != int(distinct):
+        problems.append(f"{int(total)} row(s) carry only {int(distinct)} distinct "
+                        f"transaction_id(s)")
+    return "; ".join(problems) or None
+
+
+def _gate_coverage(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
+    problems = []
+    boundary = coverage_start(declared.coverage_to)
+    if declared.coverage_from != boundary:
+        problems.append(f"coverage_from {declared.coverage_from} is not the "
+                        f"partition boundary {boundary}")
+    if declared.coverage_to != ctx.source_coverage_end:
+        problems.append(f"coverage_to {declared.coverage_to} is not the source "
+                        f"release's declared end {ctx.source_coverage_end}")
+
+    outside = int(ctx.connection.execute(
+        f"SELECT count(*) FROM {_scan(ctx.files.values())} "
+        f"WHERE transfer_date IS NULL "
+        f"   OR transfer_date < DATE {_quote(declared.coverage_from)} "
+        f"   OR transfer_date > DATE {_quote(declared.coverage_to)}").fetchone()[0])
+    if outside:
+        problems.append(f"{outside} row(s) fall outside the declared window "
+                        f"{declared.coverage_from}..{declared.coverage_to}")
+
+    for year in sorted(ctx.files):
+        path = ctx.files[year]
+        misfiled = int(ctx.connection.execute(
+            f"SELECT count(*) FROM read_parquet({_quote(path)}) "
+            f"WHERE year IS DISTINCT FROM {year} "
+            f"   OR EXTRACT(year FROM transfer_date) IS DISTINCT FROM {year}"
+        ).fetchone()[0])
+        if misfiled:
+            problems.append(
+                f"{ctx.relative(path, declared.directory)} holds {misfiled} "
+                f"row(s) that are not from {year}")
+    return "; ".join(problems) or None
+
+
+def _gate_guarantee(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
+    if covers_maximum_request(declared.coverage_from, ctx.today):
+        return None
+    return (f"coverage_from {declared.coverage_from} does not reach back 120 "
+            f"months from {ctx.today}; the largest permitted request would fall "
+            f"outside the window")
+
+
+def _gate_provisional(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
+    expected = provisional_boundary(declared.coverage_to)
+    problems = []
+    if declared.provisional_from != expected:
+        problems.append(f"provisional_from {declared.provisional_from} is not "
+                        f"the computed boundary {expected}")
+    if not (declared.coverage_from <= declared.provisional_from
+            <= declared.coverage_to):
+        problems.append(f"provisional_from {declared.provisional_from} is "
+                        f"outside coverage {declared.coverage_from}.."
+                        f"{declared.coverage_to}")
+    return "; ".join(problems) or None
+
+
+def _gate_ordering(declared: DeclaredSnapshot, ctx: _Context) -> Optional[str]:
+    """`transfer_date DESC, transaction_id ASC`, checked by physical position.
+
+    `file_row_number` is the file's own row order, so this does not depend on
+    the scan happening to return rows in storage order.
+    """
+    problems = []
+    for year in sorted(ctx.files):
+        path = ctx.files[year]
+        inversions = int(ctx.connection.execute(
+            f"WITH ordered AS (SELECT file_row_number AS rn, transfer_date, "
+            f"                        transaction_id "
+            f"                 FROM read_parquet({_quote(path)}, "
+            f"                                   file_row_number=true)) "
+            f"SELECT count(*) FROM ordered a JOIN ordered b ON b.rn = a.rn + 1 "
+            f"WHERE b.transfer_date > a.transfer_date "
+            f"   OR (b.transfer_date = a.transfer_date "
+            f"       AND b.transaction_id < a.transaction_id)").fetchone()[0])
+        if inversions:
+            problems.append(
+                f"{ctx.relative(path, declared.directory)} has {inversions} "
+                f"row(s) out of transfer_date DESC, transaction_id ASC order")
+    return "; ".join(problems) or None
+
+
+# -- runner ------------------------------------------------------------------
+
+def content_digests(directory: Path | str,
+                    connection: Any = None) -> dict[str, str]:
+    """An order-sensitive digest of each partition's contents.
+
+    This is how a rebuild is compared with the build before it. It is
+    deliberately **logical**, not byte-level: whether DuckDB 1.5.5 writes
+    byte-identical Parquet for identical input is a property of the writer that
+    has not been established here, and asserting it would be testing an
+    assumption. What matters to a reader of the snapshot is that the same source
+    yields the same rows, with the same values, in the same order -- which this
+    detects, and which a byte comparison would conflate with compressor detail.
+    """
+    import duckdb
+
+    directory = Path(directory)
+    con = connection or duckdb.connect()
+    try:
+        digests: dict[str, str] = {}
+        for path in sorted(directory.glob(f"year=*/{PARTITION_FILE}")):
+            year = path.parent.name[len("year="):]
+            columns = [str(row[0]) for row in con.execute(
+                f"DESCRIBE SELECT * FROM read_parquet({_quote(path)})").fetchall()]
+            # NULL is rendered explicitly: `concat_ws` skips NULLs, so without
+            # this a row of (a, NULL, b) and one of (a, b, NULL) would digest
+            # identically.
+            rendered = ", ".join(
+                f"coalesce(CAST({name} AS VARCHAR), '~NULL~')" for name in columns)
+            digests[year] = str(con.execute(
+                f"SELECT coalesce(md5(string_agg(row_text, chr(10) "
+                f"                              ORDER BY rn)), '') FROM ("
+                f"  SELECT file_row_number AS rn, concat_ws('|', {rendered}) "
+                f"         AS row_text "
+                f"  FROM read_parquet({_quote(path)}, file_row_number=true))"
+            ).fetchone()[0])
+        return digests
+    finally:
+        if connection is None:
+            con.close()
+
+
+def _facts(ctx: _Context, declared: DeclaredSnapshot) -> dict[str, Any]:
+    if ctx.connection is None or not ctx.files:
+        return {}
+    row = ctx.connection.execute(
+        f"SELECT count(*), count(DISTINCT transaction_id), min(transfer_date), "
+        f"max(transfer_date) FROM {_scan(ctx.files.values())}").fetchone()
+    per_year = {}
+    for year in sorted(ctx.files):
+        per_year[str(year)] = int(ctx.connection.execute(
+            f"SELECT count(*) FROM read_parquet({_quote(ctx.files[year])})"
+        ).fetchone()[0])
+    return {
+        "rows": int(row[0]),
+        "distinct_transaction_ids": int(row[1]),
+        "earliest_transfer_date": str(row[2]) if row[2] else None,
+        "latest_transfer_date": str(row[3]) if row[3] else None,
+        "rows_per_year": per_year,
+        "bytes_on_disk": sum(p.stat().st_size for p in ctx.files.values()),
+        "content_digest_per_year": content_digests(declared.directory,
+                                                   ctx.connection),
+    }
+
+
+def validate_snapshot(declared: DeclaredSnapshot, *, source_coverage_end: date,
+                      today: date) -> ValidationReport:
+    """Run every gate and report each one's result.
+
+    All gates run, rather than stopping at the first failure: an operator fixing
+    a build wants the whole picture, and a report that stops early hides how bad
+    the artifact is.
+    """
+    import duckdb
+
+    directory = Path(declared.directory)
+    files, strays = _discover(directory)
+    ctx = _Context(files=files, strays=strays, today=today,
+                   source_coverage_end=source_coverage_end)
+
+    results: list[GateResult] = []
+    ctx.connection = duckdb.connect()
+    try:
+        schema_failed = False
+        for name in GATE_ORDER:
+            if name in _DATA_GATES and (schema_failed or not files):
+                results.append(GateResult(
+                    name, "skipped",
+                    "not run: the partitions did not pass the schema gate"))
+                continue
+            detail = globals()[f"_gate_{name}"](declared, ctx)
+            if name == "schema" and detail:
+                schema_failed = True
+            results.append(GateResult(name, "fail" if detail else "pass",
+                                      detail or ""))
+        facts = {} if schema_failed else _facts(ctx, declared)
+    finally:
+        ctx.connection.close()
+
+    return ValidationReport(gates=tuple(results), facts=facts)


### PR DESCRIPTION
PR 5 of the PPD snapshot programme, against the frozen specification at
`docs/design/ppd-source-routing.md` rev 6 (§1.1–1.3, §4.8, §4.9, §10 item 5).

Builds the eleven year-only Parquet partitions from `pp-complete.csv`, publishes
the immutable manifest the merged runtime requires, and proves the artifact by
booting it through that runtime rather than by marking its own work.

## Scope — local build and validation only

`tools/ppd_snapshot/` is deliberately outside the published wheel: the pipeline
needs DuckDB and a 5.5 GB CSV, and no library consumer should carry either.
Verified by building the wheel — same four packages (`property_core`, `app`,
`property_cli`, `property_app`), same version `1.14.2`.

**Explicitly excluded, per §4.8:** no upload, bucket, cloud resource, Fly
command, secret, Dockerfile change, deployment config, feature-flag change,
release or version bump, and no production mutation of any kind. `--dist` is a
directory on this machine; `current.json` is written beside the manifest only so
the boot path can be exercised offline through `LocalDirectorySource`.
**Artifact distribution — where a bundle is hosted and how a deployed app reaches
it — remains a separately approved decision and is not settled here.**

Also not in this PR: G1/G2/G3, the shadow corpus (PR 6), and the rollout.
`PPD_SNAPSHOT_ENABLED` is untouched and remains off; the diff against `main` for
`property_core/`, `app/`, `property_cli/`, `property_app/`, `pyproject.toml`,
both Dockerfiles and both fly configs is empty.

## Real build measurements

From two full local builds on 2026-08-28 against the HM Land Registry release
fetched 2026-08-27. No network during the build; nothing deployed.

| | |
|---|---|
| Source | `pp-complete.csv`, 5,494,145,759 bytes, sha256 `b643c0ff…4031d0` |
| Declared coverage | `2016-01-01` … `2026-06-30`, `provisional_from` `2026-03-01` |
| Source rows | 31,430,611 |
| **Rows in the eleven-year window** | **10,394,935** |
| **Distinct `transaction_id`** | **10,394,935** — equal, so the key holds |
| Eligible source rows (counted from the source, independently) | 10,394,935 — nothing lost between reading and writing |
| Rows with a malformed required value | 0 |
| Non-canonical prices, whole file | 0 of 31,430,611 |
| Partitions | 11 (`year=2016` … `year=2026`), 267.9 MiB Parquet |
| **Bundle** | 279,109,872 B (**266.2 MiB**), sha256 `50f802b2…9072c` |
| Extracted by the runtime | 280,925,271 B (267.9 MiB) |
| Build | ingest 44.6 s · derive 13.5 s · write 8.7 s |
| Whole pipeline | 82 s wall clock, peak RSS 2,912 MB at `--memory 2GB` |
| DuckDB | v1.5.5 |

Two independent builds produced byte-identical Parquet files and a
byte-identical bundle, and identical logical content digests. **Observed twice
on one machine, not a guarantee** — nothing here establishes that DuckDB or zstd
promise byte-reproducible output, so the pipeline depends on the logical content
digest (same rows, same values, same order), not on that.

### The 266.2 MiB finding — recorded, not acted on

§1.1 sizes eleven partitions at **214 MiB**. That figure is a **year+area**
measurement, while §1.2 mandates **year-only**, which the same Phase 3 run
measured at **+22%**. The real year-only bundle is **266.2 MiB (+24.4%)**, which
moves two numbers the rollout depends on:

| | Spec §1.1 / §4.7 | Measured |
|---|---|---|
| Bundle size | 214 MiB | **266.2 MiB** |
| Download @100 Mbit/s | 18.0 s | **~22.3 s** |
| Peak transient boot disk | ~444 MiB implied | **~534 MiB** (bundle and extraction both live until the bundle is unlinked) |
| §4.7 free-space precondition (`bundle_bytes × 2.5`) | ~535 MiB | **665.4 MiB** |

These are **inputs to G1, not a G1 result**. The specification is frozen and is
not edited by this PR; correcting its sizing table is a decision round that
belongs before G1. `MAX_BUNDLE_BYTES` (1 GiB) is unaffected.

## Runtime READY and real-adapter validation

The gates below check what the build declared against what it wrote. They are
not what makes the artifact servable — the merged runtime is:
`SnapshotRuntime` streams and digest-verifies the bundle, extracts it with
member validation, checks the exact Parquet-file count and the full file
inventory, and activates atomically; then `SnapshotAdapter.open` runs its own
schema, row-count and queryability validation before it will answer anything.

The real build **booted READY in 1.4 s and validated through the real adapter**
(`coverage_from` `2016-01-01`, `coverage_to` `2026-06-30`, `provisional_from`
`2026-03-01`). `all` exits non-zero unless that happens, and nothing is promoted
otherwise. (The 1.4 s is from a local directory source: it contains no transfer
and is not a readiness-target measurement — only G1 can produce that.)

Gates: `partitions`, `schema` (per file, never over the union), `required_values`,
`rows`, `reconciliation`, `uniqueness`, `coverage`, `guarantee`, `provisional`,
`ordering`. A skipped gate is reported as skipped and never counted as a pass.

**Coverage is a declaration about the source release, not a measurement of the
rows.** The bounds must be the intended partition boundary and the end the bound
release's publication date implies, and every row must fall inside them.
`min(transfer_date) == coverage_from` is deliberately not required, and
`build`/`all` accept no way to override the expected end.

## Source receipt and transactional recovery

Every gate downstream checks the snapshot against itself, so an internally
consistent snapshot of the wrong file passes all of them. The receipt is the
binding, and it refuses in four directions:

- **file vs recorded download** — minting requires the SHA-256 captured when the
  release was fetched; length agreement alone lets same-length bytes through;
- **file vs release** — the file's length must be the length the release declares;
- **file vs receipt** — every build recomputes digest and length, so a file
  edited since is refused, including an edit that preserves length;
- **receipt vs latest observation** — a moved `ETag`/`Last-Modified` means the
  file on disk is a previous release, and the build refuses.

A missing receipt is a refusal, not a default, on both `build` and `all`. The
intended way to obtain one is `download`, which streams the release and takes
bytes, digest and validators from a single response; `receipt --expected-sha256`
is the weaker path for a file already on disk, and the receipt records which was
used.

**Recovery guarantees.** The CSV and its receipt are one fact in two files, so
the commit is an explicit transaction (`staged` → `backed_up` →
`dest_published` → `published`):

- a failed transfer, a failed receipt write or a failed rename leaves the
  previous CSV **and** receipt byte-for-byte intact, with no staging files left;
- the renamed-aside backup is removed at exactly two points — after publication,
  and after a restoration confirmed to have worked;
- if the rollback itself fails the backup is **retained** and its path reported
  (`download` exits 3), because it is then the only copy of the previous release.

Promotion is equally deliberate: candidates are assembled outside `dist`, booted
from there, and promoted only on READY; device IDs are compared before anything
moves and a cross-filesystem layout is refused (a `shutil.move` fallback would
silently copy 266 MiB, breaking the transient-disk and timing model G1 is
measured against); `current.json` is replaced last and atomically. Every
document the pipeline replaces goes through one sibling-and-rename helper.

The release check is a `HEAD` on the **official HTTPS endpoint**
(`https://price-paid-data.publicdata.landregistry.gov.uk/pp-complete.csv`, per
the GOV.UK single-file page) rather than the plaintext S3 website endpoint,
where the validators the receipt binds to would themselves be tamperable. **No
real request was made to that host in this work** — the release check and the
downloader are exercised against a loopback server and a recording opener.

## Tests

**1,486 passed / 26 skipped on Python 3.11 and on Python 3.12**, both with
`--extra snapshot`. 130 of those are this pipeline's own, written red-first,
each gate with a targeted corrupt-artifact fixture and the load-bearing gates
additionally mutation-checked — with that one gate neutralised the same artifact
passes, which is what proves the gate is what rejects it.

Worth flagging for reviewers: without `--extra snapshot` the ~200 tests under
`tests/snapshot/` **skip** rather than fail (`importorskip`, pre-existing since
PR 3/4), so a green run said nothing about them. The test command in `CLAUDE.md`
now includes the extra and says why.

## The real artifact was not rebuilt

Later rounds tightened the source predicates (fail-closed on malformed required
values, canonical-integer prices) and changed packaging layout, atomicity and
recovery. None of it alters the derivation or the written columns, and this was
**measured rather than assumed**: the shipped predicates were re-run over the
real 5.5 GB CSV and found **zero** malformed required values, **zero**
non-canonical prices in all 31,430,611 rows, and an eligible source count of
**10,394,935** — exactly the published row count. Valid output bytes and the
measured size are unchanged, so the 5.5 GB build was not re-run.

The grounded receipt was also minted against the real file: its computed digest
matches `b643c0ff…4031d0`, the checksum recorded at the 2026-08-27 fetch, under
ETag `"333695120b…-655"`.

---

**Held for review. Not to be merged**, and PR 6, rebuilds, uploads, image or
flag changes and any Fly/cloud work are out of scope for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
