### PR TITLE
feat(ppd): rehearse the shadow corpus locally, and correct what it exposed

### DIFF
--- a/docs/design/ppd-shadow-corpus.md
+++ b/docs/design/ppd-shadow-corpus.md
@@ -103,7 +103,12 @@ row count:
 * **`sample_complete` is `false`** — including where the returned page is
   plainly exhausted, far below `limit`. Exhausting a page is not completeness
   when the requested interval extends past what the snapshot holds;
-* **`completeness_basis` is `null`**.
+* **`completeness_basis` is `null`**;
+* **`recent_period_provisional` is `true`**. The resolved upper bound is always
+  `coverage_to`, and `provisional_from` never exceeds `coverage_to`, so **every**
+  comps window intersects the provisional period. This was originally written as
+  a property of two particular cases; a rehearsal against a real artifact showed
+  it holding on all fourteen, for the same structural reason as the clamp.
 
 These are structural, not situational. A case reporting `sample_complete: true`
 is a **defect**, not a divergence.
@@ -127,18 +132,22 @@ justification.
 |---|---|---|---|
 | S1 | `postcode=B5`, `search_level=district` | contamination boundary | the longer neighbouring outcode holds comparable or greater volume |
 | S2 | `postcode=B50`, `search_level=district` | reverse boundary | non-empty under frozen parameters |
-| S3 | `postcode=B5 4`, `search_level=sector` | sector isolation | a strict subset of S1 |
+| S3 | `postcode=B5 4`, `search_level=sector` | sector isolation | its **full aggregate count** is a strict subset of S1's — see §9 on why a paged result cannot show this |
 | S4 | `postcode=<sector>`, `search_level=sector` | thin market | falls below `thin_market_threshold` under frozen parameters |
 | S5 | `postcode=<sector>`, `search_level=sector` | dense market and truncation | matching rows greatly exceed `limit` |
 | S6 | `postcode=<unit>`, `search_level=postcode` | exact-postcode geography | aggregate-dense, so not individually identifying |
 | S7 | `postcode=<sector>`, `search_level=sector`, `property_type=F` | type filter that barely bites | at least 90% of the base is `F` |
 | S8 | `postcode=<sector>`, `search_level=sector`, `property_type=F` | type filter that genuinely bites | a real spread across `F/D/S/T` |
-| S9 | S3's geography, `transaction_category=all` | category filtering | materially exceeds S3 on identical geography and window |
-| S10 | `postcode=<sector>`, `search_level=sector`, `months=6` | provisional tail, non-empty | window intersects the provisional period; returns rows |
+| S9 | S3's geography, `transaction_category=all` | category filtering | its **full aggregate count** materially exceeds S3's on identical geography and window |
 | S11 | `postcode=<sector>`, `search_level=sector`, `months=6` | **the provisional flag is a property of the window** | window intersects the provisional period; **returns zero rows** |
 | S12 | `postcode=B5`, `search_level=district`, `months=120` | widest window, deepest history | matching rows greatly exceed `limit` |
 | S13 | `postcode=<unit>`, `search_level=postcode`, `property_type=D` | expected empty | geography non-empty under defaults, that type absent |
 | S14 | S3's geography, `property_type=T` | expected empty, sector shape | as S13 |
+
+**S10 was removed.** It asserted "provisional tail, non-empty", which
+discriminates nothing now that §3 records every comps case as provisional — it
+was redundant with all thirteen others. **S11 is retained:** an empty result
+that must still be flagged provisional is the control with teeth.
 
 **S11 is the case a naive implementation gets wrong.** `recent_period_provisional`
 is computed from the resolved *requested window* before any row is examined, so
@@ -288,16 +297,60 @@ expected shape — before any production shadow.
    parameter of §2 explicitly. The live adapter is not constructed, patched or
    called.
 3. Record everything in §6, plus row count, returned geography membership
-   (sector and outcode only), the date bounds of returned rows, the provenance
-   block, and latency.
+   (sector and outcode only), the **date bounds of returned rows**, the
+   provenance block, warning classes, and **per-case latency**. Record any
+   **midnight exclusion and retry**; an observation that cannot be obtained
+   within a single calendar date **fails the run** rather than being recorded
+   against a window that does not describe it. **The failure is written to
+   the report before the run exits** — an aggregate-only report carrying
+   `midnight.unrecoverable`, the retry count and the reason. A traceback
+   with no report is not "clearly", and leaves nothing to review.
 4. Assert §3's invariants on every case, plus each shape's intent: S1 contains
-   no row from the neighbouring outcode; S3 is a subset of S1; S4 trips the
-   thin-market threshold; S5 and S12 return exactly `limit` rows; S9 exceeds S3
-   on identical geography; S10 and S11 both report
-   `recent_period_provisional: true`, S11 while returning zero rows; S13 and S14
+   no row from the neighbouring outcode; S4 trips the thin-market threshold;
+   S5 and S12 return exactly `limit` rows; **S11 reports
+   `recent_period_provisional: true` while returning zero rows**; S13 and S14
    are empty.
-5. Sockets hard-failed throughout, so an accidental network call fails the run
-   rather than making it non-deterministic.
+
+   **Containment between cases is asserted on counts, not on pages.** A paged
+   result ordered most-recent-first is not a subset of a wider page: S1's fifty
+   most recent rows across a district need not contain S3's fifty most recent
+   within one of its sectors, and S9's page with category B included pushes
+   category-A rows off the equivalent S3 page. Set containment over
+   transaction ids is therefore **only meaningful when neither side is
+   saturated**. Accordingly:
+
+   * **Instance qualification uses full aggregate counts** — that is where
+     "S3 is a strict subset of S1" and "S9 exceeds S3" are established, against
+     the whole artifact rather than a page.
+   * **The rehearsal reports `not_evaluable`, with its reason, whenever either
+     paged result is saturated at `limit`.** A saturated comparison is an
+     unanswerable question, and reporting it as a failure would blame the
+     artifact for the corpus asking it.
+   * **Geography containment is always checked**, because it remains meaningful
+     on a page: every row S3 returns must lie inside S1's outcode however the
+     page was truncated.
+
+   **`not_evaluable` is never counted as a passing assertion.** It is recorded
+   explicitly with its reason, counted separately from passes and failures, and
+   a run may still exit 0 with `not_evaluable` assertions present — but it may
+   never exit 0 with a failed one.
+
+   **The declared baselines are carried in the rehearsal instance**, as
+   `aggregate_baselines` (`S1_full`, `S3_full`, `S9_full`), validated before
+   anything is materialized: they must be counts, `S3_full` may not exceed
+   `S1_full`, and `S9_full` must exceed `S3_full`. A baseline set contradicting
+   the relation it exists to establish is refused — it would look like evidence
+   while qualifying nothing. The report records them as **declared, not
+   measured**: a paged rehearsal cannot re-derive a full aggregate count and
+   must not imply it did.
+5. Sockets hard-failed throughout, with a self-check proving the block is
+   armed, so an accidental network call fails the run rather than making it
+   non-deterministic.
+6. **Pre-existing `PPD_SNAPSHOT_*` environment values and installed snapshot
+   state are captured and restored**, not deleted. A rehearsal is a guest in
+   whatever process runs it: unsetting a variable the caller had set, or
+   dropping an adapter the caller had installed, would leave that process
+   quietly different afterwards.
 
 **A rehearsal produces no real-traffic sample.** It can satisfy neither the p95
 criterion nor any divergence criterion — there is no live arm to diverge from.
@@ -310,7 +363,8 @@ evidence**.
 
 An Instance records: the selected `snapshot_version` and `bundle_sha256`; its
 qualification date; per case, the aggregate baseline and the qualification rule
-it satisfied; any substituted geography with justification; its staleness bound;
+it satisfied — including the **full aggregate counts** establishing S3's
+containment in S1 and S9's excess over S3, which a paged rehearsal cannot show; any substituted geography with justification; its staleness bound;
 and the Stage 1 run it governs.
 
 ---

