### PR TITLE
docs(ppd): correct the rollout premises to what was measured (spec rev 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased — v1.15.0 (pending): PPD snapshot source routing + live-path correctness containment
 
-Not released. No version bump. Four PRs against the frozen design in
-`docs/design/ppd-source-routing.md`.
+Not released. No version bump. **Five** PRs against the design in
+`docs/design/ppd-source-routing.md`, now at rev 7.
 
 **`PPD_SNAPSHOT_ENABLED` is off by default, and nothing about the deployed
 behaviour changes while it stays off.** With no snapshot materialized every PPD
@@ -310,13 +310,15 @@ coverage take effect only once a snapshot is enabled and materialized.
   neither production image installs the `snapshot` extra yet — which G3 requires
   **before** the flag may be enabled. The build pipeline produces a bundle on a
   workstation and stops there; where one would be hosted is separately approved.
-- **A measurement the rollout needs, recorded rather than acted on:** the real
-  eleven-partition **year-only** bundle is **266.2 MiB**, not the 214 MiB §1.1
-  estimates — that figure is a year+area measurement, while §1.2 mandates
-  year-only, which the same Phase 3 run measured at +22%. This moves §1.1's
-  download estimate and the G1 transient-disk budget. The specification is frozen
-  and is not edited here; correcting its sizing table is a decision round that
-  belongs before G1.
+- **A measurement the rollout needs:** the real eleven-partition **year-only**
+  bundle is **266.2 MiB**, not the 214 MiB §1.1 previously estimated — that figure is a
+  year+area measurement, while §1.2 mandates year-only, which the same Phase 3
+  run measured at +22%. **Corrected in specification rev 7** by the
+  rollout-premise decision round: §1.1 now publishes the measured 266.2 MiB with
+  22.3 s labelled as calculated, G1 is split into G1a (`property-shared`, 2 GB)
+  and G1b (`propertydata`, 512 MB), and G3's ordering clause is replaced with the
+  deploy-and-observe invariant. No gate is relaxed, no image or flag is touched,
+  and nothing is enabled.
 
 
 ## v1.14.2 (2026-08-26) — MCP server card version; inferred-GBP warning ordering

--- a/docs/design/ppd-source-routing.md
+++ b/docs/design/ppd-source-routing.md
@@ -1,7 +1,16 @@
-# PPD source-routing and implementation specification (rev 6 — FROZEN)
+# PPD source-routing and implementation specification (rev 7 — FROZEN)
 
-**Status:** **FROZEN at rev 6.** Accepted. No further architecture work. Changes
+**Status:** **FROZEN at rev 7.** Accepted. No further architecture work. Changes
 to this document require a new decision round, not an edit in passing.
+
+**Revision 7** was authorised by the rollout-premise decision round, after
+PR 5 produced and measured a real artifact. It corrects the §1.1 sizing baseline
+against measured bytes, separates measurements from calculations, splits G1 into
+the per-target gates G1a and G1b, replaces G3's now-impossible "before routing is
+introduced" ordering with a satisfiable deploy-and-observe invariant, updates the
+implementation status to PRs 1-5, and removes Fly-Volume language from §7.2. **No
+requirement is relaxed:** the 30 s readiness target, the `bundle_bytes * 2.5`
+headroom rule and every Stage 1 exit criterion are unchanged.
 
 **Revision 6** was authorised by the PR 4 review, which found that §2.5 checked
 only the lower coverage bound. It adds the disjoint and extends-past cases, the
@@ -22,10 +31,17 @@ wiring per section 4.10; coverage routing and the bounded existence probe of
 sections 2.4-2.5; live fallback on every typed snapshot failure; and response
 wiring of the provenance block across all four consumers.
 
-**Still unimplemented:** the build pipeline (PR 5), the fixed shadow corpus
-(PR 6), and rollout gates G1-G3 (PR 7) with the staged enablement that follows.
-`PPD_SNAPSHOT_ENABLED` remains off, neither production image installs the
-`snapshot` extra, and no request is served from a snapshot in production.
+By **PR 5**: the local build and validation pipeline of section 4.8 — build,
+gates, packaging, source receipt, boot check and atomic promotion — local only,
+with no upload, image, deployment or flag surface touched.
+
+**Still unimplemented or unperformed:** artifact distribution and the Royal Mail
+review that gates it (§6); the dependency-only image rollout; real completion of
+G1a, G1b, G2 and G3; the fixed shadow corpus and its local rehearsal; the Stage 1
+production shadow; snapshot enablement at any stage; and the v1.15 release.
+`PPD_SNAPSHOT_ENABLED` remains off in all checked-in configuration, neither
+production image installs the `snapshot` extra, and no request is served from a
+snapshot in production.
 
 **Deliberately not implemented, and not deferred by omission:** auto-escalation
 stays disabled on both sources. The snapshot adapter does supply the
@@ -69,14 +85,26 @@ not from a year boundary:
 Ten calendar-year partitions would silently under-serve a legal 120-month request
 for most of the year. **The snapshot retains the last 11 calendar-year partitions.**
 
-| Partitions | Years | Size | Download @100 Mbit/s |
+| Partitions | Years | Size | Transfer @100 Mbit/s |
 |---|---|---|---|
-| 10 | 2017–2026 | 193 MiB | 16.2 s |
-| **11** | **2016–2026** | **214 MiB** | **18.0 s** |
-| 12 | 2015–2026 | 244 MiB | 20.4 s |
+| 10 | 2017–2026 | 193 MiB — **estimated** (year+area basis) | 16.2 s — **calculated from that estimate** |
+| **11** | **2016–2026** | **266.2 MiB — measured (year-only)** | **22.3 s — calculated from the measurement** |
+| 12 | 2015–2026 | 244 MiB — **estimated** (year+area basis) | 20.4 s — **calculated from that estimate** |
 
-18.0 s transfer leaves ~12 s inside the 30 s readiness target; Phase 3 measured
-extract+probe at 2.0 s on a 4.4x larger bundle.
+**The eleven-partition row is the only measured row.** 279,109,872 bytes
+(266.2 MiB), from two independent local builds on 2026-08-28 that produced a
+byte-identical bundle (`docs/ops/ppd-snapshot-build.md`).
+An earlier revision published 214 MiB here — a superseded year+area measurement
+applied to a year-only layout, when §1.2 mandates year-only and the same Phase 3
+run measured that layout at +22%. The 10- and 12-partition rows remain year+area
+**estimates**, retained only for shape; their transfer times are calculated from
+those estimates and are therefore doubly derived.
+
+**22.3 s is arithmetic, not a measurement**: 279,109,872 × 8 / 1e8, assuming full
+link utilisation and zero protocol overhead. It leaves ~7.7 s inside the 30 s
+readiness target — down from the ~12 s the superseded figure implied. No real
+transfer has been timed on either Machine; only G1a/G1b can produce one. Phase 3
+measured extract+probe at 2.0 s on a 3.55x larger bundle (945.5 MiB).
 
 The published guarantee is **`from_date >= coverage_from`**, never "10 years".
 
@@ -578,7 +606,8 @@ one undifferentiated label.
 * Bundle **streamed** to a temp file in 1 MiB chunks, SHA-256 incremental. **The
   body is never held in memory** — verified at scale: a 945.5 MiB bundle booted at
   199.5 MB peak RSS.
-* Limits: `MAX_BUNDLE_BYTES` **1 GiB** (~4.8x margin over 214 MiB); socket
+* Limits: `MAX_BUNDLE_BYTES` **1 GiB** (~3.8x margin over the measured
+  266.2 MiB bundle); socket
   timeout **10 s**; total download deadline **300 s**; stall detection
   **60 s**. Any breach aborts and deletes the temp file. Both time budgets are
   checked after **every** read, the one returning EOF included — checking only
@@ -688,7 +717,8 @@ version identify several different snapshots.
 ### 4.6 Process-safe single-flight
 Exclusive `flock()` on `<cache>/.boot.lock` held across download → verify →
 extract → activate. A worker that cannot acquire it **blocks** (bounded by
-`LOCK_WAIT_SECONDS`, default 420 s), then re-reads `CURRENT` and activates from
+`property_core.snapshot.lock.DEFAULT_TIMEOUT`, default 420 s), then re-reads
+`CURRENT` and activates from
 cache with **no download**. The lock file records a PID for diagnosis only:
 `flock` is released by the kernel when its holder dies, so there is no stale lock
 to break, no `LOCK_STALE_SECONDS`, and no PID consulted to decide whether the
