### PR TITLE
docs(ppd): reconcile rollout status with what merged (spec rev 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased — v1.15.0 (pending): PPD snapshot source routing + live-path correctness containment
 
-Not released. No version bump. **Five** PRs against the design in
-`docs/design/ppd-source-routing.md`, now at rev 7.
+Not released. No version bump. **Five implementation PRs** (#24-#28) and
+**three rollout-preparation PRs** (#29-#31), against the design in
+`docs/design/ppd-source-routing.md`, now at rev 8. The rollout-preparation PRs
+change documents and tests only: they touch no Dockerfile, fly config, image,
+secret, dependency, flag or deployment.
 
 **`PPD_SNAPSHOT_ENABLED` is off by default, and nothing about the deployed
 behaviour changes while it stays off.** With no snapshot materialized every PPD
@@ -120,11 +123,14 @@ coverage take effect only once a snapshot is enabled and materialized.
   which live only in the optional `snapshot` extra. Neither production image
   installs it (`--extra api` / `--extra apps`), which is correct while the flag
   is off because the runtime is never booted. G3 requires all four of: both
-  Dockerfiles installing `--extra snapshot` unconditionally *before* routing is
-  introduced; built-image smoke tests importing both packages in the actual
-  image; flag-on with either dependency unavailable failing closed with snapshot
-  readiness false; and the production flag staying off until those checks plus
-  G1 and G2 pass. Requirements 2 and 3 belong to PR 4 / the rollout.
+  Dockerfiles installing `--extra snapshot` unconditionally, with that
+  dependency-only change landing, deploying and being observed while
+  `PPD_SNAPSHOT_ENABLED` is off, before any snapshot enablement; built-image
+  smoke tests importing both packages in the actual image; flag-on with either
+  dependency unavailable failing closed with snapshot readiness false; and the
+  production flag staying off until those checks, G2, and the G1 gate for the
+  target being enabled — G1a for `property-shared`, G1b for `propertydata` —
+  all pass. Requirements 2 and 3 belong to PR 4 / the rollout.
   A repository-config lint ships here as a **secondary guard only** — it reads
   checked-in Dockerfiles and fly configs, so it cannot see the flag being enabled
   by a Fly secret or injected environment. Both packages stay optional and stay
@@ -275,6 +281,38 @@ coverage take effect only once a snapshot is enabled and materialized.
   against.
 - Optional `snapshot` extra (`duckdb==1.5.5`) and `PPD_SNAPSHOT_ENABLED`
   (default **off**). The published library gains no required dependency.
+- **The Stage 1 shadow corpus, frozen** (`docs/design/ppd-shadow-corpus.md`) —
+  the fixed set of `comps` request shapes the Stage 1 shadow will run through
+  both adapters, with frozen parameters, universal invariants, executable
+  warning-class predicates, recording rules and a four-class divergence taxonomy.
+  Split into a **Definition** and an artifact-bound **Instance**: the Definition
+  carries no artifact, date or count, so a monthly rebuild produces a new
+  Instance rather than rewriting the evidence for a run already under way.
+  Warning *classes* are compared, never warning *text*, because snapshot and
+  live warnings are deliberately worded differently by source — and each
+  substring is pinned against the call site that emits it, so a reworded warning
+  fails loudly instead of leaving the corpus silently matching nothing.
+- **A local rehearsal of that corpus** (`tools.ppd_snapshot rehearse`), outside
+  the published wheel. Adapter-only, sockets hard-failed with a self-check, the
+  instance refused before anything is materialized. Running it against a real
+  artifact corrected four things the Definition had wrong, none visible from
+  reading it — the provisional flag is universal rather than per-case; page-set
+  containment is unanswerable at `limit=50` and moved to declared aggregate
+  counts; `not_evaluable` is never a pass; and the recorded midnight-failure
+  state could not occur. All four were applied before the freeze.
+  **A rehearsal is not Stage 1 and can never become it:** with no live arm it
+  satisfies no p95 and no divergence criterion, and its reports are marked
+  `not_stage_1_evidence`. Summary of the real run:
+  `docs/ops/ppd-shadow-rehearsal-summary.md`.
+- **The artifact-distribution scope determination**
+  (`docs/design/ppd-artifact-distribution-decision.md`) — the owner's decision
+  permitting private delivery of the bundle to project-controlled Fly Machines
+  for internal, read-only price-information use. No public download, no surface
+  serving the bundle or bulk rows, no address use outside price information,
+  attribution unchanged. **It grants no mutation authority:** hosting,
+  credentials, transport, retention and audit remain a separate design and a
+  separate authorisation, and it settles exactly one of the four Royal Mail
+  review triggers in specification §6.
 - `docs/design/ppd-source-routing.md` — the frozen specification governing this
   work.
 
@@ -305,11 +343,19 @@ coverage take effect only once a snapshot is enabled and materialized.
   changing which area a caller's request covers is a behaviour change of its
   own. Both paths return the requested area with a warning saying why, and the
   reason differs by source because the reasons genuinely differ.
-- Artifact distribution, the shadow corpus, and rollout gates G1–G3. No
-  Dockerfile, Fly config, image, secret or deployment is touched here, and
-  neither production image installs the `snapshot` extra yet — which G3 requires
-  **before** the flag may be enabled. The build pipeline produces a bundle on a
-  workstation and stops there; where one would be hosted is separately approved.
+- **Rollout gates G1a, G1b, G2 and G3**, and every deployment step behind them.
+  No Dockerfile, Fly config, image, secret or deployment is touched here, and
+  neither production image installs the `snapshot` extra yet — which G3 requires,
+  landed and observed with the flag off, before the flag may be enabled.
+- **Artifact distribution, as built.** Its *scope* is now determined (above); its
+  hosting, credentials, transport, retention and audit are not designed, and
+  nothing is hosted. The build pipeline produces a bundle on a workstation and
+  stops there.
+- **The Stage 1 production shadow.** No dual-read, sampling or diff-recording
+  code path exists in `property_core`, the API or either MCP server. The corpus
+  is defined and rehearsed locally; Stage 1 additionally needs that production
+  instrumentation, a corpus Instance bound to a selected artifact, and an
+  artifact materialized on a deployed Machine.
 - **A measurement the rollout needs:** the real eleven-partition **year-only**
   bundle is **266.2 MiB**, not the 214 MiB §1.1 previously estimated — that figure is a
   year+area measurement, while §1.2 mandates year-only, which the same Phase 3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,10 @@ property_app/               # FastMCP MCP app server (4th consumer of property_c
 └── dashboards/             # Prefab UI dashboard views
 
 tools/                      # Local operator tooling. NOT in the published wheel.
-└── ppd_snapshot/           # PPD snapshot build + validation pipeline. Local
-                            # build only, no distribution — see
+└── ppd_snapshot/           # PPD snapshot build + validation pipeline, and the
+                            # local shadow-corpus rehearsal. Local build only;
+                            # distribution scope is determined but its hosting
+                            # and transport are not designed or built — see
                             # docs/ops/ppd-snapshot-build.md
 ```
 

--- a/docs/design/ppd-artifact-distribution-decision.md
+++ b/docs/design/ppd-artifact-distribution-decision.md
@@ -1,0 +1,105 @@
+# PPD snapshot artifact distribution — scope determination
+
+**Owner:** Paul Boucherat
+**Date:** 2026-08-29
+**Status:** determined, for the scope below only
+**Governs:** [`ppd-source-routing.md`](ppd-source-routing.md) §4.8 and the fourth
+Royal Mail review trigger in §6
+
+---
+
+## What this is, and what it is not
+
+This records **the owner's determination of permitted scope** for distributing
+the PPD snapshot bundle. It is an operational decision by the party responsible
+for this project, made under the existing HM Land Registry Open Government
+Licence v3.0 terms and the posture already written into §6.
+
+**It is not legal advice**, and it is not a legal opinion on the underlying
+licence. Nothing here was produced by a qualified adviser, and it should not be
+cited as though it were. Anyone relying on it should read it as what it is: the
+owner deciding what this project will and will not do.
+
+Three merged documents previously described distribution as an undecided
+question — §4.8, the build runbook, and the changelog. This record exists so
+that the decision is not silently re-litigated each time someone reads them.
+
+---
+
+## Determination
+
+**Permitted:**
+
+* **Private delivery of the snapshot bundle to project-controlled Fly Machines.**
+* **Internal, read-only use for PPD price information** — matching a property to
+  its sale history, and locating comparables, exactly as §6 already scopes the
+  address fields.
+
+**Not permitted, and unchanged by this determination:**
+
+* **No public bundle download.** The bundle is never offered for download, to
+  anyone, by any route.
+* **No API, MCP or CLI surface serving bulk rows or the bundle.** §6's rule
+  stands verbatim: no route serves the bundle or bulk rows, and no bulk or
+  address export exists.
+* **No address use outside price information** — no address validation, no
+  autocomplete, no geocoding, no PAF-like lookup, no mailing lists, no
+  address-derived product.
+* **Attribution and provenance requirements are unchanged.** The required HM Land
+  Registry statement, its placement rules, and the per-response
+  `attribution_ref` pointer all continue to apply exactly as §6 specifies.
+
+---
+
+## This grants **no mutation authority**
+
+Permission to distribute is **not** permission to build the distribution.
+Specifically, this record authorises **none** of:
+
+* creating a bucket, object store or any other cloud resource;
+* uploading a bundle anywhere;
+* creating or setting a Fly secret;
+* configuring transport, credentials or access control;
+* changing a Dockerfile, fly config, image, dependency or feature flag;
+* deploying anything.
+
+**Hosting, credentials, transport, retention and audit require their own written
+design**, and that design requires its own mutation authorisation before any of
+it is built. The design must state, at minimum: where the artifact is hosted and
+under whose account; how a Machine authenticates to it; how long artifacts are
+retained and what deletes them; what is audited and where those records go; and
+what happens on failure — which must degrade to the live SPARQL source and never
+to an unready service.
+
+---
+
+## Scope of the Royal Mail trigger this settles
+
+§6 lists four triggers requiring separate Royal Mail review. **This determination
+settles exactly one — redistribution of the snapshot bundle — for the scope
+above.** The other three are untouched and still stop for review:
+
+* raw or bulk export of address-bearing rows in any format;
+* any endpoint returning address fields not tied to a price result;
+* any non-price use — address validation, autocomplete, geocoding, PAF-like
+  lookup.
+
+Reading this record as clearance for any of those three would be a misreading.
+
+---
+
+## Re-review triggers
+
+This determination is reopened, by the owner, on any of:
+
+* **any change to the permitted scope** above, in either direction;
+* **any new consumer of the bundle** — a service, a machine, a person or an
+  environment not covered by "project-controlled Fly Machines";
+* **any move toward public hosting**, including a bucket made public by default,
+  a signed URL with a long or unbounded lifetime, or a CDN in front of the
+  artifact;
+* **any change to the HM Land Registry licence terms or Royal Mail's position**
+  on address data in Price Paid Data;
+* **any approach to the other three §6 triggers**;
+* **the distribution implementation design** being written, which must be checked
+  against this scope rather than assumed to fit it.

--- a/docs/design/ppd-shadow-corpus.md
+++ b/docs/design/ppd-shadow-corpus.md
@@ -1,8 +1,22 @@
 # PPD shadow-comparison corpus — Definition
 
-**Status:** proposed. Governed by
-[`docs/design/ppd-source-routing.md`](ppd-source-routing.md) rev 7 §7.2, which
+**Status: ACCEPTED AND FROZEN, 2026-08-29.** Governed by
+[`docs/design/ppd-source-routing.md`](ppd-source-routing.md) rev 8 §7.2, which
 this document implements and never overrides.
+
+Frozen for the duration of Stage 1, per §1 and §7.2 of the governing spec.
+Amending it mid-flight restarts Stage 1. The text frozen here is **post-
+rehearsal**: PR #30 wrote the Definition, and PR #31 ran it against a real
+artifact and corrected four things it had wrong — the universal provisional
+invariant in §3, the removal of S10, the `not_evaluable` rules in §9, and the
+containment qualification moved to the Instance. Freezing the pre-rehearsal
+text would have frozen those defects.
+
+**No Instance exists yet, and that is the design, not an omission.** §0 and §10
+place the artifact, its qualification and its baselines in an Instance written
+**when the Stage 1 artifact is selected** — which has not happened. A rehearsal
+instance is a different kind (`instance_kind: "rehearsal"`) and cannot stand in
+for one.
 
 **Scope: `comps` only.** The explicit-date coverage-refusal path on
 `GET /v1/ppd/transactions` (§2.5) is covered by its own routing tests. Pulling it
@@ -270,8 +284,8 @@ in whichever source produced it.
 
 ## 8. Stage 1 exit criteria
 
-Carried forward from rev 7 §7.2 unchanged. All must hold. **No percentage
-threshold.**
+Carried forward from rev 7 §7.2 unchanged, and unchanged again by rev 8. All
+must hold. **No percentage threshold.**
 
 * **Zero unexplained false empties** — no case where the snapshot returns empty
   and live returns rows within coverage without a classified explanation.

--- a/docs/design/ppd-source-routing.md
+++ b/docs/design/ppd-source-routing.md
@@ -1,7 +1,19 @@
-# PPD source-routing and implementation specification (rev 7 — FROZEN)
+# PPD source-routing and implementation specification (rev 8 — FROZEN)
 
-**Status:** **FROZEN at rev 7.** Accepted. No further architecture work. Changes
+**Status:** **FROZEN at rev 8.** Accepted. No further architecture work. Changes
 to this document require a new decision round, not an edit in passing.
+
+**Revision 8** was authorised by the corpus-acceptance and artifact-distribution
+decision round, after PRs #30 and #31 merged. It is a **status** revision, not an
+architecture one. It records the fixed shadow corpus and its local rehearsal as
+merged, corrects a Basis paragraph that denied the adapter and boot lifecycle
+this same document describes, and narrows the artifact-distribution language to
+what the owner's scoped determination settled — pointing at
+[`ppd-artifact-distribution-decision.md`](ppd-artifact-distribution-decision.md)
+rather than continuing to call the question open. **No requirement is relaxed:**
+the 30 s readiness target, the `bundle_bytes * 2.5` headroom rule, every Stage 1
+exit criterion, and G1a, G1b, G2 and G3 are unchanged; nothing is enabled, no
+image or flag is touched, and no artifact is hosted.
 
 **Revision 7** was authorised by the rollout-premise decision round, after
 PR 5 produced and measured a real artifact. It corrects the §1.1 sizing baseline
@@ -35,10 +47,21 @@ By **PR 5**: the local build and validation pipeline of section 4.8 — build,
 gates, packaging, source receipt, boot check and atomic promotion — local only,
 with no upload, image, deployment or flag surface touched.
 
-**Still unimplemented or unperformed:** artifact distribution and the Royal Mail
-review that gates it (§6); the dependency-only image rollout; real completion of
-G1a, G1b, G2 and G3; the fixed shadow corpus and its local rehearsal; the Stage 1
-production shadow; snapshot enablement at any stage; and the v1.15 release.
+By **PR 6** (rollout step 6, first half): the fixed shadow corpus of section 7.2,
+as [`docs/design/ppd-shadow-corpus.md`](ppd-shadow-corpus.md) — the Definition,
+split from the artifact-bound Instance that is written when the Stage 1 artifact
+is selected. By **PR 7** (rollout step 6, second half): the local rehearsal of
+that corpus in `tools/ppd_snapshot/rehearse.py`, adapter-only and socket-blocked,
+which ran against one real artifact and corrected four defects in the Definition
+before it was frozen. **Neither is Stage 1**, and the rehearsal produces no
+Stage 1 evidence — see section 7.2.
+
+**Still unimplemented or unperformed:** the **hosting, credentials, transport,
+retention and audit design** for artifact distribution, and its implementation
+(§6, and the decision record it now points at); the dependency-only image
+rollout; real completion of G1a, G1b, G2 and G3; the **Stage 1 corpus Instance**
+and the Stage 1 production shadow itself, for which no production dual-read
+implementation exists; snapshot enablement at any stage; and the v1.15 release.
 `PPD_SNAPSHOT_ENABLED` remains off in all checked-in configuration, neither
 production image installs the `snapshot` extra, and no request is served from a
 snapshot in production.
@@ -53,9 +76,15 @@ a source-specific warning.
 **Governing rule:** this specification governs PRs 1–4; **no implementation PR
 may land before the specification that governs it.**
 
-**Basis:** Phase 2 (contract prototype) and Phase 3 (full-history validation),
-both local-only. `PricePaidDataClient.sparql_search` remains patched in a lab
-harness; no production adapter or boot lifecycle exists.
+**Basis:** the sizing, layout and latency figures throughout come from Phase 2
+(contract prototype) and Phase 3 (full-history validation), both local-only, in
+which `PricePaidDataClient.sparql_search` was patched in a lab harness. **That is
+their provenance, not a statement about what exists today:** PR 3 shipped the
+boot runtime and PR 4 the snapshot adapter and its lifespan wiring, both in
+`property_core.snapshot` and both asserted to be wired in
+`tests/snapshot/test_rollout_prerequisites.py`. What no figure here rests on is a
+*deployed* measurement — none has been taken on either Machine, which is what
+G1a and G1b exist to produce.
 
 **Revision 5** derives `source_exhausted` as a tri-state property, models
 completeness evidence explicitly as `completeness_basis`, and re-scopes the PR 1
@@ -745,9 +774,17 @@ runtime.
 
 The build pipeline stage may **build and validate an artifact locally only**.
 **No upload, bucket creation, Fly secret, cloud resource or production mutation
-is authorised.** Artifact distribution — where a bundle is hosted and how a
-deployed app reaches it — remains a **separately approved decision** and is not
-settled by this specification.
+is authorised.**
+
+The **scope** of artifact distribution is settled: the owner's determination in
+[`ppd-artifact-distribution-decision.md`](ppd-artifact-distribution-decision.md)
+permits private delivery of the bundle to project-controlled Fly Machines for
+internal, read-only price-information use. **That is a scope decision and
+nothing more.** Where a bundle is hosted, how a deployed app authenticates to
+it, how long it is retained and how access is audited remain a **separate design
+and a separate mutation authorisation**, neither of which this specification
+settles. Permission to distribute is not permission to create a bucket, upload
+an artifact, or configure Fly.
 
 ### 4.9 Release cadence and freshness — decision O3
 
@@ -850,7 +887,15 @@ address-derived product.
 * any non-price use — address validation, autocomplete, geocoding, PAF-like lookup;
 * redistribution of the snapshot bundle.
 
-None are proposed. Any of them stops for review.
+The first three are not proposed and stop for review. **The fourth is
+determined, for one scope only:**
+[`ppd-artifact-distribution-decision.md`](ppd-artifact-distribution-decision.md)
+records the owner's determination permitting private delivery of the bundle to
+project-controlled Fly Machines, for internal read-only price-information use,
+with no public download and no surface serving the bundle or bulk rows. **It
+settles that trigger and no other**, and it grants no implementation or mutation
+authority. Everything above about placement, address-field use and attribution
+is unchanged by it.
 
 ---
 

--- a/docs/design/ppd-source-routing.md
+++ b/docs/design/ppd-source-routing.md
@@ -47,14 +47,20 @@ By **PR 5**: the local build and validation pipeline of section 4.8 — build,
 gates, packaging, source receipt, boot check and atomic promotion — local only,
 with no upload, image, deployment or flag surface touched.
 
-By **PR 6** (rollout step 6, first half): the fixed shadow corpus of section 7.2,
-as [`docs/design/ppd-shadow-corpus.md`](ppd-shadow-corpus.md) — the Definition,
-split from the artifact-bound Instance that is written when the Stage 1 artifact
-is selected. By **PR 7** (rollout step 6, second half): the local rehearsal of
-that corpus in `tools/ppd_snapshot/rehearse.py`, adapter-only and socket-blocked,
-which ran against one real artifact and corrected four defects in the Definition
-before it was frozen. **Neither is Stage 1**, and the rehearsal produces no
-Stage 1 evidence — see section 7.2.
+By **GitHub PR #30** (rollout step 6, first half): the fixed shadow corpus of
+section 7.2, as [`docs/design/ppd-shadow-corpus.md`](ppd-shadow-corpus.md) — the
+Definition, split from the artifact-bound Instance that is written when the
+Stage 1 artifact is selected. By **GitHub PR #31** (rollout step 6, second half):
+the local rehearsal of that corpus in `tools/ppd_snapshot/rehearse.py`,
+adapter-only and socket-blocked, which ran against one real artifact and
+corrected four defects in the Definition before it was frozen. **Neither is
+Stage 1**, and the rehearsal produces no Stage 1 evidence — see section 7.2.
+
+The numbering is deliberately explicit: "PR 1"–"PR 5" above are the *specified*
+sequence of section 10, which stops at the build pipeline. #30 and #31 are the
+GitHub pull requests that merged the corpus work, and conflating the two
+numbering schemes is how a reader loses track of which is a plan and which is a
+fact.
 
 **Still unimplemented or unperformed:** the **hosting, credentials, transport,
 retention and audit design** for artifact distribution, and its implementation
@@ -1286,12 +1292,16 @@ Then, each separately authorised:
 5. **Build pipeline** — *merged (PR 5).* 11-partition year-only build, manifest
    with `provisional_from`, daily release check, monthly rebuild.
    **Local build and validation only. No upload, bucket, Fly secret, cloud
-   resource or production mutation** (§4.8). Artifact distribution remains a
-   separate approval, still outstanding.
-6. **Fixed shadow corpus**, agreed before Stage 1 and frozen for its duration. A
-   local rehearsal of that corpus against an already-verified artifact is a
-   correctness exercise only: it **cannot satisfy** Stage 1's real-traffic p95 or
-   divergence exit criteria.
+   resource or production mutation** (§4.8). Artifact distribution's **scope is
+   determined** — see
+   [`ppd-artifact-distribution-decision.md`](ppd-artifact-distribution-decision.md)
+   — while its **hosting, credentials, transport, retention and audit remain a
+   separate design, and every mutation remains separately authorised.**
+6. **Fixed shadow corpus** — *merged (PR #30), and frozen.* Agreed before Stage 1
+   and frozen for its duration. Its **local rehearsal** — *merged (PR #31)* — is
+   a correctness exercise only: it **cannot satisfy** Stage 1's real-traffic p95
+   or divergence exit criteria. The artifact-bound corpus **Instance** is written
+   when the Stage 1 artifact is selected, and has not been.
 7. **Rollout gates** — G1a (`property-shared`, 2 GB), G1b (`propertydata`,
    512 MB), G2 (verified worker count, or one worker pinned) and G3
    (dependency-only images landed, deployed and observed with the flag off).

--- a/docs/ops/ppd-shadow-rehearsal-summary.md
+++ b/docs/ops/ppd-shadow-rehearsal-summary.md
@@ -1,0 +1,88 @@
+# PPD shadow-corpus local rehearsal — summary of the 2026-08-28 run
+
+**Reconstructed from commit `6f969eb` and PR #31. This is not the tool's output.**
+
+The rehearsal writes a JSON report to an operator-chosen `--report` path. **That
+file was not retained.** A search on 2026-08-29 across this repository, the home
+directory and `.ppd-lab/` found no rehearsal report. What follows is a summary of
+what those two sources record about the run — prose about a file, not the file.
+Nothing here has been re-derived, and no figure appears below that is not stated
+in one of those two sources.
+
+**This is a rehearsal result. It can never be filed as Stage 1 evidence.** A
+rehearsal has no live arm, so it satisfies no divergence criterion and no p95
+criterion. The tool marks its own reports `not_stage_1_evidence`, and the
+governing corpus Definition (§9) says the same. Recorded here for continuity
+only: what the corpus was exercised against, and how it came out.
+
+---
+
+## What ran
+
+| | |
+|---|---|
+| Tool | `tools.ppd_snapshot rehearse` — local operator tooling, outside the published wheel |
+| Corpus | [`docs/design/ppd-shadow-corpus.md`](../design/ppd-shadow-corpus.md), Definition only |
+| Path | snapshot adapter only; no live adapter constructed |
+| Artifact | `v20260828T194003Z`, bundle digest `50f802b2…9072c` |
+| Network | sockets hard-failed, with a self-check proving the block was armed |
+
+The artifact is the one the build runbook records from the two byte-identical
+local builds on 2026-08-28.
+
+## Outcome
+
+| | |
+|---|---|
+| Exit code | **0** |
+| Cases | **13 of 13** |
+| Assertions passed | **85** |
+| Assertions failed | **0** |
+| Assertions not evaluable | **2** |
+| Midnight exclusions | none |
+| Isolation | socket blocker armed and self-checked |
+| Environment | `PPD_SNAPSHOT_ENABLED=0` restored intact after the run |
+| Report written | 24.6 KB (the file that was not retained) |
+
+**The two `not_evaluable` assertions are the correct answer, not a failure.**
+They are the saturated containment comparisons: at `limit=50`, a paged result
+ordered most-recent-first cannot demonstrate set containment, so the question is
+unanswerable rather than unmet. `not_evaluable` is counted separately from passes
+and never as one; a run may exit 0 with them present and may never exit 0 with a
+failure.
+
+## What the run changed
+
+Running the Definition against a real artifact corrected four things in it, none
+visible from reading it. All four were applied **before** the corpus was frozen,
+so the frozen text is post-rehearsal:
+
+1. **`recent_period_provisional` is universal, not per-case** — it held on all
+   fourteen cases then defined, for the same structural reason as the coverage
+   clamp. S10 was removed as discriminating nothing; S11 was retained, because an
+   empty result that must still be flagged provisional is the control with teeth.
+2. **Page-set containment is unanswerable at `limit=50`** — 39 of S3's ids sat
+   outside S1's page. Containment moved to full aggregate counts declared in the
+   Instance; the rehearsal reports `not_evaluable` with a reason when either side
+   is saturated; geography containment, which stays meaningful on any page, is
+   always checked.
+3. **`not_evaluable` is never a pass.**
+4. **The recorded midnight-failure state could not occur** — the exception was
+   re-raised before the report was written, making that state unreachable. It now
+   writes a failed aggregate-only report.
+
+## Report hygiene
+
+The report carried counts, geography membership, provenance, warning classes,
+latency, returned date bounds and invariant outcomes. Transaction-id sets existed
+in memory for the containment checks and were discarded. No id, address or sale
+value reached the report, and none appears in this summary.
+
+## Status
+
+Rollout step 6 (corpus and local rehearsal) is complete. **Stage 1 is not
+started**, and needs three things this run does not provide: a production
+dual-read shadow implementation, which does not exist; a Stage 1 corpus Instance
+bound to a selected artifact, which is written only when that artifact is
+selected; and an artifact materialized on a deployed Machine, which depends on
+distribution and gate G1a.

--- a/docs/ops/ppd-snapshot-build.md
+++ b/docs/ops/ppd-snapshot-build.md
@@ -2,7 +2,7 @@
 
 How the Price Paid Data snapshot is built and validated on a workstation.
 Governed by [`docs/design/ppd-source-routing.md`](../design/ppd-source-routing.md)
-rev 6 (§1.1–1.3, §4.8, §4.9). The pipeline lives in
+rev 8 (§1.1–1.3, §4.8, §4.9). The pipeline lives in
 [`tools/ppd_snapshot/`](../../tools/ppd_snapshot/) and is deliberately
 outside the published wheel.
 
@@ -15,9 +15,13 @@ change, release or version bump happens here or is enabled by anything here.
 manifest only so the whole boot path can be exercised offline through
 `LocalDirectorySource`.
 
-**Artifact distribution — where a bundle is hosted and how a deployed app
-reaches it — is a separately approved decision** and is not settled by this
-runbook.
+**Artifact distribution.** Its *scope* is settled — the owner's determination in
+[`docs/design/ppd-artifact-distribution-decision.md`](../design/ppd-artifact-distribution-decision.md)
+permits private delivery of the bundle to project-controlled Fly Machines for
+internal, read-only price-information use. **Nothing about that changes this
+runbook**: where a bundle is hosted, how a deployed app authenticates to it, how
+long it is retained and how access is audited remain a separate design and a
+separate mutation authorisation. This pipeline still builds locally and stops.
 
 ## Inputs
 

--- a/tests/snapshot/rehearsal_fixtures.py
+++ b/tests/snapshot/rehearsal_fixtures.py
@@ -1,0 +1,20 @@
+"""Values shared by the rehearsal guards. **No optional dependency.**
+
+`test_shadow_rehearsal.py` needs DuckDB and zstandard to run the tool, so it
+`importorskip`s both at module level. The guards over the *summary document*
+need neither -- they read a markdown file -- and must not inherit that skip: a
+documentation guard that disappears when a native wheel is absent is a guard
+that stops working exactly when nobody notices.
+
+So the forbidden values live here, imported by both, and the summary guards live
+in their own dependency-free module.
+"""
+
+from __future__ import annotations
+
+#: Values from the rehearsal fixture rows that must NEVER appear in a report or
+#: in any document describing one. Ids, prices and addresses are the three
+#: categories the authorisation forbids, and both are files someone will paste
+#: into a review.
+FORBIDDEN_IN_REPORT = ["T-B57-A", "T-B50-A", "T-M37-A",
+                       "210000", "400000", "250000", "HIGH STREET"]

--- a/tests/snapshot/test_rollout_premises.py
+++ b/tests/snapshot/test_rollout_premises.py
@@ -1,4 +1,4 @@
-"""Rev 7 — the corrected rollout premises, pinned so they cannot drift back.
+"""Rev 7-8 — the rollout premises and status, pinned so they cannot drift back.
 
 Specification rev 7 corrected a sizing baseline that had been wrong since rev 1:
 §1.1 sized eleven partitions at 214 MiB, which was a **year+area** measurement
@@ -26,9 +26,20 @@ is not one of them fails. A loose textual window around each hit would be
 brittle across table reflows and would quietly accept a new live claim that
 happened to sit near an explanatory word.
 
+**Rev 8** added a third group. It is a *status* round, not an architecture one:
+it accepts the shadow corpus, records the owner's scoped artifact-distribution
+determination, and corrects status text that had gone stale as PRs merged
+beneath it -- a Basis paragraph denying the adapter the same document describes,
+a changelog requiring an ordering PR 4 made impossible, a runbook citing two
+different revisions of its own governing spec. Status text is exactly where a
+requirement gets softened by accident, because none of it looks like a
+requirement, so `test_revision_8_relaxed_no_requirement` guards the same
+invariants for rev 8 that this file already guards for rev 7.
+
 Nothing here relaxes a requirement. The 30 s readiness target, the
 `bundle_bytes * 2.5` headroom rule and every Stage 1 exit criterion are
-unchanged by rev 7, and several assertions below exist to keep them that way.
+unchanged by rev 7 and by rev 8, and several assertions below exist to keep
+them that way.
 """
 
 from __future__ import annotations
@@ -47,6 +58,7 @@ REPO = Path(__file__).resolve().parents[2]
 SPEC = REPO / "docs" / "design" / "ppd-source-routing.md"
 RUNBOOK = REPO / "docs" / "ops" / "ppd-snapshot-build.md"
 CHANGELOG = REPO / "CHANGELOG.md"
+DECISION = REPO / "docs" / "design" / "ppd-artifact-distribution-decision.md"
 
 MiB = 1024 ** 2
 
@@ -76,6 +88,20 @@ def _section(path: Path, heading: str) -> str:
     rest = body[start + len(heading):]
     nxt = re.search(rf"^#{{1,{level}}} ", rest, re.MULTILINE)
     return rest[: nxt.start()] if nxt else rest
+
+
+def _paragraph(path: Path, opener: str) -> str:
+    """One paragraph, from `opener` to the next blank line.
+
+    `_section` above only understands `#` headings. A status list that opens
+    with bold text needs its own scope, and it has to be a tight one: widening
+    it to the rest of the document would let any later mention of the corpus
+    satisfy an assertion about what this paragraph claims is outstanding.
+    """
+    body = path.read_text()
+    start = body.index(opener)
+    end = body.find("\n\n", start)
+    return " ".join(body[start: end if end != -1 else len(body)].split())
 
 
 def _rounded(value: float, places: int = 1) -> str:
@@ -378,14 +404,202 @@ def test_the_lock_wait_bound_names_a_constant_that_exists():
 # Scope -- this correction changes documents and tests, nothing operational
 # ---------------------------------------------------------------------------
 
-def test_the_changelog_records_the_correction_rather_than_the_freeze():
+def test_the_changelog_describes_pr_groups_rather_than_a_total():
+    """A bare total is a counter that has to be right forever.
+
+    It was wrong twice already -- "four", then "Five" against eight merged PRs.
+    The groups are what a reader actually needs: five PRs that built the thing
+    (#24-#28) and three that prepared its rollout without touching production
+    (#29-#31). A ninth PR extends a range, which is a one-line edit; it does
+    not force a recount, and a recount is what kept going stale.
+    """
     normalised = _normalised(CHANGELOG)
-    assert "Five** PRs" in normalised or "**Five** PRs" in normalised, (
-        "the changelog still counts four merged PRs"
+    assert "Five** PRs" not in normalised, (
+        "the changelog still states a bare PR total; totals go stale silently"
     )
-    assert "specification rev 7" in normalised, (
-        "the changelog still says the sizing correction is deferred"
+    for phrase in ("implementation PRs", "rollout-preparation PRs",
+                   "#24-#28", "#29-#31"):
+        assert phrase in normalised, (
+            f"the changelog no longer describes its PR groups: {phrase!r} is gone"
+        )
+
+
+def test_the_changelog_still_records_the_sizing_correction():
+    """Rev 8 must not erase rev 7's provenance.
+
+    The surviving half of the assertion this replaced: the sizing correction was
+    made by rev 7, and saying so stays true no matter how many revisions follow.
+    """
+    assert "specification rev 7" in _normalised(CHANGELOG), (
+        "the changelog no longer records which revision corrected the sizing"
     )
+
+
+# ---------------------------------------------------------------------------
+# Rev 8 -- the corpus-acceptance and artifact-distribution decision round
+# ---------------------------------------------------------------------------
+
+def test_the_specification_declares_revision_8_and_a_revision_note():
+    """History is appended, never overwritten.
+
+    A revision that replaced its predecessor's note would make the document's
+    own account of itself unfalsifiable: nobody could tell which decision round
+    settled what.
+    """
+    body = _text(SPEC)
+    head = body.splitlines()[0]
+    assert "rev 8" in head and "FROZEN" in head, head
+    normalised = _normalised(SPEC)
+    assert "**Revision 8**" in normalised, "rev 8 landed without a revision note"
+    for earlier in ("**Revision 7**", "**Revision 6**"):
+        assert earlier in normalised, (
+            f"{earlier} was overwritten; revision notes accumulate, they do not "
+            f"replace each other"
+        )
+
+
+def test_revision_8_relaxed_no_requirement():
+    """Sibling of the rev 7 assertion below, for the same reason.
+
+    A status-reconciliation round is exactly where a requirement gets softened
+    by accident, because nothing in it looks like a requirement change.
+    """
+    normalised = _normalised(SPEC)
+    for requirement in (
+        "30 s readiness target",
+        "bundle_bytes * 2.5",
+        "Zero unexplained false empties",
+        "Zero geography contamination",
+        "100% field equality on shared transaction IDs",
+        "Every divergence classified",
+        "Zero snapshot errors",
+        "p95 < 1 second",
+        "Passing G1a authorises neither `propertydata` nor Stage 3",
+        "blocking G2 if the deployed count exceeds one",
+    ):
+        assert requirement in normalised, (
+            f"rev 8 relaxed a requirement it had no authority to touch: "
+            f"{requirement!r}"
+        )
+
+
+def test_the_specification_records_the_corpus_and_rehearsal_as_merged():
+    """PRs #30 and #31 merged; the status list said they had not."""
+    unimplemented = _paragraph(SPEC, "**Still unimplemented or unperformed:**")
+    for merged in ("shadow corpus", "rehearsal"):
+        assert merged not in unimplemented, (
+            f"the status list still calls {merged!r} unimplemented, but it "
+            f"merged and its guard tests run in this suite"
+        )
+    normalised = _normalised(SPEC)
+    assert "ppd-shadow-corpus.md" in normalised, (
+        "the specification never names the corpus document it governs"
+    )
+
+
+def test_the_specification_no_longer_denies_the_adapter_it_documents():
+    """The sharpest self-contradiction in the repository, until rev 8.
+
+    The Basis paragraph said no production adapter or boot lifecycle existed
+    while the implementation-status paragraph, thirty lines above, described
+    both -- and `test_the_lifespan_rule_is_wired_in_both_deployments` asserts
+    they boot.
+    """
+    normalised = _normalised(SPEC)
+    assert "no production adapter or boot lifecycle exists" not in normalised, (
+        "the specification still denies the adapter and lifespan that PR 3 and "
+        "PR 4 shipped and that this suite asserts are wired"
+    )
+
+
+def test_the_changelog_no_longer_carries_the_impossible_ordering():
+    """Replaced in the spec by rev 7; the changelog kept the dead phrase.
+
+    The spec's *quotation* of it must survive: recording what was replaced, and
+    why it can no longer be satisfied, is how the correction stays legible.
+    """
+    assert "*before* routing is introduced" not in _normalised(CHANGELOG), (
+        "the changelog still requires an ordering that routing made impossible "
+        "when PR 4 merged"
+    )
+    assert "before routing is introduced" in _normalised(SPEC), (
+        "the specification stopped recording which ordering rev 7 replaced"
+    )
+
+
+def test_the_runbook_cites_the_current_specification_revision():
+    """It cited rev 6 in its header and rev 7 in its body -- both, at once."""
+    normalised = _normalised(RUNBOOK)
+    assert "rev 6" not in normalised, (
+        "the runbook still says it is governed by a superseded revision"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The artifact-distribution decision record
+# ---------------------------------------------------------------------------
+
+def test_the_distribution_decision_record_exists_and_states_its_limits():
+    """Three merged documents said distribution was undecided.
+
+    Without a record, the next session reads them and re-litigates a settled
+    decision -- which is the failure this whole reconciliation exists to stop.
+    A record that states the permission without stating its edges is worse than
+    none: it reads as blanket approval.
+    """
+    assert DECISION.exists(), (
+        "the scoped distribution determination is not written down anywhere"
+    )
+    normalised = _normalised(DECISION)
+    assert "Paul Boucherat" in normalised, "the record names no owner"
+    assert "2026-08-29" in normalised, "the record carries no date"
+    for exclusion in (
+        "No public bundle download",
+        "bulk rows",
+        "address validation",
+        "attribution",
+    ):
+        assert exclusion in normalised, (
+            f"the record states the permission without its {exclusion!r} limit"
+        )
+    for trigger in ("re-review", "public hosting", "new consumer"):
+        assert trigger in normalised.lower(), (
+            f"the record states no re-review trigger for {trigger!r}; a "
+            f"determination with no reopening condition is a permanent one"
+        )
+    assert "no mutation authority" in normalised.lower(), (
+        "the record does not say that permission to distribute is not "
+        "permission to create a bucket, upload anything, or configure Fly"
+    )
+
+
+def test_the_distribution_record_is_a_determination_not_legal_advice():
+    """It records what the owner decided, not what a lawyer concluded.
+
+    It also settles exactly one of section 6's four Royal Mail triggers. Reading
+    it as clearing the other three is the mistake it must make impossible.
+    """
+    normalised = _normalised(DECISION)
+    assert "not legal advice" in normalised.lower(), (
+        "the record does not disclaim independent legal advice"
+    )
+    assert "determination" in normalised.lower(), (
+        "the record does not present itself as the owner's determination"
+    )
+    for still_gated in ("autocomplete", "geocoding", "PAF-like"):
+        assert still_gated in normalised, (
+            f"the record does not restate that {still_gated!r} remains gated by "
+            f"section 6"
+        )
+
+
+def test_the_specification_points_at_the_decision_record():
+    """The places that said "separately approved" must now resolve somewhere."""
+    for document, name in ((SPEC, "specification"), (RUNBOOK, "runbook")):
+        assert "ppd-artifact-distribution-decision" in _normalised(document), (
+            f"the {name} still describes distribution as an open decision "
+            f"without pointing at the record that settled its scope"
+        )
 
 
 def test_the_lock_wait_versus_grace_period_question_is_recorded_not_resolved():

--- a/tests/snapshot/test_rollout_premises.py
+++ b/tests/snapshot/test_rollout_premises.py
@@ -495,6 +495,16 @@ def test_the_specification_records_the_corpus_and_rehearsal_as_merged():
     assert "ppd-shadow-corpus.md" in normalised, (
         "the specification never names the corpus document it governs"
     )
+    status = _paragraph(SPEC, "By **GitHub PR #30**")
+    for pr in ("#30", "#31"):
+        assert pr in status, (
+            f"the implementation status does not name GitHub PR {pr}. "
+            f'"PR 6"/"PR 7" are step numbers from section 10 and are not '
+            f"resolvable to anything a reader can look up"
+        )
+    assert "rehearse.py" in status, (
+        "the status names the corpus but not the rehearsal that corrected it"
+    )
 
 
 def test_the_specification_no_longer_denies_the_adapter_it_documents():
@@ -567,6 +577,28 @@ def test_the_distribution_decision_record_exists_and_states_its_limits():
             f"the record states no re-review trigger for {trigger!r}; a "
             f"determination with no reopening condition is a permanent one"
         )
+
+
+def test_the_record_pins_what_is_permitted_and_not_only_what_is_not():
+    """A record that lists only exclusions does not say what was decided.
+
+    Both halves have to be pinned. Widening the permission is the failure this
+    catches -- an edit that quietly dropped "project-controlled Fly Machines",
+    or "read-only", would leave every exclusion below intact while changing what
+    the determination actually allows.
+    """
+    normalised = _normalised(DECISION)
+    for permitted in (
+        "Private delivery of the snapshot bundle to project-controlled Fly "
+        "Machines",
+        "Internal, read-only use for PPD price information",
+    ):
+        assert permitted in normalised, (
+            f"the record no longer states its permitted scope: {permitted!r}"
+        )
+    assert "**Permitted:**" in normalised and "Not permitted" in normalised, (
+        "the record no longer separates what it permits from what it does not"
+    )
     assert "no mutation authority" in normalised.lower(), (
         "the record does not say that permission to distribute is not "
         "permission to create a bucket, upload anything, or configure Fly"
@@ -590,6 +622,31 @@ def test_the_distribution_record_is_a_determination_not_legal_advice():
         assert still_gated in normalised, (
             f"the record does not restate that {still_gated!r} remains gated by "
             f"section 6"
+        )
+
+
+def test_no_section_still_calls_the_distribution_scope_undecided():
+    """Four places said it was open; the final sequence was the fourth.
+
+    Scoped to the phrases that assert an *undecided scope*, because the words
+    "separately authorised" must survive everywhere -- hosting, transport,
+    credentials, retention, audit and every mutation genuinely are.
+    """
+    for document, name in ((SPEC, "specification"), (RUNBOOK, "runbook")):
+        normalised = _normalised(document)
+        for undecided in (
+            "still outstanding",
+            "remains a **separately approved decision**",
+            "is a separately approved decision",
+        ):
+            assert undecided not in normalised, (
+                f"the {name} still calls the distribution scope undecided "
+                f"({undecided!r}), which the owner's determination settled"
+            )
+        assert "separately authorised" in normalised or (
+            "separate mutation authorisation" in normalised), (
+            f"the {name} no longer says the mutations remain separately "
+            f"authorised -- settling the scope does not authorise building it"
         )
 
 

--- a/tests/snapshot/test_shadow_corpus_definition.py
+++ b/tests/snapshot/test_shadow_corpus_definition.py
@@ -241,3 +241,45 @@ def test_stage_1_exit_criteria_are_carried_forward_unchanged():
 def test_the_rehearsal_cannot_be_filed_as_stage_1():
     body = _normalised(DEFINITION)
     assert "never filed as Stage 1 evidence" in body
+
+
+# ---------------------------------------------------------------------------
+# 4. The freeze
+# ---------------------------------------------------------------------------
+
+def test_the_corpus_is_frozen_not_proposed():
+    """Its own section 1 says it is frozen for Stage 1's duration.
+
+    Carrying "Status: proposed" contradicted that, and left the next reader
+    entitled to reopen shapes that a real rehearsal had already corrected.
+    """
+    body = _normalised(DEFINITION)
+    assert "**Status:** proposed" not in body, (
+        "the corpus still calls itself proposed while its own section 1 says it "
+        "is agreed before Stage 1 and frozen for its duration"
+    )
+    assert "frozen" in body.lower(), "the corpus does not state that it is frozen"
+    assert "2026-08-29" in body, "the freeze carries no date"
+    assert "rev 8" in body, (
+        "the corpus still cites a superseded revision of its governing spec"
+    )
+
+
+def test_the_freeze_does_not_claim_an_instance():
+    """An absent Instance is the design, not an outstanding task.
+
+    Section 0 says an Instance is written when the Stage 1 artifact is selected.
+    Describing its absence as incompleteness would invite someone to write one
+    against no artifact, which is exactly the coupling the split exists to
+    prevent -- and it would make this document's status permanently unachievable.
+    """
+    body = _normalised(DEFINITION)
+    assert "written when the Stage 1 artifact is selected" in body, (
+        "the Definition no longer states when an Instance comes into being"
+    )
+    for overreach in ("Instance is outstanding", "Instance is missing",
+                      "pending Instance", "awaiting an Instance"):
+        assert overreach not in body, (
+            f"the freeze describes the absent Instance as incomplete work "
+            f"({overreach!r}); it is deferred by design, not missing"
+        )

--- a/tests/snapshot/test_shadow_rehearsal.py
+++ b/tests/snapshot/test_shadow_rehearsal.py
@@ -222,6 +222,28 @@ def test_the_valid_instance_is_accepted(tmp_path, dist):
 FORBIDDEN_IN_REPORT = ["T-B57-A", "T-B50-A", "T-M37-A",
                        "210000", "400000", "250000", "HIGH STREET"]
 
+#: The reconstructed summary of the real run. Not the tool's output: the
+#: original `--report` JSON was not retained, and a search on 2026-08-29 across
+#: the repository, the home directory and `.ppd-lab/` found none.
+SUMMARY = Path(__file__).resolve().parents[2] / "docs" / "ops" / "ppd-shadow-rehearsal-summary.md"
+
+#: JSON field names that only appear if row data was pasted in. Quoted, so
+#: ordinary prose about a district or a street cannot trip them -- a real leak
+#: is JSON-shaped or is one of the fixture values above.
+FORBIDDEN_KEYS_IN_SUMMARY = ['"transaction_id"', '"paon"', '"saon"', '"street"',
+                             '"locality"', '"county"', '"price"']
+
+#: Exactly what commit 6f969eb and PR #31 record about the real run. The summary
+#: may state these and nothing else numeric about the outcome.
+RECORDED_RESULTS = {
+    "version": "v20260828T194003Z",
+    "digest": "50f802b2",
+    "cases": "13",
+    "passed": "85",
+    "failed": "0",
+    "not_evaluable": "2",
+}
+
 
 @pytest.fixture
 def rehearsed(tmp_path, dist):
@@ -617,3 +639,74 @@ def test_an_unrecoverable_midnight_crossing_writes_a_failed_report(
     assert body["failure"], "the report does not say what went wrong"
     assert "midnight" in body["failure"].lower()
     assert body["kind"] == "rehearsal" and body["not_stage_1_evidence"] is True
+
+
+# ---------------------------------------------------------------------------
+# The reconstructed summary of the real run
+# ---------------------------------------------------------------------------
+
+def test_the_rehearsal_summary_is_labelled_reconstructed():
+    """It must not read as the tool's own output.
+
+    A document that looks like a report, but was assembled from a commit
+    message, is evidence of the wrong kind: it would be cited later as though a
+    file had been verified, when what was verified was prose about a file.
+    """
+    assert SUMMARY.exists(), "the real rehearsal result is recorded only in git"
+    body = " ".join(SUMMARY.read_text().split())
+    assert "econstructed" in body, "the summary does not say it is reconstructed"
+    for source in ("6f969eb", "#31"):
+        assert source in body, f"the summary does not cite {source}"
+    assert "not retained" in body, (
+        "the summary does not record that the original report JSON is gone -- a "
+        "later reader would assume it was consulted"
+    )
+    assert "never" in body and "Stage 1 evidence" in body, (
+        "the summary is not labelled as something that can never be Stage 1 "
+        "evidence, which its own subject matter requires"
+    )
+
+
+def test_the_rehearsal_summary_carries_no_row_data():
+    """Same rule as the report it describes: aggregates only.
+
+    Checked against the fixture values this suite already forbids in a report,
+    plus JSON field names that only appear if rows were pasted in. Not a
+    pattern for what an id or a price looks like -- a pattern that broad
+    matches coverage dates and byte counts, and would have to be loosened until
+    it stopped meaning anything.
+    """
+    body = SUMMARY.read_text()
+    for forbidden in FORBIDDEN_IN_REPORT:
+        assert forbidden not in body, (
+            f"the summary leaked the fixture value {forbidden!r}"
+        )
+    for key in FORBIDDEN_KEYS_IN_SUMMARY:
+        assert key not in body, (
+            f"the summary carries the row field {key}; it records counts, "
+            f"outcomes and artifact identity only"
+        )
+
+
+def test_the_rehearsal_summary_matches_the_recorded_counts():
+    """It may state what the two sources record, and must not exceed it.
+
+    The failure this guards is a summary that grows detail nobody can check --
+    a per-case table, a latency figure, a divergence claim -- none of which
+    survives in any artifact.
+    """
+    body = " ".join(SUMMARY.read_text().split())
+    for name, value in RECORDED_RESULTS.items():
+        assert value in body, f"the summary no longer records {name}: {value!r}"
+    assert "no p95 criterion" in body, (
+        "the summary does not state that it satisfies no p95 criterion, which "
+        "is the whole reason it is not Stage 1 evidence"
+    )
+    # Saying it HAS no p95 is required; reporting one is forbidden. Banning the
+    # bare token would ban the disclaimer along with the claim.
+    for claimed in ("p95 of", "p95:", "p95 =", "divergence rate",
+                    "field equality"):
+        assert claimed not in body, (
+            f"the summary reports {claimed!r}; a rehearsal has no live arm and "
+            f"neither source records it"
+        )

--- a/tests/snapshot/test_shadow_rehearsal.py
+++ b/tests/snapshot/test_shadow_rehearsal.py
@@ -216,33 +216,10 @@ def test_the_valid_instance_is_accepted(tmp_path, dist):
 # 2. A fixture artifact runs adapter-only, isolated, and reports as a rehearsal
 # ---------------------------------------------------------------------------
 
-#: Values from the fixture rows that must NEVER appear in a report. Ids, prices
-#: and addresses are the three categories the authorisation forbids, and a
-#: report is a file someone will paste into a review.
-FORBIDDEN_IN_REPORT = ["T-B57-A", "T-B50-A", "T-M37-A",
-                       "210000", "400000", "250000", "HIGH STREET"]
-
-#: The reconstructed summary of the real run. Not the tool's output: the
-#: original `--report` JSON was not retained, and a search on 2026-08-29 across
-#: the repository, the home directory and `.ppd-lab/` found none.
-SUMMARY = Path(__file__).resolve().parents[2] / "docs" / "ops" / "ppd-shadow-rehearsal-summary.md"
-
-#: JSON field names that only appear if row data was pasted in. Quoted, so
-#: ordinary prose about a district or a street cannot trip them -- a real leak
-#: is JSON-shaped or is one of the fixture values above.
-FORBIDDEN_KEYS_IN_SUMMARY = ['"transaction_id"', '"paon"', '"saon"', '"street"',
-                             '"locality"', '"county"', '"price"']
-
-#: Exactly what commit 6f969eb and PR #31 record about the real run. The summary
-#: may state these and nothing else numeric about the outcome.
-RECORDED_RESULTS = {
-    "version": "v20260828T194003Z",
-    "digest": "50f802b2",
-    "cases": "13",
-    "passed": "85",
-    "failed": "0",
-    "not_evaluable": "2",
-}
+#: Shared with the dependency-free summary guards in
+#: `test_shadow_rehearsal_summary.py`, which must not inherit this module's
+#: `importorskip`.
+from tests.snapshot.rehearsal_fixtures import FORBIDDEN_IN_REPORT  # noqa: E402
 
 
 @pytest.fixture
@@ -640,73 +617,3 @@ def test_an_unrecoverable_midnight_crossing_writes_a_failed_report(
     assert "midnight" in body["failure"].lower()
     assert body["kind"] == "rehearsal" and body["not_stage_1_evidence"] is True
 
-
-# ---------------------------------------------------------------------------
-# The reconstructed summary of the real run
-# ---------------------------------------------------------------------------
-
-def test_the_rehearsal_summary_is_labelled_reconstructed():
-    """It must not read as the tool's own output.
-
-    A document that looks like a report, but was assembled from a commit
-    message, is evidence of the wrong kind: it would be cited later as though a
-    file had been verified, when what was verified was prose about a file.
-    """
-    assert SUMMARY.exists(), "the real rehearsal result is recorded only in git"
-    body = " ".join(SUMMARY.read_text().split())
-    assert "econstructed" in body, "the summary does not say it is reconstructed"
-    for source in ("6f969eb", "#31"):
-        assert source in body, f"the summary does not cite {source}"
-    assert "not retained" in body, (
-        "the summary does not record that the original report JSON is gone -- a "
-        "later reader would assume it was consulted"
-    )
-    assert "never" in body and "Stage 1 evidence" in body, (
-        "the summary is not labelled as something that can never be Stage 1 "
-        "evidence, which its own subject matter requires"
-    )
-
-
-def test_the_rehearsal_summary_carries_no_row_data():
-    """Same rule as the report it describes: aggregates only.
-
-    Checked against the fixture values this suite already forbids in a report,
-    plus JSON field names that only appear if rows were pasted in. Not a
-    pattern for what an id or a price looks like -- a pattern that broad
-    matches coverage dates and byte counts, and would have to be loosened until
-    it stopped meaning anything.
-    """
-    body = SUMMARY.read_text()
-    for forbidden in FORBIDDEN_IN_REPORT:
-        assert forbidden not in body, (
-            f"the summary leaked the fixture value {forbidden!r}"
-        )
-    for key in FORBIDDEN_KEYS_IN_SUMMARY:
-        assert key not in body, (
-            f"the summary carries the row field {key}; it records counts, "
-            f"outcomes and artifact identity only"
-        )
-
-
-def test_the_rehearsal_summary_matches_the_recorded_counts():
-    """It may state what the two sources record, and must not exceed it.
-
-    The failure this guards is a summary that grows detail nobody can check --
-    a per-case table, a latency figure, a divergence claim -- none of which
-    survives in any artifact.
-    """
-    body = " ".join(SUMMARY.read_text().split())
-    for name, value in RECORDED_RESULTS.items():
-        assert value in body, f"the summary no longer records {name}: {value!r}"
-    assert "no p95 criterion" in body, (
-        "the summary does not state that it satisfies no p95 criterion, which "
-        "is the whole reason it is not Stage 1 evidence"
-    )
-    # Saying it HAS no p95 is required; reporting one is forbidden. Banning the
-    # bare token would ban the disclaimer along with the claim.
-    for claimed in ("p95 of", "p95:", "p95 =", "divergence rate",
-                    "field equality"):
-        assert claimed not in body, (
-            f"the summary reports {claimed!r}; a rehearsal has no live arm and "
-            f"neither source records it"
-        )

--- a/tests/snapshot/test_shadow_rehearsal_summary.py
+++ b/tests/snapshot/test_shadow_rehearsal_summary.py
@@ -1,0 +1,176 @@
+"""Guards for the reconstructed rehearsal summary. **No optional dependency.**
+
+`docs/ops/ppd-shadow-rehearsal-summary.md` is the only durable record of the
+real rehearsal run: the tool's `--report` JSON was not retained, and a search on
+2026-08-29 across the repository, the home directory and `.ppd-lab/` found none.
+The summary is therefore prose assembled from commit `6f969eb` and PR #31, and
+the danger it carries is precisely that it will later be cited as though a file
+had been verified.
+
+These guards live in their own module, deliberately. `test_shadow_rehearsal.py`
+runs the tool, so it `importorskip`s DuckDB and zstandard at module level; a
+document guard that inherited that skip would vanish in exactly the runs where
+nobody was watching for it. Nothing here imports anything optional.
+
+Two failures are worth naming, because a looser test misses both:
+
+* **A label bound to no value.** Asserting that "0" appears somewhere in the
+  document is satisfied by a coverage date, a byte count, or a summary claiming
+  nine failed assertions. Each figure is read out of its own table row and
+  compared exactly.
+
+* **Row data pasted in.** Checked against the fixture values this suite already
+  forbids in a report, and against quoted JSON field names -- not against a
+  pattern for what an id or a price looks like, which would match coverage dates
+  and byte counts and would have to be loosened until it meant nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tests.snapshot.rehearsal_fixtures import FORBIDDEN_IN_REPORT
+
+SUMMARY = (Path(__file__).resolve().parents[2]
+           / "docs" / "ops" / "ppd-shadow-rehearsal-summary.md")
+
+#: JSON field names that only appear if row data was pasted in. Quoted, so
+#: ordinary prose about a district search or a town cannot trip them -- a real
+#: leak is JSON-shaped, or is one of the fixture values above.
+FORBIDDEN_KEYS_IN_SUMMARY = ['"transaction_id"', '"paon"', '"saon"', '"street"',
+                             '"locality"', '"town"', '"district"', '"county"',
+                             '"price"']
+
+#: Exactly what commit 6f969eb and PR #31 record, bound label to value. Reading
+#: these out of their own rows is what makes `failed` mean zero rather than
+#: "the character 0 occurs somewhere in the document".
+RECORDED_RESULTS = {
+    "Exit code": "0",
+    "Cases": "13 of 13",
+    "Assertions passed": "85",
+    "Assertions failed": "0",
+    "Assertions not evaluable": "2",
+}
+
+#: Artifact identity, from the same two sources.
+RECORDED_ARTIFACT = ("v20260828T194003Z", "50f802b2")
+
+
+def _body() -> str:
+    return " ".join(SUMMARY.read_text().split())
+
+
+def _rows() -> dict[str, str]:
+    """Every `| label | value |` row, with markdown emphasis stripped.
+
+    A label missing from this mapping fails the lookup below, so deleting a row
+    is as loud as changing its value.
+    """
+    rows: dict[str, str] = {}
+    for line in SUMMARY.read_text().splitlines():
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) == 2 and cells[0] and not set(cells[0]) <= {"-", ":"}:
+            rows[cells[0]] = cells[1].replace("**", "").strip()
+    return rows
+
+
+def test_the_rehearsal_summary_is_labelled_reconstructed():
+    """It must not read as the tool's own output.
+
+    A document that looks like a report, but was assembled from a commit
+    message, is evidence of the wrong kind: it would be cited later as though a
+    file had been verified, when what was verified was prose about a file.
+    """
+    assert SUMMARY.exists(), "the real rehearsal result is recorded only in git"
+    body = _body()
+    assert "econstructed" in body, "the summary does not say it is reconstructed"
+    for source in ("6f969eb", "#31"):
+        assert source in body, f"the summary does not cite {source}"
+    assert "not retained" in body, (
+        "the summary does not record that the original report JSON is gone -- a "
+        "later reader would assume it was consulted"
+    )
+    assert "never" in body and "Stage 1 evidence" in body, (
+        "the summary is not labelled as something that can never be Stage 1 "
+        "evidence, which its own subject matter requires"
+    )
+
+
+def test_the_rehearsal_summary_carries_no_row_data():
+    """Same rule as the report it describes: aggregates only."""
+    raw = SUMMARY.read_text()
+    for forbidden in FORBIDDEN_IN_REPORT:
+        assert forbidden not in raw, (
+            f"the summary leaked the fixture value {forbidden!r}"
+        )
+    for key in FORBIDDEN_KEYS_IN_SUMMARY:
+        assert key not in raw, (
+            f"the summary carries the row field {key}; it records counts, "
+            f"outcomes and artifact identity only"
+        )
+
+
+def test_each_recorded_result_is_bound_to_its_own_label():
+    """The figures, read out of their own rows and compared exactly.
+
+    Substring matching would have accepted `failed = 9` and
+    `not_evaluable = 7`: the digits it was really matching live elsewhere in the
+    document. A result table is a set of claims, and each one has to be checked
+    against the claim it makes, not against the document as a bag of characters.
+    """
+    rows = _rows()
+    for label, expected in RECORDED_RESULTS.items():
+        assert label in rows, (
+            f"the summary no longer reports {label!r}; commit 6f969eb records it"
+        )
+        assert rows[label] == expected, (
+            f"the summary reports {label} = {rows[label]!r}, but commit 6f969eb "
+            f"and PR #31 record {expected!r}"
+        )
+
+
+def test_the_summary_binds_to_the_artifact_the_run_used():
+    """A result with no artifact identity describes nothing in particular."""
+    rows = _rows()
+    assert "Artifact" in rows, "the summary names no artifact"
+    for token in RECORDED_ARTIFACT:
+        assert token in rows["Artifact"], (
+            f"the artifact row no longer carries {token!r}, so the result is "
+            f"not bound to the bundle it was produced from"
+        )
+
+
+def test_the_summary_claims_no_outcome_neither_source_records():
+    """It may say it HAS no p95; it may not report one.
+
+    Banning the bare token would ban the disclaimer along with the claim, and
+    the disclaimer is the reason this document is not Stage 1 evidence.
+    """
+    body = _body()
+    assert "no p95 criterion" in body, (
+        "the summary does not state that it satisfies no p95 criterion, which "
+        "is the whole reason it is not Stage 1 evidence"
+    )
+    for claimed in ("p95 of", "p95:", "p95 =", "divergence rate",
+                    "field equality"):
+        assert claimed not in body, (
+            f"the summary reports {claimed!r}; a rehearsal has no live arm and "
+            f"neither source records it"
+        )
+
+
+def test_no_result_row_is_left_unchecked():
+    """Every numeric outcome row is one this file pins.
+
+    Without this, a new row -- "Divergences: 0", say -- could be added to the
+    result table and no assertion would ever look at it.
+    """
+    numeric = {label: value for label, value in _rows().items()
+               if re.fullmatch(r"[\d ,.]+(of [\d ,.]+)?", value)}
+    unchecked = set(numeric) - set(RECORDED_RESULTS)
+    assert not unchecked, (
+        f"the summary states numeric outcomes nothing pins: {sorted(unchecked)}. "
+        f"Add them to RECORDED_RESULTS with the value the sources record, or "
+        f"remove them -- an unchecked figure is one nobody verified."
+    )

--- a/tests/test_ppd_spec_and_attribution.py
+++ b/tests/test_ppd_spec_and_attribution.py
@@ -26,8 +26,13 @@ def test_governing_specification_ships_with_the_code():
 
 
 def test_specification_is_version_stamped():
+    """Rev 8 -- the corpus-acceptance and artifact-distribution decision round.
+
+    The stamp moves only on a decision round, never on an edit in passing, so
+    this assertion is what makes "frozen" mean something.
+    """
     head = SPEC.read_text().splitlines()[0]
-    assert "rev 7" in head and "FROZEN" in head, head
+    assert "rev 8" in head and "FROZEN" in head, head
 
 
 def _normalised(text: str) -> str:


### PR DESCRIPTION
Step A of the rollout order: reconcile the documents with what has actually merged. **Docs and tests only.** No architecture, production behaviour, Dockerfile, fly config, image, secret, dependency, flag or deployment surface is touched, and nothing is enabled, hosted or released.

## Why

Eight PRs have merged into the Unreleased section. The documents describing them still described the state before several of them landed, and every one of these reads as current:

| Contradiction | Was |
|---|---|
| The spec's **Basis** paragraph | "no production adapter or boot lifecycle exists" — thirty lines below the paragraph describing both, and while `test_rollout_prerequisites` asserts they are wired in **both** deployments |
| The spec's **status list** | called the shadow corpus and its rehearsal unimplemented; both merged in #30/#31 with guard tests running in this suite |
| The **changelog's G3** | still required the image change "*before* routing is introduced" — the ordering rev 7 replaced because PR 4 made it unsatisfiable by any future action |
| The **runbook** | cited rev 6 in its header and rev 7 in its body |
| The **corpus** | `Status: proposed`, while its own §1 said it is agreed before Stage 1 and frozen for its duration |

## Specification → rev 8

Accepting the corpus and recording the distribution scope are **decisions**, so the frozen spec goes to rev 8 with its own revision note rather than being edited in passing. Rev 7 and rev 6 notes are kept — history accumulates.

**Rev 8 is a status round and relaxes nothing.** `test_revision_8_relaxed_no_requirement` pins the 30 s readiness target, the `bundle_bytes * 2.5` rule, all six Stage 1 exit criteria, G1a's non-transferability and G2's open question against it — the same guard rev 7 already carries, because status text is exactly where a requirement gets softened by accident.

## The corpus is frozen, post-rehearsal

PR #30 wrote the Definition; PR #31 ran it against a real artifact and corrected four things in it. Freezing the pre-rehearsal text would have frozen those defects, so the freeze note says which text is frozen and why.

**The absence of a Stage 1 Instance is the design, not an omission.** §0 places it at artifact selection, which has not happened. `test_the_freeze_does_not_claim_an_instance` forbids describing it as outstanding work — that framing invites someone to write one against no artifact, which is the coupling the Definition/Instance split exists to prevent.

## The distribution determination

New: `docs/design/ppd-artifact-distribution-decision.md`. Recorded as **the owner's scoped decision, explicitly not legal advice**.

Permitted: private delivery of the bundle to project-controlled Fly Machines, internal read-only price-information use. Not permitted, unchanged: public download; any surface serving the bundle or bulk rows; any address use outside price information; attribution requirements.

**It grants no mutation authority** — no bucket, upload, Fly secret, transport, image or deploy — and it settles **exactly one** of §6's four Royal Mail triggers. The other three still stop for review. Three merged documents had said the question was open; without a record the next session re-litigates a settled decision, which is the failure this reconciliation exists to stop.

## The rehearsal result, preserved as a reconstruction

New: `docs/ops/ppd-shadow-rehearsal-summary.md`.

The tool's `--report` JSON **was not retained** — a search on 2026-08-29 across the repository, the home directory and `.ppd-lab/` found none. The summary is therefore built from commit `6f969eb` and PR #31, is labelled reconstructed in its first line, and carries only what those two sources record: `v20260828T194003Z` / `50f802b2…9072c`, exit 0, 13/13 cases, 85 passed / 0 failed / 2 `not_evaluable`, no midnight exclusions, isolation armed and self-checked, `PPD_SNAPSHOT_ENABLED=0` restored, 24.6 KB report.

A document that looked like tool output would later be cited as though a file had been verified, when what was verified was prose about a file.

Hygiene is tested against **the fixture values this suite already forbids in a report** and against quoted JSON field names — not against patterns for what an id or a price looks like, which would match coverage dates and byte counts and would have to be loosened until they stopped meaning anything.

## PR groups instead of a count

The changelog's bare total was wrong twice — "four", then "Five" against eight merged. It now reads **five implementation PRs (#24–#28)** and **three rollout-preparation PRs (#29–#31)**. A ninth PR extends a range; it does not force a recount, and the recount is what kept going stale.

## Verification

**1,602 passed / 26 skipped**, from the 1,587 / 26 baseline — +15, matching the 15 net new tests. Every new guard was **red before its document changed**, including `test_specification_is_version_stamped`, which pinned `rev 7` and was missed in the review that preceded this PR.

```
git diff --stat -- Dockerfile Dockerfile.app fly.toml fly.app.toml \
                   pyproject.toml uv.lock .github/ \
                   property_core/ app/ property_app/ property_cli/ tools/
```
is **empty**. All ten relative markdown links across the five documents resolve.

Two guards were fixed during the run rather than loosened: `_section` only understands `#` headings, so the status-list assertion got a `_paragraph` helper with a tight scope; and banning the token `p95` had also banned the summary's *disclaimer* that it satisfies no p95 criterion, so the test now requires the disclaimer and forbids only a reported figure.

## Caveat

The three summary guards live in `test_shadow_rehearsal.py`, which `importorskip`s `duckdb`/`zstandard` at module level. They **skip** in a run without `--extra snapshot`, as ~200 other tests in this directory already do. CI and the documented dev command both pass the extra.

## Not in this PR

No release. No Fly access. The deployed version of either app is **unknown** and is not asserted anywhere: what is established is only that `v1.14.2` (`0e267d7`) predates PR #25 and that `main` is 40 commits ahead of it. Confirming what is actually running needs a separately authorised read-only check.

Also not here, each separately authorised: G2 read-only verification; the distribution implementation design; the dependency-only image change; G1a; the Stage 1 shadow implementation, Instance and run; Stage 2; G1b; Stage 3; v1.15.


---

# Review round 1 — four findings closed (`44feda3`)

**1. The final sequence still called the scope undecided.** §10 item 5 kept "Artifact distribution remains a separate approval, still outstanding" — the fourth of four places, and the last one a reader reaches. It now records the scope as determined while **hosting, credentials, transport, retention, audit and every mutation remain separately authorised**. `test_no_section_still_calls_the_distribution_scope_undecided` pins both halves, scoped to phrases asserting an undecided *scope* so that "separately authorised" survives everywhere it is still true.

**2. The result test was vacuous — confirmed, not assumed.** It asked whether `"0"` and `"2"` appeared anywhere in the document, which a coverage date or a byte count already satisfies. Mutating the summary to `failed = 9` / `not_evaluable = 7`:

```
old substring test would report missing: NOTHING -- it passes on the mutation
new binding test: FAILED test_each_recorded_result_is_bound_to_its_own_label
                  - 0
                  + 9
```

Each figure is now read out of its own table row and compared exactly. `test_no_result_row_is_left_unchecked` additionally fails on any numeric result row nothing pins, so an unchecked figure cannot be added later.

**3. The summary guards could skip.** They sat in `test_shadow_rehearsal.py`, which `importorskip`s duckdb and zstandard at module level. They move to `tests/snapshot/test_shadow_rehearsal_summary.py`, importing nothing optional; the shared forbidden values move to `tests/snapshot/rehearsal_fixtures.py`. Quoted `"town"` and `"district"` join the prohibited keys.

Proven with a `sys.meta_path` blocker — the repo's own idiom — rather than by omitting the extra, which leaves the packages installed in the project environment and would have made the proof meaningless:

```
self-check OK: duckdb blocked: simulating a missing 'snapshot' extra
tests/snapshot/test_shadow_rehearsal_summary.py .... 6 PASSED
SKIPPED [1] tests/snapshot/test_shadow_rehearsal.py:37: could not import 'duckdb'
6 passed, 1 skipped
```

**4. The status paragraph named step numbers, not pull requests.** "PR 6"/"PR 7" are positions in §10's sequence and resolve to nothing lookupable. It now names **GitHub PRs #30 and #31**, states which numbering scheme is which, and the guard asserts both appear in that paragraph.

**Also:** the determination pinned only its exclusions, so an edit dropping "read-only" or "project-controlled Fly Machines" would have left every exclusion intact while widening what is permitted. `test_the_record_pins_what_is_permitted_and_not_only_what_is_not` now pins the permitted scope too.

## Verification

Every new guard **mutation-tested**: restoring the "still outstanding" sentence, dropping "read-only" from the permission, and reverting the PR numbers each fail their own guard and nothing else. All three documents restored byte-identical afterwards (`git diff --stat` empty on each).

Focused governance set: **155 passed / 2 skipped**. Full suite: **1,607 passed / 26 skipped**, from 1,602 / 26 — +5 net (−3 moved out, +6 in the new module, +2 new pins). `git diff --stat` against `main` over both Dockerfiles, both fly configs, `pyproject.toml`, `uv.lock`, `.github/`, `tools/` and all four consumer packages is **empty**.

The caveat in the previous section no longer applies: the summary guards cannot skip.