--- a/tests/snapshot/test_shadow_rehearsal.py
+++ b/tests/snapshot/test_shadow_rehearsal.py
@@ -1,0 +1,619 @@
+"""Local shadow-corpus rehearsal (`tools.ppd_snapshot rehearse`).
+
+The rehearsal exercises the corpus Definition's cases against an already-built
+local artifact, through the snapshot adapter only. It is a correctness exercise:
+it has no live arm, so it can satisfy neither the p95 criterion nor any
+divergence criterion, and its report is never Stage 1 evidence.
+
+Two properties are worth more than the rest, and both are tested first:
+
+* **An instance is refused before an artifact is opened.** The instance names
+  the artifact and supplies the concrete geographies the Definition leaves as
+  placeholders. An instance that is malformed, incomplete, or bound to a
+  different artifact must stop the run at argument-validation time -- before
+  ~534 MiB is materialized, and before any snapshot is opened. Refusing after
+  materialization would still be correct, but it would burn the disk and the
+  wall time first, and it would leave a cache directory whose provenance nobody
+  can explain.
+
+* **No live path is constructed.** A rehearsal that quietly fell back to live
+  SPARQL would produce a report that looks like a rehearsal and is not one. The
+  socket blocker is armed with a self-check, and every case asserts its answer
+  came from the snapshot.
+
+Exit codes follow the tool's existing convention: 2 for a refused instance,
+1 for a rehearsal that ran but failed an invariant, 0 only when every case
+passed.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("duckdb")
+pytest.importorskip("zstandard")
+
+from tools.ppd_snapshot import __main__ as cli  # noqa: E402
+from tools.ppd_snapshot.build import BuildRequest, build_snapshot  # noqa: E402
+from tools.ppd_snapshot.package import (  # noqa: E402
+    package_release,
+    promote_release,
+    snapshot_version,
+)
+from tests.snapshot.build_fixtures import csv_row, write_source_csv  # noqa: E402
+
+COVERAGE_TO = date(2026, 6, 30)
+
+
+@pytest.fixture
+def dist(tmp_path: Path) -> Path:
+    """A real published dist: bundle, manifest and current.json.
+
+    Built through the shipped pipeline rather than hand-assembled, so the
+    rehearsal is exercised against the artifact shape it will actually meet.
+    """
+    # Dates sit inside a 24-month window measured from "today", and inside the
+    # provisional tail, so the geography and provisional cases are not vacuous.
+    # An out-of-window B5 row would make the B5/B50 contamination check pass by
+    # returning nothing at all, which proves less than nothing.
+    csv_path = write_source_csv(tmp_path / "pp.csv", [
+        csv_row("{T-B57-A}", "B5 7AA", "2026-05-01 00:00", 210_000),
+        csv_row("{T-B50-A}", "B50 4AA", "2026-05-02 00:00", 400_000),
+        csv_row("{T-M37-A}", "M3 7AA", "2026-06-30 00:00", 250_000),
+    ])
+    built = build_snapshot(BuildRequest(
+        csv_path=csv_path, out_dir=tmp_path / "snapshot",
+        coverage_to=COVERAGE_TO, temp_dir=tmp_path / "tmp"))
+    release = package_release(
+        built, dist_dir=tmp_path / "dist", candidate_root=tmp_path / "work",
+        version=snapshot_version(datetime(2026, 8, 28, 10, 15, tzinfo=timezone.utc)),
+        source={"file": "pp.csv", "sha256": "a" * 64, "etag": '"abc"'},
+        facts={"rows_per_year": {"2024": 2, "2026": 1}},
+    )
+    promote_release(release)
+    return tmp_path / "dist"
+
+
+def _manifest(dist_dir: Path) -> dict:
+    current = json.loads((dist_dir / "current.json").read_text())
+    return json.loads((dist_dir / current["current_manifest"]).read_text())
+
+
+def valid_instance(dist_dir: Path) -> dict:
+    """An instance bound to `dist_dir`, with every placeholder supplied."""
+    m = _manifest(dist_dir)
+    return {
+        "instance_kind": "rehearsal",
+        "snapshot_version": m["snapshot_version"],
+        "bundle_sha256": m["bundle_sha256"],
+        "geographies": {
+            "S4_thin": "B5 6",
+            "S5_dense": "B5 7",
+            "S6_unit": "B5 7AA",
+            "S7_type_weak": "M3 7",
+            "S8_type_strong": "B5 7",
+            "S11_provisional_empty": "B5 6",
+            "S13_empty_unit": "B5 7AA",
+        },
+        # Definition section 10: containment is qualified from FULL aggregate
+        # counts, which a paged rehearsal cannot show. Declaring them here makes
+        # the qualification evidence explicit instead of merely described.
+        "aggregate_baselines": {
+            "S1_full": 2, "S3_full": 1, "S9_full": 2,
+        },
+    }
+
+
+def write_instance(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload, indent=2))
+    return path
+
+
+def run(tmp_path: Path, dist_dir: Path, instance: Path) -> tuple[int, Path, Path]:
+    cache = tmp_path / "rehearsal-cache"
+    report = tmp_path / "report.json"
+    code = cli.main([
+        "rehearse",
+        "--instance", str(instance),
+        "--dist", str(dist_dir),
+        "--cache-dir", str(cache),
+        "--report", str(report),
+    ])
+    return code, cache, report
+
+
+# ---------------------------------------------------------------------------
+# 1. The instance is refused before an artifact is opened
+# ---------------------------------------------------------------------------
+
+def _mutations(dist_dir: Path):
+    """Each returns (label, instance payload) that must be refused."""
+    base = valid_instance(dist_dir)
+
+    missing = dict(base)
+    missing.pop("bundle_sha256")
+
+    unknown = dict(base, extra_key="not in the schema")
+
+    wrong_kind = dict(base, instance_kind="stage1")
+
+    wrong_digest = dict(base, bundle_sha256="f" * 64)
+
+    wrong_version = dict(base, snapshot_version="v20200101T000000Z")
+
+    incomplete_geo = dict(base)
+    incomplete_geo["geographies"] = {
+        k: v for k, v in base["geographies"].items() if k != "S4_thin"}
+
+    unknown_geo = dict(base)
+    unknown_geo["geographies"] = dict(base["geographies"], S99_nonsense="B5 7")
+
+    malformed_geo = dict(base)
+    malformed_geo["geographies"] = dict(base["geographies"], S4_thin="not a postcode!")
+
+    return [
+        ("missing required key", missing),
+        ("unknown top-level key", unknown),
+        ("instance_kind is not rehearsal", wrong_kind),
+        ("bundle_sha256 does not bind to the artifact", wrong_digest),
+        ("snapshot_version does not bind to the artifact", wrong_version),
+        ("a placeholder is unsupplied", incomplete_geo),
+        ("an unknown placeholder is supplied", unknown_geo),
+        ("a placeholder is not a postcode or sector", malformed_geo),
+    ]
+
+
+def test_every_invalid_instance_is_refused_with_exit_2(tmp_path, dist):
+    for label, payload in _mutations(dist):
+        instance = write_instance(tmp_path / f"inst-{abs(hash(label))}.json", payload)
+        code, cache, report = run(tmp_path, dist, instance)
+        assert code == 2, f"{label!r} was not refused with exit 2 (got {code})"
+        assert not report.exists(), f"{label!r} wrote a report despite being refused"
+
+
+def test_a_refused_instance_materializes_nothing(tmp_path, dist):
+    """The refusal must happen before ~534 MiB is written, not after."""
+    for label, payload in _mutations(dist):
+        instance = write_instance(tmp_path / f"nomat-{abs(hash(label))}.json", payload)
+        code, cache, _report = run(tmp_path, dist, instance)
+        assert code == 2, label
+        materialized = list(cache.rglob("*.parquet")) if cache.exists() else []
+        assert not materialized, (
+            f"{label!r} materialized a snapshot before refusing the instance: "
+            f"{materialized[:3]}"
+        )
+
+
+def test_unparseable_json_is_refused_with_exit_2(tmp_path, dist):
+    instance = tmp_path / "broken.json"
+    instance.write_text("{not json")
+    code, _cache, report = run(tmp_path, dist, instance)
+    assert code == 2
+    assert not report.exists()
+
+
+def test_a_missing_instance_file_is_refused_with_exit_2(tmp_path, dist):
+    code, _cache, report = run(tmp_path, dist, tmp_path / "absent.json")
+    assert code == 2
+    assert not report.exists()
+
+
+def test_the_valid_instance_is_accepted(tmp_path, dist):
+    """Control: the refusals above must be refusing the mutation, not the shape."""
+    from tools.ppd_snapshot.rehearse import load_instance
+
+    instance = write_instance(tmp_path / "ok.json", valid_instance(dist))
+    loaded = load_instance(instance, dist)
+    assert loaded.instance_kind == "rehearsal"
+    assert loaded.geographies["S4_thin"] == "B5 6"
+
+
+# ---------------------------------------------------------------------------
+# 2. A fixture artifact runs adapter-only, isolated, and reports as a rehearsal
+# ---------------------------------------------------------------------------
+
+#: Values from the fixture rows that must NEVER appear in a report. Ids, prices
+#: and addresses are the three categories the authorisation forbids, and a
+#: report is a file someone will paste into a review.
+FORBIDDEN_IN_REPORT = ["T-B57-A", "T-B50-A", "T-M37-A",
+                       "210000", "400000", "250000", "HIGH STREET"]
+
+
+@pytest.fixture
+def rehearsed(tmp_path, dist):
+    instance = write_instance(tmp_path / "ok.json", valid_instance(dist))
+    code, cache, report = run(tmp_path, dist, instance)
+    assert report.exists(), f"no report written (exit {code})"
+    return code, json.loads(report.read_text()), report
+
+
+def test_the_report_is_labelled_a_rehearsal_and_not_stage_1_evidence(rehearsed):
+    _code, report, _path = rehearsed
+    assert report["kind"] == "rehearsal"
+    assert report["not_stage_1_evidence"] is True
+    assert "no live arm" in report["disclaimer"].lower()
+
+
+def test_the_socket_blocker_was_armed_and_self_checked(rehearsed):
+    """Isolation is recorded as an observed fact, not an assumption."""
+    _code, report, _path = rehearsed
+    assert report["isolation"]["socket_blocker_armed"] is True
+    assert report["isolation"]["self_check_passed"] is True
+
+
+def test_every_case_was_answered_by_the_snapshot(rehearsed):
+    """Proof no live path answered, independent of the socket blocker."""
+    _code, report, _path = rehearsed
+    for case in report["cases"]:
+        assert case["provenance"]["source"] == "snapshot", (
+            f"{case['shape']} was not answered by the snapshot"
+        )
+
+
+def test_the_report_binds_to_the_artifact_it_ran_against(rehearsed, dist):
+    _code, report, _path = rehearsed
+    m = _manifest(dist)
+    assert report["artifact"]["snapshot_version"] == m["snapshot_version"]
+    assert report["artifact"]["bundle_sha256"] == m["bundle_sha256"]
+
+
+def test_the_report_records_the_reconstructed_window_per_case(rehearsed):
+    _code, report, _path = rehearsed
+    for case in report["cases"]:
+        assert case["observed_at_before"] == case["observed_at_after"], (
+            "a midnight-crossing observation was kept instead of excluded"
+        )
+        assert case["derived_from_date"], "the reconstructed window is missing"
+        assert case["resolved_to_date"], "the resolved upper bound is missing"
+
+
+def test_the_report_separates_wire_parameters_from_effective_semantics(rehearsed):
+    _code, report, _path = rehearsed
+    for case in report["cases"]:
+        wire = case["request"]["wire"]
+        effective = case["request"]["effective"]
+        assert wire["address"] == "<omitted>"
+        assert effective["address"] is None
+        if wire["property_type"] == "<omitted>":
+            assert effective["property_type"] == "residential_default (F/D/S/T)"
+
+
+def test_the_report_carries_no_ids_prices_or_addresses(rehearsed):
+    """Aggregates only. The subset checks run in memory and discard their sets."""
+    _code, _report, path = rehearsed
+    body = path.read_text()
+    for forbidden in FORBIDDEN_IN_REPORT:
+        assert forbidden not in body, (
+            f"the rehearsal report leaked {forbidden!r}; reports carry counts, "
+            f"geography membership and outcomes only"
+        )
+
+
+def test_geography_isolation_is_actually_evaluated(rehearsed):
+    """The fixture holds B5 and B50, so S1 must exclude B50 for real."""
+    _code, report, _path = rehearsed
+    s1 = next(c for c in report["cases"] if c["shape"] == "S1")
+    assert s1["outcodes_returned"] == ["B5"], (
+        f"S1 returned outcodes {s1['outcodes_returned']}; B50 is a different "
+        f"place and must never appear in a B5 district search"
+    )
+    assert s1["invariants"]["geography_isolation"] is True
+
+
+def test_the_universal_invariants_are_evaluated_on_every_case(rehearsed):
+    _code, report, _path = rehearsed
+    for case in report["cases"]:
+        inv = case["invariants"]
+        assert inv["coverage_clamp_warning_present"] is True, case["shape"]
+        assert inv["sample_complete_is_false"] is True, case["shape"]
+        assert inv["completeness_basis_is_null"] is True, case["shape"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Exit codes and isolation, proven rather than assumed
+# ---------------------------------------------------------------------------
+
+def test_the_socket_blocker_actually_refuses_a_socket():
+    """Directly exercised. An unarmed blocker would let a live call through
+    while the report still claimed isolation."""
+    from tools.ppd_snapshot.rehearse import LivePathAttempted, SocketBlocker
+    import socket as socket_mod
+
+    blocker = SocketBlocker()
+    blocker.arm()
+    try:
+        with pytest.raises(LivePathAttempted):
+            socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+    finally:
+        blocker.disarm()
+    # Restored, so the blocker cannot leak into the rest of the suite.
+    sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+    sock.close()
+
+
+def test_a_three_row_fixture_cannot_satisfy_the_dense_cases_and_exits_1(rehearsed):
+    """Exit 1 means "ran, and an invariant failed" -- and is correct here.
+
+    A fixture holding three rows cannot be a dense market, so S5 and S12 must
+    fail their truncation invariant. If this ever exits 0, the invariants are
+    not being evaluated.
+    """
+    code, report, _path = rehearsed
+    assert code == 1, f"expected exit 1 on a fixture that cannot be dense, got {code}"
+    assert report["passed"] is False
+    dense = [c for c in report["cases"] if c["shape"] in {"S5", "S12"}]
+    assert dense, "the dense cases are missing from the report"
+    for case in dense:
+        assert case["invariants"]["truncated_at_limit"] is False
+
+
+def test_the_universal_invariants_hold_even_where_a_case_fails(rehearsed):
+    """A failing shape must not take the universal invariants down with it."""
+    _code, report, _path = rehearsed
+    for case in report["cases"]:
+        assert case["invariants"]["answered_by_snapshot"] is True, case["shape"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Saturated comparisons are not_evaluable, never failures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def dense_dist(tmp_path: Path) -> Path:
+    """An artifact where S1, S3 and S9 all saturate at limit=50.
+
+    Page-set containment is meaningless once either side is truncated: S1's
+    fifty most recent rows across the district need not contain S3's fifty most
+    recent within one sector. The rehearsal must say so rather than report a
+    failure the artifact did not cause.
+    """
+    rows = []
+    for i in range(60):                       # B5 4 -- S3's sector, saturates
+        rows.append(csv_row("{T-B54-%03d}" % i, "B5 4AA", f"2026-05-{i % 28 + 1:02d} 00:00",
+                            200_000 + i))
+    for i in range(60):                       # B5 7 -- widens B5 beyond B5 4
+        rows.append(csv_row("{T-B57-%03d}" % i, "B5 7AA", f"2026-06-{i % 28 + 1:02d} 00:00",
+                            300_000 + i))
+    for i in range(20):                       # category B, so S9 differs from S3
+        rows.append(csv_row("{T-B54B-%03d}" % i, "B5 4AB", f"2026-06-{i % 28 + 1:02d} 00:00",
+                            900_000 + i, ppd_category="B"))
+    csv_path = write_source_csv(tmp_path / "pp.csv", rows)
+    built = build_snapshot(BuildRequest(
+        csv_path=csv_path, out_dir=tmp_path / "snapshot",
+        coverage_to=COVERAGE_TO, temp_dir=tmp_path / "tmp"))
+    release = package_release(
+        built, dist_dir=tmp_path / "dist", candidate_root=tmp_path / "work",
+        version=snapshot_version(datetime(2026, 8, 28, 11, 0, tzinfo=timezone.utc)),
+        source={"file": "pp.csv", "sha256": "b" * 64, "etag": '"dense"'},
+        facts={"rows_per_year": {"2026": len(rows)}},
+    )
+    promote_release(release)
+    return tmp_path / "dist"
+
+
+def _dense_instance(dist_dir: Path) -> dict:
+    payload = valid_instance(dist_dir)
+    payload["geographies"].update({
+        "S4_thin": "B5 6", "S5_dense": "B5 4", "S6_unit": "B5 4AA",
+        "S7_type_weak": "B5 7", "S8_type_strong": "B5 7",
+        "S11_provisional_empty": "B5 6", "S13_empty_unit": "B5 4AA",
+    })
+    return payload
+
+
+@pytest.fixture
+def dense_report(tmp_path, dense_dist):
+    instance = write_instance(tmp_path / "dense.json", _dense_instance(dense_dist))
+    code, _cache, report = run(tmp_path, dense_dist, instance)
+    assert report.exists(), f"no report written (exit {code})"
+    return code, json.loads(report.read_text())
+
+
+def test_saturated_subset_comparisons_are_not_evaluable(dense_report):
+    _code, report = dense_report
+    by = {c["shape"]: c for c in report["cases"]}
+    assert by["S3"]["count"] == 50 and by["S1"]["count"] == 50, "fixture is not saturated"
+
+    not_eval = by["S3"]["not_evaluable"]
+    assert "subset_of_S1" in not_eval, (
+        "a saturated page-set comparison was evaluated instead of being "
+        "reported as not_evaluable"
+    )
+    assert "saturat" in not_eval["subset_of_S1"].lower(), (
+        f"the reason does not name saturation: {not_eval['subset_of_S1']!r}"
+    )
+    assert "subset_of_S1" not in by["S3"]["invariants"], (
+        "a not_evaluable assertion must not also appear as an invariant outcome"
+    )
+
+
+def test_saturated_category_comparison_is_not_evaluable(dense_report):
+    _code, report = dense_report
+    by = {c["shape"]: c for c in report["cases"]}
+    assert "category_all_is_superset_of_default" in by["S9"]["not_evaluable"]
+
+
+def test_not_evaluable_is_never_counted_as_a_pass(dense_report):
+    _code, report = dense_report
+    assert report["assertions_not_evaluable"] > 0, "the fixture should saturate"
+    counted = (report["assertions_passed"] + report["assertions_failed"]
+               + report["assertions_not_evaluable"])
+    assert counted == report["assertions_total"]
+    for case in report["cases"]:
+        overlap = set(case["invariants"]) & set(case["not_evaluable"])
+        assert not overlap, f"{case['shape']} counts {overlap} twice"
+
+
+def test_geography_containment_is_checked_even_when_sets_are_not(dense_report):
+    """Truncation does not excuse geography: it is meaningful on any page."""
+    _code, report = dense_report
+    by = {c["shape"]: c for c in report["cases"]}
+    assert by["S3"]["invariants"]["geography_isolation"] is True
+    assert by["S3"]["invariants"]["within_S1_geography"] is True
+
+
+# ---------------------------------------------------------------------------
+# 5. The rehearsal is a guest: it restores what it found
+# ---------------------------------------------------------------------------
+
+def test_pre_existing_snapshot_environment_is_restored(tmp_path, dist, monkeypatch):
+    """Unsetting a caller's variable would leave their process quietly changed."""
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "0")
+    monkeypatch.setenv("PPD_SNAPSHOT_DIR", "/somewhere/else")
+    monkeypatch.delenv("PPD_SNAPSHOT_CACHE_DIR", raising=False)
+
+    instance = write_instance(tmp_path / "ok.json", valid_instance(dist))
+    run(tmp_path, dist, instance)
+
+    import os
+    assert os.environ["PPD_SNAPSHOT_ENABLED"] == "0", "a caller's flag was not restored"
+    assert os.environ["PPD_SNAPSHOT_DIR"] == "/somewhere/else"
+    assert "PPD_SNAPSHOT_CACHE_DIR" not in os.environ, (
+        "a variable the caller did not set was left behind"
+    )
+
+
+def test_a_pre_existing_installed_adapter_is_restored(tmp_path, dist):
+    """The rehearsal installs its own adapter; it must hand back the caller's."""
+    from property_core.snapshot import state
+
+    sentinel = object()
+    state.install(sentinel, "caller-boot-report")
+    try:
+        instance = write_instance(tmp_path / "ok.json", valid_instance(dist))
+        run(tmp_path, dist, instance)
+        assert state.installed_adapter() is sentinel, (
+            "the rehearsal dropped an adapter the caller had installed"
+        )
+        assert state.boot_report() == "caller-boot-report"
+    finally:
+        state.install(None, None)
+
+
+# ---------------------------------------------------------------------------
+# 6. Latency, date bounds, and midnight accounting
+# ---------------------------------------------------------------------------
+
+def test_each_case_records_latency_and_returned_date_bounds(rehearsed):
+    _code, report, _path = rehearsed
+    for case in report["cases"]:
+        assert isinstance(case["latency_ms"], (int, float)), case["shape"]
+        assert case["latency_ms"] >= 0
+        assert "returned_date_from" in case and "returned_date_to" in case, case["shape"]
+
+
+def test_midnight_accounting_is_reported(rehearsed):
+    _code, report, _path = rehearsed
+    assert report["midnight"]["exclusions"] == 0
+    assert report["midnight"]["retries"] == 0
+    assert report["midnight"]["unrecoverable"] is False
+
+
+# ---------------------------------------------------------------------------
+# 7. The universal invariants really are universal
+# ---------------------------------------------------------------------------
+
+def test_provisional_is_asserted_on_every_case_not_just_one(rehearsed):
+    """Definition section 3 makes it universal, so the harness must check it
+    everywhere. Asserting it on one shape while the contract claims all of them
+    is a gap nothing else would catch: the field would still read `true`."""
+    _code, report, _path = rehearsed
+    for case in report["cases"]:
+        assert "provisional_flagged" in case["invariants"], (
+            f"{case['shape']} does not assert recent_period_provisional, which "
+            f"section 3 makes a universal snapshot-side invariant"
+        )
+        assert case["invariants"]["provisional_flagged"] is True, case["shape"]
+
+
+# ---------------------------------------------------------------------------
+# 8. Aggregate baselines are part of the instance, and validated
+# ---------------------------------------------------------------------------
+
+def test_the_instance_carries_the_declared_aggregate_baselines(tmp_path, dist):
+    from tools.ppd_snapshot.rehearse import load_instance
+
+    instance = write_instance(tmp_path / "ok.json", valid_instance(dist))
+    loaded = load_instance(instance, dist)
+    assert loaded.aggregate_baselines["S1_full"] == 2
+    assert loaded.aggregate_baselines["S3_full"] == 1
+
+
+def test_missing_aggregate_baselines_are_refused(tmp_path, dist):
+    payload = valid_instance(dist)
+    payload.pop("aggregate_baselines")
+    instance = write_instance(tmp_path / "nobase.json", payload)
+    code, _cache, report = run(tmp_path, dist, instance)
+    assert code == 2
+    assert not report.exists()
+
+
+@pytest.mark.parametrize("baselines, why", [
+    ({"S1_full": 1, "S3_full": 2, "S9_full": 3}, "S3 is larger than S1"),
+    # Equality contradicts the contract just as surely: section 4 requires a
+    # STRICT subset, and S3_full == S1_full says the sector is the whole
+    # district. It would have passed a `>` check.
+    ({"S1_full": 5, "S3_full": 5, "S9_full": 6}, "S3 equals S1, so is not strict"),
+    ({"S1_full": 5, "S3_full": 3, "S9_full": 3}, "S9 does not exceed S3"),
+    ({"S1_full": 5, "S3_full": 3}, "a required baseline is missing"),
+    ({"S1_full": 5, "S3_full": 3, "S9_full": 4, "extra": 1}, "an unknown baseline"),
+    ({"S1_full": "many", "S3_full": 3, "S9_full": 4}, "a baseline is not an integer"),
+])
+def test_inconsistent_aggregate_baselines_are_refused(tmp_path, dist, baselines, why):
+    """The baselines ARE the qualification evidence. A set that contradicts the
+    relation it is supposed to establish would qualify nothing."""
+    payload = valid_instance(dist)
+    payload["aggregate_baselines"] = baselines
+    instance = write_instance(tmp_path / f"bad-{abs(hash(why))}.json", payload)
+    code, _cache, report = run(tmp_path, dist, instance)
+    assert code == 2, f"{why} was not refused"
+    assert not report.exists()
+
+
+def test_the_report_records_the_declared_qualification_evidence(rehearsed):
+    """Recorded as DECLARED, not measured: the rehearsal reads pages, so it
+    cannot re-derive a full aggregate count and must not imply it did."""
+    _code, report, _path = rehearsed
+    qual = report["qualification"]
+    assert qual["source"] == "declared in the instance, not measured by this rehearsal"
+    assert qual["baselines"]["S1_full"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 9. An unrecoverable midnight crossing is reported, not just raised
+# ---------------------------------------------------------------------------
+
+def test_an_unrecoverable_midnight_crossing_writes_a_failed_report(
+        tmp_path, dist, monkeypatch):
+    """The Definition says the failure is recorded. Re-raising before the report
+    is written meant the recorded state could never actually occur."""
+    from datetime import date as real_date
+    import tools.ppd_snapshot.rehearse as reh
+
+    ticker = {"n": 0}
+
+    class AlternatingDate(real_date):
+        @classmethod
+        def today(cls):
+            ticker["n"] += 1
+            # Every observation straddles a boundary: before != after, always.
+            return real_date(2026, 8, 29) if ticker["n"] % 2 else real_date(2026, 8, 30)
+
+    monkeypatch.setattr(reh, "date", AlternatingDate)
+
+    instance = write_instance(tmp_path / "ok.json", valid_instance(dist))
+    code, _cache, report = run(tmp_path, dist, instance)
+
+    assert code == 1, f"an unrecoverable crossing must exit 1, got {code}"
+    assert report.exists(), "no report was written for an unrecoverable crossing"
+    body = json.loads(report.read_text())
+    assert body["passed"] is False
+    assert body["midnight"]["unrecoverable"] is True
+    assert body["midnight"]["retries"] > 0
+    assert body["failure"], "the report does not say what went wrong"
+    assert "midnight" in body["failure"].lower()
+    assert body["kind"] == "rehearsal" and body["not_stage_1_evidence"] is True

--- a/tools/ppd_snapshot/__main__.py
+++ b/tools/ppd_snapshot/__main__.py
@@ -459,7 +459,48 @@ def build_parser() -> argparse.ArgumentParser:
     every.add_argument("--source-receipt", required=True,
                        help="the receipt binding the CSV to a release")
     every.set_defaults(handler=_cmd_all)
+
+    rehearse = sub.add_parser(
+        "rehearse",
+        help="run the shadow-corpus Definition against a local artifact")
+    rehearse.add_argument("--instance", required=True,
+                          help="rehearsal instance JSON (untracked, not a Stage 1 instance)")
+    rehearse.add_argument("--dist", required=True,
+                          help="published dist directory: current.json, manifest, bundle")
+    rehearse.add_argument("--cache-dir", required=True,
+                          help="where the snapshot is materialized; ephemeral, put it under /tmp")
+    rehearse.add_argument("--report", required=True,
+                          help="rehearsal report JSON; aggregates only, never rows")
+    rehearse.set_defaults(handler=_cmd_rehearse)
     return parser
+
+
+def _cmd_rehearse(args) -> int:
+    """Run the corpus Definition against one local artifact. Not Stage 1.
+
+    Exit 2 refuses the instance before anything is materialized; 1 means the
+    rehearsal ran and an invariant failed; 0 means every case passed.
+    """
+    from tools.ppd_snapshot.rehearse import InstanceRefused, load_instance
+
+    dist_dir = Path(args.dist)
+    try:
+        instance = load_instance(Path(args.instance), dist_dir)
+    except InstanceRefused as exc:
+        print(f"instance refused: {exc}", file=sys.stderr)
+        return 2
+
+    from tools.ppd_snapshot.rehearse import run_rehearsal
+
+    outcome = run_rehearsal(
+        instance=instance,
+        dist_dir=dist_dir,
+        cache_dir=Path(args.cache_dir),
+        report_path=Path(args.report),
+    )
+    print(f"rehearsal: {outcome['cases_passed']}/{outcome['cases_total']} cases "
+          f"passed; report {args.report}")
+    return 0 if outcome["passed"] else 1
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/tools/ppd_snapshot/rehearse.py
+++ b/tools/ppd_snapshot/rehearse.py
@@ -1,0 +1,705 @@
+"""Local rehearsal of the shadow-corpus Definition against a built artifact.
+
+`docs/design/ppd-shadow-corpus.md` defines the Stage 1 corpus as request shapes
+plus semantic assertions, deliberately carrying no artifact and no concrete
+geographies. This module runs those shapes against one local artifact, through
+the snapshot adapter only, and reports whether each Definition invariant held.
+
+**It is not Stage 1.** There is no live arm, so it can satisfy neither the p95
+criterion nor any divergence criterion, and its report is labelled accordingly.
+What it can establish is that every case is well-formed, routes to the snapshot,
+and produces the shape the Definition says it must.
+
+Three rules shape the implementation:
+
+* **Refuse the instance before materializing.** The instance names the artifact
+  and supplies the geographies the Definition leaves as placeholders. Validating
+  it after boot would burn ~534 MiB and the wall time first, and leave a cache
+  directory nobody can account for. Schema and digest binding are both checked
+  before `SnapshotRuntime` is constructed.
+
+* **No live path.** Sockets are blocked with a self-check proving the block is
+  armed, and every case asserts its provenance says `snapshot`. A rehearsal that
+  silently fell back to live would look exactly like one that did not.
+
+* **Aggregates only in the report.** Some invariants -- subset containment
+  between two cases -- need transaction-id sets. Those sets are built in memory
+  and discarded; the report carries booleans, counts and offending outcodes.
+  No id, price, address or row ever reaches the report or a log line.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import socket
+from dataclasses import dataclass, field
+import time
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any, Optional
+
+#: Exactly these top-level keys. Unknown keys are refused rather than ignored:
+#: a typo in an instance is a silently different rehearsal.
+REQUIRED_KEYS = frozenset({
+    "instance_kind", "snapshot_version", "bundle_sha256", "geographies",
+    "aggregate_baselines",
+})
+
+#: Full-artifact counts that qualify the containment relations. A paged
+#: rehearsal cannot re-derive these -- section 9 says containment is
+#: established here, during instance qualification, not from a page -- so they
+#: are declared, and checked for consistency with what they claim to establish.
+REQUIRED_BASELINES = frozenset({"S1_full", "S3_full", "S9_full"})
+
+#: The Definition's placeholders. Every one must be supplied; no others.
+REQUIRED_GEOGRAPHIES = frozenset({
+    "S4_thin", "S5_dense", "S6_unit", "S7_type_weak",
+    "S8_type_strong", "S11_provisional_empty", "S13_empty_unit",
+})
+
+#: `rehearsal`, never `stage1`. The kind is in the file so a rehearsal instance
+#: cannot be handed to a Stage 1 runner by accident.
+INSTANCE_KIND = "rehearsal"
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_VERSION = re.compile(r"^v\d{8}T\d{6}Z$")
+#: Outward code, optional sector digit, optional unit. Deliberately narrow: a
+#: placeholder that is not a real geography is a corpus error, not a query that
+#: happens to return nothing.
+_GEOGRAPHY = re.compile(r"^[A-Z]{1,2}\d[A-Z\d]?( \d([A-Z]{2})?)?$")
+
+
+class InstanceRefused(Exception):
+    """The instance is malformed, incomplete, or bound to another artifact.
+
+    Raised before anything is materialized. The CLI maps it to exit 2.
+    """
+
+
+@dataclass(frozen=True)
+class RehearsalInstance:
+    instance_kind: str
+    snapshot_version: str
+    bundle_sha256: str
+    geographies: dict[str, str]
+    aggregate_baselines: dict[str, int]
+
+
+def _published_manifest(dist_dir: Path) -> dict[str, Any]:
+    """Read the dist pointer and manifest. Metadata only -- nothing is opened."""
+    current = dist_dir / "current.json"
+    if not current.is_file():
+        raise InstanceRefused(f"no current.json in {dist_dir}")
+    try:
+        pointer = json.loads(current.read_text())
+        name = pointer["current_manifest"]
+        return json.loads((dist_dir / name).read_text())
+    except (OSError, ValueError, KeyError) as exc:
+        raise InstanceRefused(f"unreadable dist pointer or manifest: {exc}") from exc
+
+
+def load_instance(path: Path, dist_dir: Path) -> RehearsalInstance:
+    """Validate the instance and bind it to the artifact at `dist_dir`.
+
+    Structure first, then binding. Both complete before any materialization, so
+    a refused instance costs a file read rather than half a gigabyte.
+    """
+    try:
+        raw = json.loads(Path(path).read_text())
+    except FileNotFoundError as exc:
+        raise InstanceRefused(f"instance file not found: {path}") from exc
+    except (OSError, ValueError) as exc:
+        raise InstanceRefused(f"instance is not readable JSON: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise InstanceRefused("instance must be a JSON object")
+
+    keys = set(raw)
+    if missing := REQUIRED_KEYS - keys:
+        raise InstanceRefused(f"instance is missing required key(s): {sorted(missing)}")
+    if unknown := keys - REQUIRED_KEYS:
+        raise InstanceRefused(f"instance carries unknown key(s): {sorted(unknown)}")
+
+    if raw["instance_kind"] != INSTANCE_KIND:
+        raise InstanceRefused(
+            f"instance_kind is {raw['instance_kind']!r}; this tool runs "
+            f"{INSTANCE_KIND!r} instances only. A Stage 1 instance is not a "
+            f"rehearsal and must not be run through it."
+        )
+
+    version, digest = raw["snapshot_version"], raw["bundle_sha256"]
+    if not isinstance(version, str) or not _VERSION.match(version):
+        raise InstanceRefused(f"snapshot_version is not a version string: {version!r}")
+    if not isinstance(digest, str) or not _SHA256.match(digest):
+        raise InstanceRefused("bundle_sha256 is not a 64-character hex digest")
+
+    geographies = raw["geographies"]
+    if not isinstance(geographies, dict):
+        raise InstanceRefused("geographies must be a JSON object")
+    supplied = set(geographies)
+    if missing := REQUIRED_GEOGRAPHIES - supplied:
+        raise InstanceRefused(
+            f"the Definition's placeholder(s) {sorted(missing)} are unsupplied")
+    if unknown := supplied - REQUIRED_GEOGRAPHIES:
+        raise InstanceRefused(
+            f"geographies carries unknown placeholder(s): {sorted(unknown)}")
+    for key, value in sorted(geographies.items()):
+        if not isinstance(value, str) or not _GEOGRAPHY.match(value.strip().upper()):
+            raise InstanceRefused(
+                f"{key} is {value!r}, which is not a postcode, sector or outcode")
+
+    baselines = raw["aggregate_baselines"]
+    if not isinstance(baselines, dict):
+        raise InstanceRefused("aggregate_baselines must be a JSON object")
+    supplied_b = set(baselines)
+    if missing := REQUIRED_BASELINES - supplied_b:
+        raise InstanceRefused(
+            f"aggregate_baselines is missing {sorted(missing)}; these are the "
+            f"qualification evidence for the containment relations")
+    if unknown := supplied_b - REQUIRED_BASELINES:
+        raise InstanceRefused(
+            f"aggregate_baselines carries unknown key(s): {sorted(unknown)}")
+    for key in sorted(REQUIRED_BASELINES):
+        value = baselines[key]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise InstanceRefused(
+                f"aggregate_baselines[{key}] is {value!r}, not a count")
+    # The baselines exist to establish two relations. A set that contradicts
+    # them qualifies nothing, and would be worse than absent: it would look
+    # like evidence.
+    if baselines["S3_full"] >= baselines["S1_full"]:
+        raise InstanceRefused(
+            f"aggregate_baselines say S3 holds {baselines['S3_full']} rows and "
+            f"S1 holds {baselines['S1_full']}; S3 is one sector inside S1's "
+            f"district, and the Definition requires a STRICT subset. Equal "
+            f"counts would say the sector is the whole district, which "
+            f"qualifies nothing.")
+    if baselines["S9_full"] <= baselines["S3_full"]:
+        raise InstanceRefused(
+            f"aggregate_baselines say S9 ({baselines['S9_full']}) does not "
+            f"exceed S3 ({baselines['S3_full']}); including category B cannot "
+            f"return fewer rows than excluding it")
+
+    # Binding: the instance must name the artifact it is about to be run
+    # against. An instance that is internally valid but describes a different
+    # snapshot would produce a report whose provenance is a fiction.
+    manifest = _published_manifest(dist_dir)
+    if manifest.get("snapshot_version") != version:
+        raise InstanceRefused(
+            f"instance names snapshot_version {version}, but {dist_dir} publishes "
+            f"{manifest.get('snapshot_version')}"
+        )
+    if manifest.get("bundle_sha256") != digest:
+        raise InstanceRefused(
+            f"instance bundle_sha256 does not match the digest published in "
+            f"{dist_dir}; the instance describes a different artifact"
+        )
+
+    return RehearsalInstance(
+        instance_kind=raw["instance_kind"],
+        snapshot_version=version,
+        bundle_sha256=digest,
+        geographies={k: v.strip().upper() for k, v in geographies.items()},
+        aggregate_baselines=dict(baselines),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Socket blocker
+# ---------------------------------------------------------------------------
+
+class LivePathAttempted(RuntimeError):
+    """Something tried to open a socket during a rehearsal."""
+
+
+@dataclass
+class SocketBlocker:
+    """Hard-fail every socket for the duration, and prove it is armed.
+
+    An unarmed blocker is worse than none: the run would look isolated while
+    quietly reaching the network, and the report would claim a rehearsal that
+    was partly a live query.
+    """
+
+    _original: Any = field(default=None, init=False)
+
+    def arm(self) -> None:
+        self._original = socket.socket
+
+        def _refuse(*_args, **_kwargs):
+            raise LivePathAttempted(
+                "a rehearsal attempted to open a socket; no live path may be "
+                "constructed during a rehearsal"
+            )
+
+        socket.socket = _refuse  # type: ignore[assignment]
+        self.self_check()
+
+    def self_check(self) -> None:
+        """Prove the block actually fires, rather than assuming the patch took."""
+        try:
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        except LivePathAttempted:
+            return
+        raise RuntimeError(
+            "socket blocker did not fire on its own self-check; refusing to "
+            "run a rehearsal that cannot prove it is isolated"
+        )
+
+    def disarm(self) -> None:
+        if self._original is not None:
+            socket.socket = self._original  # type: ignore[assignment]
+            self._original = None
+
+
+# ---------------------------------------------------------------------------
+# Case shapes -- the Definition's S1..S14
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Case:
+    """One corpus shape, with the Definition's frozen parameters attached."""
+
+    shape: str
+    intent: str
+    postcode: str
+    search_level: str
+    months: int = 24
+    property_type: Optional[str] = None
+    transaction_category: Optional[str] = "A"
+
+    def request(self) -> dict[str, Any]:
+        """The wire request, with omissions recorded as omissions.
+
+        `property_type=None` and `address=None` are not values the HTTP surface
+        can carry: omission is the only way to ask for the residential default.
+        The record says so rather than implying a null was sent.
+        """
+        wire: dict[str, Any] = {
+            "postcode": self.postcode,
+            "search_level": self.search_level,
+            "months": self.months,
+            "limit": 50,
+            "transaction_category": self.transaction_category or "all",
+            "filter_outliers": False,
+            "auto_escalate": True,
+            "enrich_epc": False,
+        }
+        if self.property_type is None:
+            wire["property_type"] = "<omitted>"
+        else:
+            wire["property_type"] = self.property_type
+        wire["address"] = "<omitted>"
+        return wire
+
+    def effective(self) -> dict[str, Any]:
+        return {
+            "property_type": (self.property_type
+                              or "residential_default (F/D/S/T)"),
+            "address": None,
+            "transaction_category": self.transaction_category,
+        }
+
+
+def cases(geo: dict[str, str]) -> list[Case]:
+    """The Definition's thirteen shapes, with placeholders resolved."""
+    return [
+        Case("S1", "contamination boundary", "B5", "district"),
+        Case("S2", "reverse boundary", "B50", "district"),
+        Case("S3", "sector isolation", "B5 4", "sector"),
+        Case("S4", "thin market", geo["S4_thin"], "sector"),
+        Case("S5", "dense market and truncation", geo["S5_dense"], "sector"),
+        Case("S6", "exact-postcode geography", geo["S6_unit"], "postcode"),
+        Case("S7", "type filter barely bites", geo["S7_type_weak"], "sector",
+             property_type="F"),
+        Case("S8", "type filter genuinely bites", geo["S8_type_strong"], "sector",
+             property_type="F"),
+        Case("S9", "category filtering", "B5 4", "sector",
+             transaction_category=None),
+        # S10 removed: "provisional tail, non-empty" discriminates nothing now
+        # that every comps case is provisional (Definition section 3).
+        Case("S11", "provisional flag is a window property",
+             geo["S11_provisional_empty"], "sector", months=6),
+        Case("S12", "widest window, deepest history", "B5", "district", months=120),
+        Case("S13", "expected empty", geo["S13_empty_unit"], "postcode",
+             property_type="D"),
+        Case("S14", "expected empty, sector shape", "B5 4", "sector",
+             property_type="T"),
+    ]
+
+
+def derived_from_date(observed_at: date, months: int) -> str:
+    """The window a harness must reconstruct; `comps` does not report it.
+
+    Mirrors `PPDService.comps`. Pinned behaviourally in
+    `tests/snapshot/test_shadow_corpus_definition.py`, because if this drifts,
+    every window recorded by every observation is wrong.
+    """
+    return (observed_at - timedelta(days=months * 30)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Running the rehearsal
+# ---------------------------------------------------------------------------
+
+def _outcodes(transactions: Any) -> list[str]:
+    """Distinct outcodes in a result. Geography membership, never rows."""
+    seen = set()
+    for t in transactions:
+        pc = (getattr(t, "postcode", None) or "").strip().upper()
+        head = pc.partition(" ")[0]
+        if head:
+            seen.add(head)
+    return sorted(seen)
+
+
+def _sectors(transactions: Any) -> list[str]:
+    seen = set()
+    for t in transactions:
+        pc = (getattr(t, "postcode", None) or "").strip().upper()
+        head, _, tail = pc.partition(" ")
+        if head and tail:
+            seen.add(f"{head} {tail[0]}")
+    return sorted(seen)
+
+
+def _ids(transactions: Any) -> set[str]:
+    """In-memory only. Used for containment; never returned or written."""
+    return {t.transaction_id for t in transactions if getattr(t, "transaction_id", None)}
+
+
+class MidnightCrossing(RuntimeError):
+    """An observation could not be taken within a single calendar date.
+
+    Carries the attempts already made: they are the evidence that the guard
+    tried, and are lost if only the message survives.
+    """
+
+    def __init__(self, message: str, *, retries: int = 0) -> None:
+        super().__init__(message)
+        self.retries = retries
+
+
+def _observe(service: Any, case: Case, *,
+             attempts: int = 3) -> tuple[Any, str, int, float]:
+    """One case, guaranteed inside a single calendar date.
+
+    `comps` derives its window from `date.today()`, so an observation that
+    straddles midnight silently describes a different window than the one
+    recorded. Retry that case; if a same-date observation cannot be obtained,
+    fail the rehearsal rather than keep an observation whose window is unknown.
+    """
+    retries = 0
+    for _ in range(attempts):
+        before = date.today()
+        started = time.monotonic()
+        response = service.comps(
+            postcode=case.postcode,
+            search_level=case.search_level,
+            months=case.months,
+            property_type=case.property_type,
+            transaction_category=case.transaction_category,
+            filter_outliers=False,
+            limit=50,
+            auto_escalate=True,
+        )
+        elapsed_ms = (time.monotonic() - started) * 1000.0
+        after = date.today()
+        if before == after:
+            return response, before.isoformat(), retries, elapsed_ms
+        retries += 1
+    raise MidnightCrossing(
+        f"{case.shape}: the midnight guard could not obtain a same-date "
+        f"observation in {attempts} attempts. `comps` derives its window from "
+        f"date.today(), so the window recorded for this case would not describe "
+        f"the query that was actually run.",
+        retries=retries,
+    )
+
+
+def _warning_classes(warnings: tuple[str, ...]) -> list[str]:
+    """The Definition's classes, matched by their published predicates."""
+    found = []
+    for w in warnings:
+        if "beyond snapshot coverage" in w and "are not included" in w:
+            found.append("coverage_clamp")
+        if "narrowed to" in w and "coverage" in w:
+            found.append("coverage_floor_narrowing")
+        if "days behind its coverage end" in w:
+            found.append("freshness")
+        if w.startswith("auto-escalation not applied:"):
+            found.append("escalation_containment")
+        if "the upstream window was not exhausted" in w:
+            found.append("live_incompleteness")
+        if "removed by geography containment" in w:
+            found.append("geography_containment")
+    return sorted(set(found))
+
+
+def run_rehearsal(*, instance: RehearsalInstance, dist_dir: Path,
+                  cache_dir: Path, report_path: Path) -> dict[str, Any]:
+    """Materialize, run every case adapter-only, and write an aggregate report.
+
+    The instance is already validated and bound when this is called: nothing
+    here re-checks it, and nothing before this point materializes anything.
+    """
+    import os
+
+    blocker = SocketBlocker()
+    blocker.arm()
+
+    # A rehearsal is a guest in whatever process runs it. Capture what was
+    # there -- including "not set", which is different from "set to empty" --
+    # so the caller's process is unchanged afterwards.
+    managed = ("PPD_SNAPSHOT_ENABLED", "PPD_SNAPSHOT_DIR", "PPD_SNAPSHOT_CACHE_DIR")
+    prior_env = {k: os.environ.get(k) for k in managed}
+
+    os.environ["PPD_SNAPSHOT_ENABLED"] = "1"
+    os.environ["PPD_SNAPSHOT_DIR"] = str(dist_dir)
+    os.environ["PPD_SNAPSHOT_CACHE_DIR"] = str(cache_dir)
+
+    from property_core.ppd_service import PPDService
+    from property_core.snapshot import state
+    from property_core.snapshot.adapter import SnapshotAdapter
+    from property_core.snapshot.runtime import SnapshotRuntime
+    from property_core.snapshot.source import LocalDirectorySource
+    from property_core.snapshot.store import SnapshotStore
+
+    prior_adapter = state.installed_adapter()
+    prior_report = state.boot_report()
+
+    failure: Optional[str] = None
+    results: list[dict[str, Any]] = []
+    id_sets: dict[str, set[str]] = {}
+    counts: dict[str, int] = {}
+    midnight = {"exclusions": 0, "retries": 0, "unrecoverable": False}
+    adapter = None
+    try:
+        store = SnapshotStore(cache_dir)
+        runtime = SnapshotRuntime(source=LocalDirectorySource(dist_dir), store=store)
+        boot = runtime.boot()
+        if not boot.ready or not boot.snapshot_dir:
+            raise RuntimeError(f"snapshot did not boot READY: {boot}")
+
+        adapter = SnapshotAdapter.open(Path(boot.snapshot_dir), store.verified_record(
+            boot.version) if hasattr(store, "verified_record") else boot.record)
+        state.install(adapter, boot)
+
+        service = PPDService()
+        for case in cases(instance.geographies):
+            response, observed, retries, latency_ms = _observe(service, case)
+            midnight["retries"] += retries
+            midnight["exclusions"] += retries
+            provenance = response.provenance
+            warnings = tuple(response.warnings or ())
+            classes = _warning_classes(warnings)
+            id_sets[case.shape] = _ids(response.transactions)
+            counts[case.shape] = response.count
+            dates = sorted(t.date for t in response.transactions if getattr(t, "date", None))
+
+            results.append({
+                "shape": case.shape,
+                "intent": case.intent,
+                "request": {"wire": case.request(), "effective": case.effective()},
+                "observed_at_before": observed,
+                "observed_at_after": observed,
+                "derived_from_date": derived_from_date(
+                    date.fromisoformat(observed), case.months),
+                "resolved_to_date": provenance.coverage_to if provenance else None,
+                "count": response.count,
+                "latency_ms": round(latency_ms, 2),
+                "returned_date_from": dates[0] if dates else None,
+                "returned_date_to": dates[-1] if dates else None,
+                "thin_market": response.thin_market,
+                "outcodes_returned": _outcodes(response.transactions),
+                "sectors_returned": _sectors(response.transactions),
+                "warning_classes": classes,
+                "provenance": {
+                    "source": (provenance.source.value
+                               if provenance and hasattr(provenance.source, "value")
+                               else str(provenance.source) if provenance else None),
+                    "coverage_from": provenance.coverage_from if provenance else None,
+                    "coverage_to": provenance.coverage_to if provenance else None,
+                    "recent_period_provisional": (
+                        provenance.recent_period_provisional if provenance else None),
+                    "sample_count": provenance.sample_count if provenance else None,
+                    "sample_limit": provenance.sample_limit if provenance else None,
+                    "sample_complete": provenance.sample_complete if provenance else None,
+                    "completeness_basis": (
+                        str(provenance.completeness_basis)
+                        if provenance and provenance.completeness_basis else None),
+                },
+                "invariants": _invariants(case, response, provenance, classes),
+                "not_evaluable": {},
+            })
+    except MidnightCrossing as exc:
+        # Recorded, not raised past the report. The Definition says an
+        # unrecoverable crossing fails the run clearly; a traceback with no
+        # report is not clearly, and leaves nothing to review afterwards.
+        midnight["unrecoverable"] = True
+        midnight["retries"] += getattr(exc, "retries", 0)
+        midnight["exclusions"] += getattr(exc, "retries", 0)
+        failure = str(exc)
+    finally:
+        # Close OUR adapter, then hand back whatever the caller had installed.
+        # `state.clear()` would close the caller's adapter too, which is not
+        # ours to close.
+        if adapter is not None:
+            close = getattr(adapter, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # noqa: BLE001
+                    pass
+        if prior_adapter is None:
+            state.install(None, None)
+        else:
+            state.install(prior_adapter, prior_report)
+
+        blocker.disarm()
+        for key, value in prior_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    if failure is None:
+        _cross_case_invariants(results, id_sets, counts)
+    id_sets.clear()
+
+    # An assertion is passed, failed, or not evaluable. `not_evaluable` is
+    # counted on its own and never as a pass: a saturated comparison is an
+    # unanswerable question, not a satisfied one.
+    a_passed = sum(1 for r in results for v in r["invariants"].values() if v is True)
+    a_failed = sum(1 for r in results for v in r["invariants"].values() if v is False)
+    a_uneval = sum(len(r["not_evaluable"]) for r in results)
+    passed = sum(1 for r in results
+                 if all(v is True for v in r["invariants"].values()))
+    report = {
+        "kind": "rehearsal",
+        "not_stage_1_evidence": True,
+        "disclaimer": (
+            "A rehearsal has no live arm, so it can satisfy neither the p95 "
+            "criterion nor any divergence criterion of Stage 1. This report is "
+            "a correctness exercise and must never be filed as Stage 1 evidence."
+        ),
+        "definition": "docs/design/ppd-shadow-corpus.md",
+        "artifact": {
+            "snapshot_version": instance.snapshot_version,
+            "bundle_sha256": instance.bundle_sha256,
+            "dist_dir": str(dist_dir),
+        },
+        "isolation": {
+            "socket_blocker_armed": True,
+            "self_check_passed": True,
+            "live_adapter_constructed": False,
+        },
+        "midnight": midnight,
+        "failure": failure,
+        "qualification": {
+            "source": "declared in the instance, not measured by this rehearsal",
+            "baselines": dict(instance.aggregate_baselines),
+            "note": (
+                "Containment between cases is qualified from these full "
+                "aggregate counts. A paged rehearsal cannot re-derive them, so "
+                "it records them rather than claiming to have measured them."
+            ),
+        },
+        "cases_total": len(results),
+        "cases_passed": passed,
+        "assertions_total": a_passed + a_failed + a_uneval,
+        "assertions_passed": a_passed,
+        "assertions_failed": a_failed,
+        "assertions_not_evaluable": a_uneval,
+        # A run may exit 0 with not_evaluable assertions present; it may never
+        # exit 0 with a failed one.
+        "passed": (a_failed == 0 and not midnight["unrecoverable"]
+                   and failure is None),
+        "cases": results,
+    }
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=False))
+    return report
+
+
+def _invariants(case: Case, response: Any, provenance: Any,
+                classes: list[str]) -> dict[str, bool]:
+    """The Definition's per-case assertions. Booleans only."""
+    inv: dict[str, bool] = {
+        # Universal (Definition section 3): comps never sends to_date.
+        "coverage_clamp_warning_present": "coverage_clamp" in classes,
+        "sample_complete_is_false": bool(
+            provenance is not None and provenance.sample_complete is False),
+        "completeness_basis_is_null": bool(
+            provenance is not None and provenance.completeness_basis is None),
+        "answered_by_snapshot": bool(
+            provenance is not None and "snapshot" in str(provenance.source).lower()),
+        # Universal, not per-shape: the resolved upper bound is always
+        # `coverage_to` and `provisional_from` never exceeds it, so every comps
+        # window intersects the provisional period (Definition section 3).
+        "provisional_flagged": bool(
+            provenance is not None and provenance.recent_period_provisional is True),
+    }
+
+    outcodes = _outcodes(response.transactions)
+    requested_outcode = case.postcode.split()[0].upper()
+    if case.search_level in {"district", "sector", "postcode"}:
+        inv["geography_isolation"] = all(o == requested_outcode for o in outcodes)
+
+    if case.shape in {"S5", "S12"}:
+        inv["truncated_at_limit"] = response.count == 50
+    if case.shape == "S4":
+        inv["thin_market_flagged"] = response.thin_market is True
+    if case.shape == "S11":
+        inv["empty_result"] = response.count == 0
+    if case.shape in {"S13", "S14"}:
+        inv["expected_empty"] = response.count == 0
+    return inv
+
+
+#: The page size every case is frozen at. A result of exactly this length was
+#: truncated, and a truncated page cannot answer a containment question.
+LIMIT = 50
+
+_SATURATED = (
+    "not evaluable: {a} returned {na} rows and {b} returned {nb}, and a page "
+    "saturated at limit={limit} is not a subset of a wider page ordered "
+    "most-recent-first. Containment is established from full aggregate counts "
+    "during instance qualification, not from a page."
+)
+
+
+def _cross_case_invariants(results: list[dict[str, Any]],
+                           id_sets: dict[str, set[str]],
+                           counts: dict[str, int]) -> None:
+    """Containment between cases, from id sets held only in memory.
+
+    The sets never reach the report: the outcome is a boolean, a count, or a
+    `not_evaluable` reason. Where either side is saturated the question is
+    unanswerable on pages, and saying so is more honest than reporting a
+    failure the artifact did not cause.
+    """
+    by_shape = {r["shape"]: r for r in results}
+
+    def _compare(name: str, subject: str, a: str, b: str) -> None:
+        if a not in id_sets or b not in id_sets:
+            return
+        if counts.get(a) == LIMIT or counts.get(b) == LIMIT:
+            by_shape[subject]["not_evaluable"][name] = _SATURATED.format(
+                a=a, na=counts.get(a), b=b, nb=counts.get(b), limit=LIMIT)
+            return
+        by_shape[subject]["invariants"][name] = id_sets[a] <= id_sets[b]
+
+    _compare("subset_of_S1", "S3", "S3", "S1")
+    _compare("category_all_is_superset_of_default", "S9", "S3", "S9")
+
+    # Geography containment survives truncation: however a page was cut, every
+    # row S3 returns must lie inside the outcode S1 asked for. This is the
+    # containment check that stays meaningful when the set comparison cannot.
+    if "S3" in by_shape and "S1" in by_shape:
+        s1_outcode = by_shape["S1"]["request"]["wire"]["postcode"].split()[0].upper()
+        by_shape["S3"]["invariants"]["within_S1_geography"] = all(
+            o == s1_outcode for o in by_shape["S3"]["outcodes_returned"])
+
+    id_sets.clear()


### PR DESCRIPTION
Step 4 of the PPD snapshot rollout order. **Docs, tests and local operator tooling only** — `tools/` is outside the published wheel. No live SPARQL, artifact, image, fly config, flag, dependency or deployment surface is touched, and **no Stage 1 evidence is produced**.

## What this adds

`tools.ppd_snapshot rehearse --instance --dist --cache-dir --report` runs the corpus Definition against one already-built local artifact, through the snapshot adapter only.

**It is not Stage 1 and cannot become it.** There is no live arm, so no p95 or divergence criterion is reachable, and the report says so in its own body.

| Exit | Meaning |
|---|---|
| **2** | instance refused — before anything is materialized |
| **1** | ran, and an assertion failed |
| **0** | every meaningful assertion passed |

## What running it against the real artifact corrected

None of these were visible from reading the Definition; three survived several rounds of careful review.

**1. `recent_period_provisional` is universal, not per-case.** The resolved upper bound is always `coverage_to` and `provisional_from` never exceeds it, so *every* comps window intersects the provisional period — it held on all fourteen cases. §3 now records it alongside the coverage clamp. **S10 is removed**: "provisional tail, non-empty" discriminated nothing. **S11 is retained** — an *empty* result that must still be flagged provisional is the control with teeth.

**2. Page-set containment is unanswerable at `limit=50`.** S1's fifty most recent rows across a district need not contain S3's fifty within one of its sectors — 39 of S3's ids sat outside S1's page. The corpus was asking a question its own page size forbids. Now: containment is qualified from **full aggregate counts declared in the instance**; the rehearsal reports **`not_evaluable` with its reason** when either side is saturated; and **geography containment is always checked**, because it stays meaningful on any page.

**3. `not_evaluable` is never a pass.** Counted separately from passes and failures. A run may exit 0 with them present; never with a failure.

**4. The recorded midnight-failure state could not occur.** `MidnightCrossing` was re-raised before the report was written, making `unrecoverable: true` unreachable. It now writes a failed aggregate-only report and returns 1. Two follow-on bugs surfaced only once a test forced the path: the retry count was computed locally and **lost on failure**, and the message never named the guard that produced it.

## Instance schema

`aggregate_baselines` (`S1_full`, `S3_full`, `S9_full`), validated before materialization: counts; `S3_full < S1_full` **strictly** — equality would say the sector is the whole district; `S9_full > S3_full`, because including category B cannot return fewer rows. A baseline set contradicting the relation it exists to establish is refused: it would look like evidence while qualifying nothing. Recorded as **declared, not measured** — a paged rehearsal cannot re-derive a full aggregate count.

## Isolation — proven, not assumed

Sockets hard-failed **with a self-check**: an unarmed blocker is worse than none, because the report would claim isolation it did not have. Every case *separately* asserts its answer carried snapshot provenance.

The rehearsal is a guest in whatever process runs it: pre-existing `PPD_SNAPSHOT_*` values are captured — including *not set*, which differs from *set to empty* — and restored; a caller's installed adapter is handed back rather than closed, since `state.clear()` would have closed an adapter that was not ours.

## Report hygiene

Counts, geography membership, provenance, warning classes, latency, returned date bounds, invariant outcomes. Id sets exist only in memory for containment and are discarded. **No id, price or address reaches the report** — verified against the real 24.6 KB output.

## Verification

**Real rehearsal** against `v20260828T194003Z` (`50f802b2…9072c`): **exit 0**, 13/13 cases, **85 assertions passed, 0 failed, 2 not_evaluable**, no midnight exclusions, isolation armed and self-checked, `PPD_SNAPSHOT_ENABLED=0` restored intact. The two `not_evaluable` are the saturated containment comparisons — the correct answer, not a failure.

**36 tests, red before each change.** A fixture bug nearly made the contamination check vacuous — rows outside the 24-month window meant S1 returned nothing and "no B50 present" passed for the wrong reason — caught because the assertion pins the positive result rather than the absence.

Full suite **1,587 passed / 26 skipped**, from the 1,576 / 26 baseline. `git diff --stat` over both fly configs, both Dockerfiles, `pyproject.toml`, `uv.lock`, `.github/` and all four consumer packages is empty.

## Not in this PR

The Stage 1 corpus **Instance** (artifact selection, qualification, baselines for the real run) — a later prerequisite for Stage 1, not part of the local rehearsal. Then Step 5 onward: artifact distribution and the Royal Mail review, the dependency-only image change, G1a, Stage 1, Stage 2, G1b, Stage 3, v1.15. Each separately authorized.