@@ -976,7 +1006,8 @@ be vacuous or need a premature stub:
 34. Concurrent startup single-flight: N workers, cold cache → exactly **one**
     download; others activate from cache.
 35. Cached restart performs **zero** additional download.
-36. Cleanup retains exactly current + previous.
+36. Cleanup retains exactly the active version; no previous version survives
+    (§4.7).
 37. Insufficient disk → typed failure before download begins.
 38. Stale verified snapshot is served rather than going unready;
     `freshness_days > 45` emits a warning.
@@ -1012,19 +1043,62 @@ explanation, not a similarity score.
 
 The corpus is agreed before Stage 1 begins and is fixed for the duration.
 
+**A local rehearsal is not Stage 1.** Exercising the fixed corpus against an
+already-verified local artifact validates routing, coverage handling and
+divergence classification. It produces no real-traffic sample, so it **cannot
+satisfy** the p95 criterion or the divergence exit criteria, and must never be
+recorded as a Stage 1 result. Consistent with the rule above, live SPARQL is
+diagnostic, not the numerical gold standard; any new live SPARQL call is a
+separately authorised action.
+
 **Stage 2 — opt-in. Hard deployment gates, measured before the flag is enabled.**
 
 The two facts Phase 3 could not evidence are now **blocking gates**, not caveats:
 
-* **G1 — transient boot disk measured on the real 512 MB Fly app.** Measure peak
-  transient disk for the **11-partition** bundle (~214 MiB streamed + ~230 MiB
-  extracted, both live until the atomic rename) on the actual machine. The
-  measurement must be taken, recorded, and fit within the machine's volume with
-  the §4.7 `bundle_bytes * 2.5` headroom rule satisfied.
+* **G1a — transient boot behaviour measured on `property-shared`, the 2 GB-RAM
+  Stage 2 target.** On that app's actual image and Machine, measure: peak
+  transient disk during materialization; the overlap window in which the bundle
+  and its extraction are both live; wall-clock transfer time; and time to
+  readiness. The materialization is on Fly's **default ephemeral rootfs** —
+  neither app declares a Volume or `persist_rootfs` (§4.5) — so the constraint is
+  free rootfs bytes, not volume capacity, and it must be observed on the Machine
+  rather than assumed. **Where the materialization root resolves
+  (`PPD_SNAPSHOT_CACHE_DIR`, default `/tmp/ppd-snapshot`) must first be
+  established as disk-backed rather than tmpfs-backed**, or the disk and RAM
+  figures mean different things than they appear to. The §4.7
+  `bundle_bytes * 2.5` free-space precondition must hold against the real
+  measured bundle. The 30 s readiness target is unchanged.
+
+  **Calculated inputs, to be confirmed or refuted by the measurement — never
+  reported as its result:** ~534.1 MiB simultaneous bundle-plus-extracted payload
+  (266.2 + 267.9, arithmetic only; excludes staging directories, per-attempt
+  temporary files and filesystem overhead); ~665.4 MiB preflight threshold
+  (`bundle_bytes * 2.5`); ~22.3 s transfer at a nominal 100 Mbit/s. **None of
+  these is a measured peak.**
+
+* **G1b — the same measurement on `propertydata`, the 512 MB-RAM Stage 3
+  target**, on its own image and Machine, likewise on ephemeral rootfs.
+
+  **Both gates test ephemeral-rootfs disk behaviour; RAM size is a separate
+  constraint measured alongside it.** The two targets differ in RAM, image,
+  entrypoint and health-check grace period (60 s against 30 s), so no result
+  transfers between them. **Passing G1a authorises neither `propertydata` nor
+  Stage 3.** Stage 2 requires G1a; Stage 3 requires G1b.
 * **G2 — worker count verified, or one worker explicitly pinned.** All Phase 2/3
   RSS figures are a single uvicorn process. Either verify the deployed worker
   count and re-derive the RSS budget for that count, **or** explicitly pin the
-  app to one worker and record that as a deployment constraint.
+  app to one worker and record that as a deployment constraint. Verification is
+  read-only; **pinning is a deployment mutation with its own authorisation.**
+
+  **Open, and blocking G2 if the deployed count exceeds one:** boot runs inside
+  the lifespan and therefore blocks startup, a worker waiting on the §4.6
+  single-flight lock can block for up to 420 s, and the Fly health-check grace
+  periods are 60 s (`property-shared`) and 30 s (`propertydata`). Those three
+  numbers are not reconciled anywhere. At one worker per Machine the lock never
+  contends and the question is moot; above one it must be answered before the
+  flag is enabled. **Rev 7 records this and deliberately does not resolve it** —
+  a resolution needs deployment evidence or a new operational policy, neither of
+  which a documentation correction may invent.
 
 * **G3 — the snapshot extra is installed in both production images, and proven
   to be.** The boot runtime imports `duckdb` and `zstandard`, which live only in
@@ -1036,9 +1110,14 @@ The two facts Phase 3 could not evidence are now **blocking gates**, not caveats
 
   G3 passes only when all four hold:
 
-  1. **Both production Dockerfiles install `--extra snapshot` unconditionally**,
-     landed *before* routing is introduced — not alongside it, so the dependency
-     change can be deployed and observed on its own.
+  1. **Both production Dockerfiles install `--extra snapshot` unconditionally.**
+     **The dependency-only image change must land, deploy and be observed with
+     `PPD_SNAPSHOT_ENABLED` off before any snapshot enablement.** An earlier
+     revision required this *before routing is introduced*; routing merged in
+     PR 4, so that ordering can no longer be satisfied by any future action and
+     was replaced rather than quietly dropped. The intent it protected is kept
+     in full: the dependency change ships and is observed on its own, carrying
+     no behavioural change with it.
   2. **Built-image smoke tests import both `duckdb` and `zstandard`** in the
      actual built image. Reading the Dockerfile is not evidence that the wheel
      resolved, installed and imports on that platform.
@@ -1046,8 +1125,9 @@ The two facts Phase 3 could not evidence are now **blocking gates**, not caveats
      raises the typed `snapshot_extra_missing` error, snapshot readiness stays
      **false**, and the live source continues to serve. A missing optional
      dependency must never take the service down or silently half-enable it.
-  4. **The production flag is not enabled until those image checks, G1 and G2
-     all pass.**
+  4. **The production flag is not enabled until those image checks, G2, and the
+     G1 gate for the target being enabled, all pass** — G1a for Stage 2 on
+     `property-shared`, G1b for Stage 3 on `propertydata`.
 
   **What the repository test does NOT cover.** `tests/snapshot/test_rollout_prerequisites.py`
   is a **repository-config lint**, not enforcement of G3. It reads the checked-in
@@ -1062,9 +1142,10 @@ The two facts Phase 3 could not evidence are now **blocking gates**, not caveats
 **If any gate fails or cannot be measured, stop before enabling the flag.**
 No estimate substitutes for the measurement.
 
-Once both pass: enable for `comps`/`yield`/`report`/`blocks` on `property-shared`
-only; live adapter as automatic fallback on typed snapshot errors. Monitor
-`source` distribution and warning rates.
+Once G1a, G2 and G3 all pass: enable for `comps`/`yield`/`report`/`blocks` on
+`property-shared` only; live adapter as automatic fallback on typed snapshot
+errors. Monitor `source` distribution and warning rates. **Stage 3 additionally
+requires G1b.**
 
 **Stage 3 — default on**, both images. Live retained as fallback and as the sole
 path for exact-ID, address-search and subject-property lookups.
@@ -1130,8 +1211,9 @@ Hot refresh while serving; cross-machine fetch coordination; incremental/delta
 snapshot updates; a separate full-history service (**O6** — deep history is not a
 current product requirement); aligning the 60/120-month limits (**O5**); any bulk
 or address export (§6). Untested and therefore unclaimed: real Tigris latency or
-reliability; behaviour on a real 512 MB Fly machine, especially transient boot
-disk; concurrency beyond 2 simultaneous queries; soak testing; multi-worker RSS
+reliability; behaviour on either real Fly Machine — `property-shared` (2 GB) or
+`propertydata` (512 MB) — especially transient boot disk on ephemeral rootfs;
+concurrency beyond 2 simultaneous queries; soak testing; multi-worker RSS
 totals — all Phase 2/3 figures are a single uvicorn process.
 
 ---
@@ -1156,15 +1238,19 @@ learns more is not available and must not be worked around with
 
 Then, each separately authorised:
 
-5. **Build pipeline** — 11-partition year-only build, manifest with
-   `provisional_from`, daily release check, monthly rebuild.
+5. **Build pipeline** — *merged (PR 5).* 11-partition year-only build, manifest
+   with `provisional_from`, daily release check, monthly rebuild.
    **Local build and validation only. No upload, bucket, Fly secret, cloud
-   resource or production mutation** (§4.8). Artifact distribution is a separate
-   approval.
-6. **Fixed shadow corpus**, agreed before Stage 1 and frozen for its duration.
-7. **Rollout gates** — G1 (measured transient disk on the real 512 MB Fly app for
-   the 11-partition bundle) and G2 (verified worker count, or one worker pinned).
-   **Either failing stops the rollout before the flag is enabled.**
+   resource or production mutation** (§4.8). Artifact distribution remains a
+   separate approval, still outstanding.
+6. **Fixed shadow corpus**, agreed before Stage 1 and frozen for its duration. A
+   local rehearsal of that corpus against an already-verified artifact is a
+   correctness exercise only: it **cannot satisfy** Stage 1's real-traffic p95 or
+   divergence exit criteria.
+7. **Rollout gates** — G1a (`property-shared`, 2 GB), G1b (`propertydata`,
+   512 MB), G2 (verified worker count, or one worker pinned) and G3
+   (dependency-only images landed, deployed and observed with the flag off).
+   **Any of them failing stops the rollout before the flag is enabled.**
 8. **Stage 2 opt-in**, then **Stage 3 default on**.
 
 PR 2 is the only PR in this sequence that changes behaviour, and it does so

--- a/docs/ops/ppd-snapshot-build.md
+++ b/docs/ops/ppd-snapshot-build.md
@@ -159,9 +159,10 @@ through the real runtime from there, and promoted only on `READY`.
 enforced rather than advised: promotion compares their device IDs and refuses
 before moving anything if they differ. `os.replace` cannot cross devices and
 `shutil.move` silently degrades to a copy — not atomic, and it doubles both the
-transient disk and the wall time the G1 model was measured against, while
+transient disk and the wall time the G1a/G1b model is derived from, while
 leaving a window where a half-copied bundle sits in the publishing directory.
-Promotion is `os.replace` throughout, never a copy.
+That model is derived, not measured: no wall time has been observed on either
+Machine. Promotion is `os.replace` throughout, never a copy.
 
 Promotion moves the bundle, then the manifest, then the report, and replaces
 `current.json` **last and atomically** (write a unique sibling, then rename). A pointer is
@@ -329,32 +330,42 @@ depend on it: what it checks is the *logical* content digest — same rows, same
 values, same order, per partition — which is a property of the build rather than
 of the writer.
 
-### What this means for G1
+### What this means for G1a and G1b
 
-| | Specification §1.1 / §4.7 | Measured |
-|---|---|---|
-| Bundle size | 214 MiB | **266.2 MiB** (+24.4%) |
-| Download @100 Mbit/s | 18.0 s | **~22.3 s** |
-| Peak transient boot disk | ~444 MiB implied | **~534.1 MiB** (bundle and extraction both live until the bundle is unlinked) |
-| §4.7 free-space precondition (`bundle_bytes * 2.5`) | ~535 MiB | **665.4 MiB** |
+| | Superseded §1.1 / §4.7 baseline | Now | Class |
+|---|---|---|---|
+| Bundle size | 214 MiB (year+area) | **266.2 MiB** (+24.4%) | **measured** — 279,109,872 B |
+| Extracted | ~230 MiB implied | **267.9 MiB** | **measured** — 280,925,271 B |
+| Transfer @100 Mbit/s | 18.0 s | ~22.3 s | *calculated* — bytes × 8 / 1e8 |
+| Simultaneous bundle + extracted payload | ~444 MiB implied | ~534.1 MiB | *calculated* — 266.2 + 267.9, arithmetic only |
+| §4.7 free-space precondition (`bundle_bytes * 2.5`) | ~535 MiB | ~665.4 MiB | *calculated* — policy constant × measured bytes |
 
-These are inputs to G1, not a G1 result: G1 is a measurement on the real 512 MB
-Fly machine and is **not** part of this work.
+**Only the first two rows are measurements.** The remaining three are arithmetic
+over them, and are stated as inputs rather than results. In particular
+~534.1 MiB is **not** a measured peak disk figure: it is a sum that ignores
+staging directories, per-attempt temporary files and filesystem overhead, and no
+overlap has been observed on any machine.
 
-## Known correction required before G1
+These are inputs to G1a/G1b, not their outcome. **G1a** measures actual
+allocation, extraction overlap, transfer and readiness on `property-shared`
+(2 GB RAM, ephemeral rootfs); **G1b** repeats it on `propertydata` (512 MB RAM,
+ephemeral rootfs). Neither app declares a Fly Volume. Passing G1a authorises
+neither `propertydata` nor Stage 3. Neither gate is part of this work.
 
-§1.1 of the frozen specification sizes eleven partitions at **214 MiB**. That
-figure is a **year+area** measurement, while §1.2 mandates **year-only**, which
-the same Phase 3 run measured at **+22%**. The real year-only bundle is
-materially larger (see the table above), which moves two numbers the rollout
-depends on:
+## Sizing correction — applied in specification rev 7
 
-* the §1.1 download estimate (18.0 s @100 Mbit/s) understates transfer time, and
-  therefore overstates the headroom inside the 30 s readiness target; and
-* **G1** — transient boot disk on the 512 MB Fly app — must be measured against
-  the real bundle size, with §4.7's `bundle_bytes * 2.5` free-space rule applied
-  to it.
+§1.1 previously sized eleven partitions at **214 MiB** — a superseded year+area
+measurement, while §1.2 mandates **year-only**, which the same Phase 3 run
+measured at **+22%**. The real year-only bundle is materially larger (see the
+table above), which moved two numbers the rollout depends on:
 
-**The specification is frozen and is not edited by this PR.** Correcting §1.1's
-sizing table is a decision round that belongs before G1 and the rollout.
-`MAX_BUNDLE_BYTES` (1 GiB) is unaffected and still has ample margin.
+* the §1.1 transfer figure (18.0 s @100 Mbit/s) understated transfer time and so
+  overstated the headroom inside the 30 s readiness target — now ~22.3 s,
+  calculated, leaving ~7.7 s; and
+* the transient-disk budget, now split into **G1a** (`property-shared`, 2 GB) and
+  **G1b** (`propertydata`, 512 MB), each measured against the real bundle with
+  §4.7's `bundle_bytes * 2.5` free-space rule applied to it.
+
+**Specification rev 7 carries the correction**; this runbook records the
+measurement it was derived from. `MAX_BUNDLE_BYTES` (1 GiB) is unaffected and
+retains a ~3.8x margin over the measured bundle.

--- a/property_core/snapshot/bootstrap.py
+++ b/property_core/snapshot/bootstrap.py
@@ -131,7 +131,7 @@ async def snapshot_lifespan() -> AsyncIterator[None]:
     import anyio.to_thread
 
     # The boot does blocking I/O -- network, disk, and a flock wait of up to
-    # LOCK_WAIT_SECONDS. Off the event loop so a co-hosted FastAPI app is not
+    # lock.DEFAULT_TIMEOUT. Off the event loop so a co-hosted FastAPI app is not
     # frozen while a sibling worker holds the single-flight lock.
     await anyio.to_thread.run_sync(boot_once)
     try:

--- a/property_core/snapshot/fetch.py
+++ b/property_core/snapshot/fetch.py
@@ -26,8 +26,8 @@ from property_core.snapshot.models import SnapshotManifest
 
 DEFAULT_CHUNK_SIZE = 1024 * 1024
 #: Hard ceiling regardless of what a manifest claims. A manifest is data from
-#: outside this process; it does not get to size our disk usage. An 11-partition
-#: snapshot is ~214 MiB, so this leaves roughly 4.8x margin.
+#: outside this process; it does not get to size our disk usage. The measured
+#: 11-partition snapshot is 266.2 MiB, so this leaves roughly 3.8x margin.
 DEFAULT_MAX_BUNDLE_BYTES = 1 * 1024 ** 3
 
 #: Whole-transfer budget, evaluated BETWEEN reads. A download that never

--- a/tests/snapshot/test_rollout_premises.py
+++ b/tests/snapshot/test_rollout_premises.py
@@ -38,6 +38,11 @@ from pathlib import Path
 
 import pytest
 
+from property_core.snapshot.fetch import (
+    DEFAULT_MAX_BUNDLE_BYTES,
+    DISK_HEADROOM_MULTIPLIER,
+)
+
 REPO = Path(__file__).resolve().parents[2]
 SPEC = REPO / "docs" / "design" / "ppd-source-routing.md"
 RUNBOOK = REPO / "docs" / "ops" / "ppd-snapshot-build.md"
@@ -88,45 +93,70 @@ def test_the_recorded_byte_counts_are_the_ones_everything_derives_from():
     assert f"{EXTRACTED_BYTES:,}" in runbook, "the measured extracted byte count is gone"
 
 
+#: Where each corrected figure has to appear. "Somewhere in one of the two
+#: documents" was too weak to back the claim this file makes: a figure could
+#: vanish from the gate that depends on it and still pass because the other
+#: document happened to mention it. Each figure is required in the section that
+#: actually relies on it, and a failure names that section.
+SPEC_WINDOW = "### 1.1 Window — 11 year-partitions"
+SPEC_ROLLOUT = "## 7. TDD and rollout"
+RUNBOOK_G1 = "### What this means for G1a and G1b"
+
+#: (figure, value recomputed from the recorded bytes, required locations).
+#: The preflight threshold derives from the SHIPPED multiplier, so changing
+#: DISK_HEADROOM_MULTIPLIER without republishing the figure fails here.
+DERIVED_FIGURES = [
+    ("bundle size", BUNDLE_BYTES / MiB,
+     [(SPEC, SPEC_WINDOW), (RUNBOOK, RUNBOOK_G1)]),
+    ("extracted size", EXTRACTED_BYTES / MiB,
+     [(SPEC, SPEC_ROLLOUT), (RUNBOOK, RUNBOOK_G1)]),
+    ("transfer time", BUNDLE_BYTES * 8 / NOMINAL_BITS_PER_SECOND,
+     [(SPEC, SPEC_WINDOW), (SPEC, SPEC_ROLLOUT), (RUNBOOK, RUNBOOK_G1)]),
+    ("simultaneous payload", (BUNDLE_BYTES + EXTRACTED_BYTES) / MiB,
+     [(SPEC, SPEC_ROLLOUT), (RUNBOOK, RUNBOOK_G1)]),
+    ("preflight threshold", BUNDLE_BYTES * DISK_HEADROOM_MULTIPLIER / MiB,
+     [(SPEC, SPEC_ROLLOUT), (RUNBOOK, RUNBOOK_G1)]),
+]
+
+_FIGURE_CASES = [(label, value, path, heading)
+                 for label, value, locations in DERIVED_FIGURES
+                 for path, heading in locations]
+
+
 @pytest.mark.parametrize(
-    "label, computed, places",
-    [
-        ("bundle MiB", BUNDLE_BYTES / MiB, 1),
-        ("extracted MiB", EXTRACTED_BYTES / MiB, 1),
-        ("transfer seconds", BUNDLE_BYTES * 8 / NOMINAL_BITS_PER_SECOND, 1),
-        ("simultaneous payload MiB", (BUNDLE_BYTES + EXTRACTED_BYTES) / MiB, 1),
-    ],
+    "label, computed, path, heading",
+    _FIGURE_CASES,
+    ids=[f"{label}:{path.name}:{heading.lstrip('# ').split(chr(8212))[0].strip()}"
+         for label, _v, path, heading in _FIGURE_CASES],
 )
-def test_each_derived_figure_is_published_as_this_calculation_produces_it(
-        label, computed, places):
-    """Recomputed here, not restated. Both documents must print the result."""
-    printed = _rounded(computed, places)
-    spec, runbook = _normalised(SPEC), _normalised(RUNBOOK)
-    assert printed in spec or printed in runbook, (
-        f"{label}: the documents no longer publish {printed}, which is what "
-        f"the recorded bytes produce. Change the measurement, not the label."
+def test_each_derived_figure_is_published_where_its_gate_relies_on_it(
+        label, computed, path, heading):
+    """Recomputed here, not restated, and required in the section that uses it."""
+    printed = _rounded(computed)
+    section = " ".join(_section(path, heading).split())
+    assert printed in section, (
+        f"{label}: {path.name} section {heading!r} no longer publishes "
+        f"{printed}, which is what the recorded bytes produce. Change the "
+        f"measurement, not the label."
     )
 
 
-def test_the_preflight_threshold_uses_the_shipped_headroom_multiplier():
+@pytest.mark.parametrize("path", [SPEC, RUNBOOK], ids=lambda p: p.name)
+def test_the_preflight_figure_is_tied_to_the_shipped_headroom_multiplier(path):
     """The 2.5 is a policy constant, so the threshold is policy x measurement.
 
-    Imported from the code rather than restated, so a change to the multiplier
-    cannot leave the published threshold silently stale.
+    The value is computed from the imported constant above; this pins the
+    EXPRESSION alongside it, so a reader can see where the figure came from and
+    a changed multiplier cannot leave a stale number looking authoritative.
     """
-    from property_core.snapshot.fetch import DISK_HEADROOM_MULTIPLIER
-
-    threshold = _rounded(BUNDLE_BYTES * DISK_HEADROOM_MULTIPLIER / MiB)
-    assert threshold in _normalised(RUNBOOK), (
-        f"the runbook no longer publishes the {threshold} MiB preflight "
-        f"threshold that bundle_bytes x {DISK_HEADROOM_MULTIPLIER} produces"
+    assert "`bundle_bytes * 2.5`" in _normalised(path), (
+        f"{path.name} publishes a preflight threshold without citing the "
+        f"bundle_bytes x {DISK_HEADROOM_MULTIPLIER} rule it derives from"
     )
 
 
 def test_the_bundle_limit_margin_is_stated_against_the_measured_bundle():
     """§4.1's margin was ~4.8x against 214 MiB; against the real bundle it is less."""
-    from property_core.snapshot.fetch import DEFAULT_MAX_BUNDLE_BYTES
-
     margin = _rounded(DEFAULT_MAX_BUNDLE_BYTES / BUNDLE_BYTES)
     section = " ".join(_section(SPEC, "## 4. Runtime design").split())
     assert f"{margin}x" in section, (

--- a/tests/snapshot/test_rollout_premises.py
+++ b/tests/snapshot/test_rollout_premises.py
@@ -1,0 +1,375 @@
+"""Rev 7 — the corrected rollout premises, pinned so they cannot drift back.
+
+Specification rev 7 corrected a sizing baseline that had been wrong since rev 1:
+§1.1 sized eleven partitions at 214 MiB, which was a **year+area** measurement
+applied to the **year-only** layout §1.2 mandates. PR 5 built the real artifact
+and measured it. Every figure the rollout depends on moved with it.
+
+Two groups of assertions, and the split matters:
+
+* **Group A — arithmetic is recomputed, never restated.** The derived figures
+  (transfer time, simultaneous payload footprint, preflight threshold, bundle
+  limit margin) are computed here from the recorded byte counts and compared
+  against what the documents print. A future edit that changes a printed number
+  without changing the bytes fails; one that changes the bytes must move all of
+  them together. Restating "22.3" as a literal in both places would let the
+  document and the test drift together while the measurement said otherwise --
+  which is the exact failure rev 7 exists to correct.
+
+* **Group B — the premises themselves**, asserted against the document text.
+
+**On 214 MiB.** The figure is not banned: recording that it was wrong is how the
+correction stays legible. What is banned is *asserting* it as a current
+eleven-partition year-only size. So the permitted occurrences are enumerated by
+their anchor -- a named table cell, a named sentence -- and any occurrence that
+is not one of them fails. A loose textual window around each hit would be
+brittle across table reflows and would quietly accept a new live claim that
+happened to sit near an explanatory word.
+
+Nothing here relaxes a requirement. The 30 s readiness target, the
+`bundle_bytes * 2.5` headroom rule and every Stage 1 exit criterion are
+unchanged by rev 7, and several assertions below exist to keep them that way.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SPEC = REPO / "docs" / "design" / "ppd-source-routing.md"
+RUNBOOK = REPO / "docs" / "ops" / "ppd-snapshot-build.md"
+CHANGELOG = REPO / "CHANGELOG.md"
+
+MiB = 1024 ** 2
+
+#: The measurement, from two independent local builds on 2026-08-28 that
+#: produced a byte-identical bundle (docs/ops/ppd-snapshot-build.md).
+BUNDLE_BYTES = 279_109_872
+EXTRACTED_BYTES = 280_925_271
+
+#: Nominal link rate for the transfer calculation. Not a measured rate: no real
+#: transfer has been timed on either Fly Machine. That is G1a/G1b.
+NOMINAL_BITS_PER_SECOND = 100_000_000
+
+
+def _text(path: Path) -> str:
+    return path.read_text()
+
+
+def _normalised(path: Path) -> str:
+    return " ".join(path.read_text().split())
+
+
+def _section(path: Path, heading: str) -> str:
+    """The body of one heading, up to the next heading at the same level."""
+    body = path.read_text()
+    start = body.index(heading)
+    level = len(heading) - len(heading.lstrip("#"))
+    rest = body[start + len(heading):]
+    nxt = re.search(rf"^#{{1,{level}}} ", rest, re.MULTILINE)
+    return rest[: nxt.start()] if nxt else rest
+
+
+def _rounded(value: float, places: int = 1) -> str:
+    return f"{value:.{places}f}"
+
+
+# ---------------------------------------------------------------------------
+# Group A -- every derived figure recomputed from the recorded bytes
+# ---------------------------------------------------------------------------
+
+def test_the_recorded_byte_counts_are_the_ones_everything_derives_from():
+    """The measurement is the anchor. If it moves, every figure below moves."""
+    runbook = _normalised(RUNBOOK)
+    assert f"{BUNDLE_BYTES:,}" in runbook, "the measured bundle byte count is gone"
+    assert f"{EXTRACTED_BYTES:,}" in runbook, "the measured extracted byte count is gone"
+
+
+@pytest.mark.parametrize(
+    "label, computed, places",
+    [
+        ("bundle MiB", BUNDLE_BYTES / MiB, 1),
+        ("extracted MiB", EXTRACTED_BYTES / MiB, 1),
+        ("transfer seconds", BUNDLE_BYTES * 8 / NOMINAL_BITS_PER_SECOND, 1),
+        ("simultaneous payload MiB", (BUNDLE_BYTES + EXTRACTED_BYTES) / MiB, 1),
+    ],
+)
+def test_each_derived_figure_is_published_as_this_calculation_produces_it(
+        label, computed, places):
+    """Recomputed here, not restated. Both documents must print the result."""
+    printed = _rounded(computed, places)
+    spec, runbook = _normalised(SPEC), _normalised(RUNBOOK)
+    assert printed in spec or printed in runbook, (
+        f"{label}: the documents no longer publish {printed}, which is what "
+        f"the recorded bytes produce. Change the measurement, not the label."
+    )
+
+
+def test_the_preflight_threshold_uses_the_shipped_headroom_multiplier():
+    """The 2.5 is a policy constant, so the threshold is policy x measurement.
+
+    Imported from the code rather than restated, so a change to the multiplier
+    cannot leave the published threshold silently stale.
+    """
+    from property_core.snapshot.fetch import DISK_HEADROOM_MULTIPLIER
+
+    threshold = _rounded(BUNDLE_BYTES * DISK_HEADROOM_MULTIPLIER / MiB)
+    assert threshold in _normalised(RUNBOOK), (
+        f"the runbook no longer publishes the {threshold} MiB preflight "
+        f"threshold that bundle_bytes x {DISK_HEADROOM_MULTIPLIER} produces"
+    )
+
+
+def test_the_bundle_limit_margin_is_stated_against_the_measured_bundle():
+    """§4.1's margin was ~4.8x against 214 MiB; against the real bundle it is less."""
+    from property_core.snapshot.fetch import DEFAULT_MAX_BUNDLE_BYTES
+
+    margin = _rounded(DEFAULT_MAX_BUNDLE_BYTES / BUNDLE_BYTES)
+    section = " ".join(_section(SPEC, "## 4. Runtime design").split())
+    assert f"{margin}x" in section, (
+        f"§4.1 no longer states the {margin}x margin the 1 GiB ceiling actually "
+        f"has over the measured bundle"
+    )
+    assert "4.8x" not in section, "the superseded margin is still published"
+
+
+# ---------------------------------------------------------------------------
+# Group B -- 214 MiB: permitted only at enumerated historical anchors
+# ---------------------------------------------------------------------------
+
+def _occurrences(path: Path) -> list[tuple[int, str]]:
+    return [(n, line) for n, line in enumerate(path.read_text().splitlines(), 1)
+            if "214 MiB" in line]
+
+
+def test_the_specification_states_214_MiB_only_as_a_superseded_figure():
+    """Exactly one occurrence, and it is the sentence that supersedes it."""
+    found = _occurrences(SPEC)
+    assert len(found) == 1, (
+        f"expected one historical reference to 214 MiB in the specification, "
+        f"found {len(found)}: {[n for n, _ in found]}"
+    )
+    line = found[0][1]
+    assert line.strip().startswith("An earlier revision published 214 MiB here"), (
+        f"the surviving 214 MiB reference is not the supersession sentence: {line!r}"
+    )
+
+
+def test_the_runbook_states_214_MiB_only_in_the_superseded_baseline_column():
+    """Two anchors: the comparison table's baseline cell, and the prose beneath it."""
+    found = _occurrences(RUNBOOK)
+    assert len(found) == 2, (
+        f"expected two historical references to 214 MiB in the runbook, found "
+        f"{len(found)}: {[n for n, _ in found]}"
+    )
+
+    rows = {line.split("|")[1].strip(): line
+            for _, line in found if line.lstrip().startswith("|")}
+    assert "Bundle size" in rows, (
+        "214 MiB no longer appears in the comparison table's Bundle size row"
+    )
+    cells = [c.strip() for c in rows["Bundle size"].split("|")]
+    assert "214 MiB" in cells[2], "214 MiB has moved out of the baseline column"
+    assert "266.2 MiB" in cells[3], "the Bundle size row no longer carries the measurement"
+
+    prose = [line for _, line in found if not line.lstrip().startswith("|")]
+    assert len(prose) == 1 and "superseded" in prose[0].lower(), (
+        f"the prose reference does not mark 214 MiB as superseded: {prose!r}"
+    )
+
+
+def test_the_comparison_table_labels_its_baseline_column_as_superseded():
+    """A table that prints 214 MiB under a column headed 'Measured' is the defect."""
+    table = _section(RUNBOOK, "### What this means for G1a and G1b")
+    header = next(line for line in table.splitlines() if line.strip().startswith("|"))
+    cells = [c.strip().lower() for c in header.split("|")]
+    assert "superseded" in cells[2], f"baseline column is not marked superseded: {header!r}"
+    assert "measured" not in cells[2], (
+        "the superseded baseline column is headed 'Measured'; three of its rows "
+        "are arithmetic, which is the mislabelling rev 7 corrects"
+    )
+
+
+def test_no_stale_eleven_partition_size_survives_in_production_code():
+    """The same failure class as the docs: a superseded premise outside the prose."""
+    stale = [p for p in (REPO / "property_core").rglob("*.py")
+             if "214 MiB" in p.read_text()]
+    assert not stale, f"superseded sizing figure still in code: {stale}"
+
+
+# ---------------------------------------------------------------------------
+# Group B -- the corrected premises
+# ---------------------------------------------------------------------------
+
+def test_the_eleven_partition_row_publishes_the_measurement():
+    """The guard that matters: the current claim is the measured one."""
+    window = _section(SPEC, "### 1.1 Window — 11 year-partitions")
+    row = next((line for line in window.splitlines()
+                if line.strip().startswith("|") and "2016–2026" in line), None)
+    assert row is not None, "the eleven-partition row is gone from §1.1"
+    assert "266.2 MiB" in row and "measured" in row.lower(), (
+        f"the eleven-partition row does not publish the measurement: {row!r}"
+    )
+    assert "214" not in row, "the eleven-partition row still claims the superseded size"
+
+
+def test_the_estimated_rows_label_both_their_size_and_their_transfer():
+    """10 and 12 partitions are year+area estimates; their times are doubly derived."""
+    window = _section(SPEC, "### 1.1 Window — 11 year-partitions")
+    for years in ("2017–2026", "2015–2026"):
+        row = next(line for line in window.splitlines()
+                   if line.strip().startswith("|") and years in line)
+        assert "estimated" in row.lower(), f"{years} row does not label its size: {row!r}"
+        assert "calculated from that estimate" in row.lower(), (
+            f"{years} row does not label its transfer time as derived from an "
+            f"estimate rather than from a measurement: {row!r}"
+        )
+
+
+@pytest.mark.parametrize("phrase", [
+    "G1a",
+    "G1b",
+    "Passing G1a authorises neither",
+    "ephemeral rootfs",
+])
+def test_the_split_gate_is_recorded(phrase):
+    assert phrase in _normalised(SPEC), f"§7.2 no longer states: {phrase!r}"
+
+
+def test_each_split_gate_names_its_own_target():
+    stage2 = _section(SPEC, "## 7. TDD and rollout")
+    normalised = " ".join(stage2.split())
+    g1a = normalised.index("G1a")
+    g1b = normalised.index("G1b")
+    assert "property-shared" in normalised[g1a:g1b], "G1a does not name its target"
+    assert "2 GB" in normalised[g1a:g1b], "G1a does not state the 2 GB target"
+    assert "propertydata" in normalised[g1b:g1b + 900], "G1b does not name its target"
+    assert "512 MB" in normalised[g1b:g1b + 900], "G1b does not state the 512 MB target"
+
+
+def test_the_rollout_section_does_not_claim_a_volume_that_does_not_exist():
+    """Neither app declares one (§4.5). Naming its absence is fine; claiming it is not."""
+    rollout = _section(SPEC, "## 7. TDD and rollout")
+    flattened = " ".join(rollout.split()).replace("’", "'").lower()
+    assert "machine's volume" not in flattened, (
+        "§7.2 still requires the payload to fit within the machine's volume; "
+        "both Machines run Fly's default ephemeral rootfs with no [mounts]"
+    )
+    assert "ephemeral rootfs" in flattened, (
+        "§7.2 does not name the storage that actually constrains G1a/G1b"
+    )
+
+
+def test_the_calculated_g1_inputs_are_not_presented_as_measurements():
+    rollout = " ".join(_section(SPEC, "## 7. TDD and rollout").split())
+    marker = "Calculated inputs"
+    assert marker in rollout, "§7.2 does not separate G1's calculated inputs from its result"
+    block = rollout[rollout.index(marker):rollout.index(marker) + 700]
+    for figure in ("534.1", "665.4", "22.3"):
+        assert figure in block, f"{figure} is not inside the calculated-inputs block"
+
+
+def test_g3_states_the_deploy_and_observe_invariant_instead_of_the_impossible_order():
+    """Routing merged in PR 4, so 'before routing is introduced' can never hold."""
+    # Same rule as 214 MiB: the phrase may be QUOTED as superseded, never
+    # required. Anchored to the supersession sentence, not a textual window.
+    found = [line for line in _text(SPEC).splitlines()
+             if "before routing is introduced" in line]
+    assert len(found) == 1, (
+        f"expected one historical reference to the superseded ordering, found "
+        f"{len(found)}"
+    )
+    assert "revision required this" in found[0], (
+        f"G3 still requires an ordering that PR 4 made unsatisfiable: {found[0]!r}"
+    )
+    assert ("must land, deploy and be observed with `PPD_SNAPSHOT_ENABLED` off "
+            "before any snapshot enablement") in _normalised(SPEC), (
+        "G3 no longer carries the replacement safety invariant"
+    )
+
+
+def test_nothing_in_the_correction_relaxed_a_requirement():
+    normalised = _normalised(SPEC)
+    assert "30 s readiness target" in normalised, "the readiness target was dropped"
+    assert "`bundle_bytes * 2.5`" in normalised, "the headroom rule was dropped"
+    for criterion in ("Zero unexplained false empties", "Zero geography contamination",
+                      "100% field equality on shared transaction IDs",
+                      "Every divergence classified", "Zero snapshot errors",
+                      "p95 < 1 second"):
+        assert criterion in normalised, f"Stage 1 exit criterion dropped: {criterion!r}"
+
+
+def test_a_local_rehearsal_is_not_recorded_as_a_stage_1_result():
+    normalised = _normalised(SPEC)
+    assert "A local rehearsal is not Stage 1" in normalised
+    assert "cannot satisfy" in normalised and "p95" in normalised
+
+
+def test_the_implementation_status_records_pr_5_as_merged():
+    normalised = _normalised(SPEC)
+    assert "By **PR 5**" in normalised, "the build pipeline is still listed as unimplemented"
+    for outstanding in ("artifact distribution", "G1a", "G1b", "G2", "G3",
+                        "v1.15"):
+        assert outstanding in normalised, f"outstanding work no longer listed: {outstanding}"
+
+
+def test_the_flag_is_still_recorded_as_off_everywhere():
+    assert "remains off in all checked-in configuration" in _normalised(SPEC)
+
+
+# ---------------------------------------------------------------------------
+# Group B -- two premises the shipped implementation already contradicted
+# ---------------------------------------------------------------------------
+
+def test_the_retention_rule_agrees_with_the_runtime_that_implements_it():
+    """§7.1 item 36 said 'current + previous'; §4.7, store.py and its test say one."""
+    normalised = _normalised(SPEC)
+    assert "retains exactly current + previous" not in normalised, (
+        "§7.1 still requires a retention policy §4.7 and SnapshotStore reject"
+    )
+    assert "retains exactly the active version" in normalised
+
+
+def test_the_lock_wait_bound_names_a_constant_that_exists():
+    """`LOCK_WAIT_SECONDS` was never an identifier; the value 420 s is unchanged."""
+    from property_core.snapshot.lock import DEFAULT_TIMEOUT
+
+    assert DEFAULT_TIMEOUT == 420.0
+    assert "LOCK_WAIT_SECONDS" not in _text(SPEC), (
+        "the specification still names an identifier that does not exist"
+    )
+    assert "LOCK_WAIT_SECONDS" not in _text(REPO / "property_core" / "snapshot" / "bootstrap.py")
+
+
+# ---------------------------------------------------------------------------
+# Scope -- this correction changes documents and tests, nothing operational
+# ---------------------------------------------------------------------------
+
+def test_the_changelog_records_the_correction_rather_than_the_freeze():
+    normalised = _normalised(CHANGELOG)
+    assert "Five** PRs" in normalised or "**Five** PRs" in normalised, (
+        "the changelog still counts four merged PRs"
+    )
+    assert "specification rev 7" in normalised, (
+        "the changelog still says the sizing correction is deferred"
+    )
+
+
+def test_the_lock_wait_versus_grace_period_question_is_recorded_not_resolved():
+    """C11: recorded against G2 by rev 7, deliberately left open.
+
+    Reconciling a 420 s lock wait against 60 s / 30 s health-check grace periods
+    needs deployment evidence or a new operational policy. A documentation
+    correction may record the question; it may not invent the answer.
+    """
+    normalised = _normalised(SPEC)
+    assert "blocking G2 if the deployed count exceeds one" in normalised, (
+        "the lock-wait versus grace-period question is no longer recorded as a "
+        "G2 blocker; it would be lost between sessions"
+    )
+    assert "deliberately does not resolve it" in normalised
+    for number in ("420 s", "60 s (`property-shared`)", "30 s (`propertydata`)"):
+        assert number in normalised, f"G2's open question no longer cites {number}"

--- a/tests/snapshot/test_rollout_prerequisites.py
+++ b/tests/snapshot/test_rollout_prerequisites.py
@@ -163,14 +163,19 @@ def test_the_definitive_gate_is_recorded_in_the_governing_specification():
 
     assert "G3" in normalised, "the image prerequisite is not listed as a rollout gate"
     assert "--extra snapshot" in normalised
-    # 1. unconditional install before routing
+    # 1. unconditional install, landed and observed with the flag off
     assert "unconditionally" in normalised
     # 2. built-image smoke tests
     assert "smoke test" in normalised
     # 3. fail closed with readiness false
     assert "fails closed" in normalised
-    # 4. flag stays off until the image checks, G1 and G2 pass
-    assert "G1 and G2" in normalised
+    # 4. flag stays off until the image checks, G2 and the target's G1 gate pass.
+    #    G1 is split per target: neither result transfers to the other app.
+    assert "G1a" in normalised and "G1b" in normalised and "G2" in normalised
+    assert "deploy and be observed" in normalised, (
+        "G3 no longer states the deploy-and-observe invariant that replaced the "
+        "now-impossible 'before routing is introduced' ordering"
+    )
 
 
 def test_the_specification_states_this_lint_is_not_sufficient():

--- a/tests/test_ppd_spec_and_attribution.py
+++ b/tests/test_ppd_spec_and_attribution.py
@@ -27,7 +27,7 @@ def test_governing_specification_ships_with_the_code():
 
 def test_specification_is_version_stamped():
     head = SPEC.read_text().splitlines()[0]
-    assert "rev 6" in head and "FROZEN" in head, head
+    assert "rev 7" in head and "FROZEN" in head, head
 
 
 def _normalised(text: str) -> str:


### PR DESCRIPTION
Docs-and-tests only. **No image, fly config, dependency, flag, deployment or release surface is touched, and nothing is enabled.**

PR 5 built and measured the real eleven-partition artifact. Every figure the rollout depends on moved with it, and the governing documents still carried the old ones — including two that had become impossible to satisfy. Rev 7 corrects them.

## What was wrong

| Defect | Evidence |
|---|---|
| §1.1 sized eleven partitions at **214 MiB** — a *year+area* figure applied to the *year-only* layout §1.2 mandates | measured 266.2 MiB (279,109,872 B) |
| **G1 named the wrong target**: "measured on the real 512 MB Fly app", while Stage 2 is `property-shared` **only** — the 2 GB app | `spec:1019` vs `spec:1065`, `fly.toml` |
| **G1 required the payload to fit "within the machine's volume"** — neither app declares one | vs §4.5, which says so correctly |
| **G3 required the dependency change to land "before routing is introduced"** — routing merged in PR 4, so no future action can satisfy it | `spec:1039-41` vs `spec:20-22` |
| Implementation status said the build pipeline was unimplemented | PR 5 merged; the changelog documents it |
| §7.1 item 36 required retaining "current + previous" | §4.7, `SnapshotStore` and its test all keep exactly one |
| §4.6 named `LOCK_WAIT_SECONDS` | not an identifier that exists; the constant is `lock.DEFAULT_TIMEOUT` |
| The runbook printed three calculations under a column headed **"Measured"** | `runbook:334-339` |

## What rev 7 does

- **§1.1** publishes the measured **266.2 MiB**. **22.3 s**, **534.1 MiB** and **665.4 MiB** are labelled *calculated* — they are arithmetic over the measurement, not observations. The 10- and 12-partition rows are labelled estimated, with their transfer times marked as calculated from those estimates.
- **G1 splits.** **G1a** measures `property-shared` (2 GB, Stage 2); **G1b** measures `propertydata` (512 MB, Stage 3). Both test ephemeral-rootfs behaviour; RAM is a separate constraint. **Passing G1a authorises neither `propertydata` nor Stage 3.** G1a also requires establishing whether the materialization root (`/tmp/ppd-snapshot`) is disk- or tmpfs-backed before its figures mean anything.
- **G3** keeps every requirement and replaces the impossible ordering with the invariant it protected: *the dependency-only image change must land, deploy and be observed with `PPD_SNAPSHOT_ENABLED` off before any snapshot enablement.*
- **Implementation status** records PRs 1–5 merged and what remains outstanding.
- **Two comments carried the same stale premises outside the governing prose** and are corrected: `fetch.py`'s 214 MiB / 4.8x margin, `bootstrap.py`'s `LOCK_WAIT_SECONDS`. Comments only — no constant or behaviour changes.

**Nothing is relaxed.** The 30 s readiness target, the `bundle_bytes * 2.5` headroom rule and every Stage 1 exit criterion are unchanged, and tests pin them that way. The headroom inside the readiness target is now ~7.7 s rather than the ~12 s the superseded figure implied.

## Recorded, deliberately not resolved

Boot blocks the lifespan, a worker can wait 420 s on the single-flight lock, and the Fly grace periods are 60 s and 30 s. Above one worker per Machine those do not reconcile. It is written against **G2 as a blocker**: resolving it needs deployment evidence or a new operational policy, neither of which a documentation correction may invent.

## Tests

`tests/snapshot/test_rollout_premises.py` (new, 37 cases) pins the corrected premises.

- **Derived figures are recomputed from the recorded byte counts, never restated**, so a document and its test cannot drift together the way 214 MiB did. Each is required in the sections that rely on it, so a failure names the gate it breaks.
- **214 MiB and the superseded G3 ordering are permitted only at enumerated historical anchors** — quotable as wrong, never assertable as current. Anchored to named table cells and sentences rather than a textual window, which would be brittle across table reflows.
- The preflight figure derives from the shipped `DISK_HEADROOM_MULTIPLIER`, with the `bundle_bytes * 2.5` expression pinned in both documents.

Verified by mutation: removing 665.4 from spec §7.2 while leaving it in the runbook fails the new check and would have passed its earlier form.

## Verification

- Full suite: **1,515 passed / 26 skipped**, against the PR 5 baseline of 1,486 / 26. The delta is exactly this PR's new tests; skips unchanged.
- `test_neither_image_installs_the_extra_today_and_that_is_correct` and the five §4 substring pins in `test_limits_and_deadlines.py` pass **untouched**.
- `git diff --stat` over `fly.toml`, `fly.app.toml`, both Dockerfiles, `pyproject.toml`, `uv.lock` and `.github/` is empty. `PPD_SNAPSHOT_ENABLED` still appears in no deployment config.

## Not in this PR

Artifact distribution and the Royal Mail review; the dependency-only image change; G1a/G1b/G2/G3 execution; the fixed corpus and its rehearsal; the Stage 1 shadow; any enablement; the v1.15 release. Each remains separately authorized.