### PR TITLE
release: v1.15.0 — PPD source routing and live-path correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,21 @@
 # Changelog
 
-## Unreleased — v1.15.0 (pending): PPD snapshot source routing + live-path correctness containment
+## v1.15.0 (2026-08-30) — PPD snapshot source routing + live-path correctness containment
 
-Not released. No version bump. **Five implementation PRs** (#24-#28) and
-**three rollout-preparation PRs** (#29-#31), against the design in
-`docs/design/ppd-source-routing.md`, now at rev 8. The rollout-preparation PRs
-change documents and tests only: they touch no Dockerfile, fly config, image,
-secret, dependency, flag or deployment.
+**Five implementation PRs** (#24-#28) and **four rollout-preparation PRs**
+(#29-#32), against the design in `docs/design/ppd-source-routing.md`, now at
+rev 8. The rollout-preparation PRs change documents, tests and local operator
+tooling only: they touch no Dockerfile, fly config, image, secret, dependency,
+flag or deployment.
 
-**`PPD_SNAPSHOT_ENABLED` is off by default, and nothing about the deployed
-behaviour changes while it stays off.** With no snapshot materialized every PPD
-surface answers from live SPARQL exactly as before, with one addition: an
-additive `provenance` block declaring `source: "sparql"` and null coverage
-fields. The behavioural changes listed under *Changed* below that mention
-coverage take effect only once a snapshot is enabled and materialized.
+**Released with `PPD_SNAPSHOT_ENABLED` off, and with neither production image
+installing the `snapshot` extra** — so nothing is routed to a snapshot, none is
+materialized, and every PPD surface answers from live SPARQL. **The live path
+itself does change, and that is the point of this release:** read *Changed*
+below before upgrading. Every PPD-bearing response also gains an additive
+`provenance` block, here declaring `source: "sparql"` and null coverage fields.
+The further changes marked *only when a snapshot is enabled and materialized*
+ship dormant behind the flag and take effect nowhere in this release.
 
 ### Changed — behavioural, read before upgrading
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.14.2"
+version = "1.15.0"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates (England & Wales, GOV.UK Bearer API), rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.14.2",
+      "version": "1.15.0",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/tests/snapshot/test_rollout_premises.py
+++ b/tests/snapshot/test_rollout_premises.py
@@ -409,8 +409,8 @@ def test_the_changelog_describes_pr_groups_rather_than_a_total():
 
     It was wrong twice already -- "four", then "Five" against eight merged PRs.
     The groups are what a reader actually needs: five PRs that built the thing
-    (#24-#28) and three that prepared its rollout without touching production
-    (#29-#31). A ninth PR extends a range, which is a one-line edit; it does
+    (#24-#28) and four that prepared its rollout without touching production
+    (#29-#32). A further PR extends a range, which is a one-line edit; it does
     not force a recount, and a recount is what kept going stale.
     """
     normalised = _normalised(CHANGELOG)
@@ -418,7 +418,7 @@ def test_the_changelog_describes_pr_groups_rather_than_a_total():
         "the changelog still states a bare PR total; totals go stale silently"
     )
     for phrase in ("implementation PRs", "rollout-preparation PRs",
-                   "#24-#28", "#29-#31"):
+                   "#24-#28", "#29-#32"):
         assert phrase in normalised, (
             f"the changelog no longer describes its PR groups: {phrase!r} is gone"
         )

--- a/tests/test_release_manifest_version.py
+++ b/tests/test_release_manifest_version.py
@@ -1,0 +1,69 @@
+"""The MCP registry manifest must state the version this repository builds.
+
+`server.json` is what the MCP registry publishes about this server: the version
+a registry client believes it is installing, and the PyPI version `uvx` resolves.
+Nothing generated it and nothing checked it, so both of its version fields were
+hand-edited at each release and silently drifted whenever one was missed.
+
+This is the same defect class as the v1.14.2 server-card fix: a manifest that
+misreports what is published defeats the purpose of publishing it. That one was
+caught by dogfooding in production; this one would be caught by a user whose
+registry install resolved the wrong release.
+
+Asserted as agreement with `pyproject.toml` — the single source the build reads —
+never as a literal, so it holds across releases without edits.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = json.loads((ROOT / "server.json").read_text())
+BUILD_VERSION = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"]
+
+
+def test_the_manifest_declares_the_version_this_repository_builds():
+    assert MANIFEST["version"] == BUILD_VERSION, (
+        f"server.json declares {MANIFEST['version']!r}, but pyproject.toml "
+        f"builds {BUILD_VERSION!r}"
+    )
+
+
+def test_every_pypi_package_entry_resolves_to_that_same_version():
+    """The `uvx` install path carries its own version field, edited separately."""
+    pypi = [p for p in MANIFEST["packages"] if p["registryType"] == "pypi"]
+    assert pypi, "no PyPI package entry in server.json"
+    for package in pypi:
+        assert package["version"] == BUILD_VERSION, (
+            f"server.json PyPI entry {package['identifier']!r} pins "
+            f"{package['version']!r}, but pyproject.toml builds {BUILD_VERSION!r}"
+        )
+
+
+def test_the_manifest_names_the_distribution_actually_published():
+    """A version match is worthless if the identifier points somewhere else."""
+    name = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["name"]
+    identifiers = {p["identifier"] for p in MANIFEST["packages"] if p["registryType"] == "pypi"}
+    assert identifiers == {name}, f"manifest publishes {identifiers}, build publishes {name!r}"
+
+
+def test_the_changelog_heads_with_the_version_being_built():
+    """The other hand-edited version field in a release.
+
+    Bumping `pyproject.toml` without dating the changelog section ships a
+    release whose notes still say "Unreleased", and bumping the changelog
+    without `pyproject.toml` publishes the previous version under the new
+    notes. Both are one forgotten edit away, and neither fails anything today.
+    """
+    headings = [
+        line for line in (ROOT / "CHANGELOG.md").read_text().splitlines()
+        if line.startswith("## ")
+    ]
+    assert headings, "no release headings in CHANGELOG.md"
+    assert headings[0].startswith(f"## v{BUILD_VERSION} "), (
+        f"the changelog heads with {headings[0]!r}, but pyproject.toml builds "
+        f"{BUILD_VERSION!r}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1217,7 +1217,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.14.2"
+version = "1.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Version bump only. **No Dockerfile, fly config, dependency, secret or flag change.**

## What this releases

The live-path correctness containment from PRs #24–#28, plus the additive
`provenance` block. `PPD_SNAPSHOT_ENABLED` stays off and neither production image
installs the `snapshot` extra, so no snapshot is materialized and nothing routes to
one. The snapshot-gated behaviour ships dormant.

Rollout gates G1a, G1b, G2 and G3 are untouched and remain unmet. The
dependency-only image change that G3 requires is deliberately **not** in this
release; it lands, deploys and is observed separately with the flag off.

## Version fields

| File | Field |
|---|---|
| `pyproject.toml` | `project.version` |
| `uv.lock` | `property-shared` package version (one-line diff, no dependency drift) |
| `server.json` | top-level `version` **and** the PyPI package entry's `version` |
| `CHANGELOG.md` | section dated `v1.15.0 (2026-08-30)` |

## Two corrections the release exposed

**The changelog preamble contradicted its own *Changed* section.** It said
"nothing about the deployed behaviour changes while it stays off" and that every
PPD surface answers "exactly as before" — while the section directly below states
callers relying on auto-escalation will see fewer, closer comparables, and that
district searches no longer leak neighbouring outcodes (`B5`/`B50`). That reading
is harmless under an "Unreleased" heading and actively misleading in a release
note someone consults to decide whether to upgrade. Rewritten to say the live path
does change and that this is the point of the release.

**Four rollout-preparation PRs merged, not three** (#29–#32). The paragraph was
written by #32 and did not count itself. `test_the_changelog_describes_pr_groups_rather_than_a_total`
caught this on the range edit — the maintenance its own docstring predicted.

## New guard: `tests/test_release_manifest_version.py`

`server.json` is the MCP registry manifest — the version a registry client believes
it is installing and the one `uvx` resolves. Nothing generated it and nothing checked
it, so both version fields were hand-edited each release and a missed one drifts in
silence. This is the same defect class as the v1.14.2 server-card fix, which
production dogfooding caught; this one a user's registry install would catch.

Four assertions, all against `pyproject.toml` rather than literals so they survive
future releases: manifest version, every PyPI entry's version, the distribution
identifier, and the changelog's leading heading.

Written red-first — with `pyproject.toml` at 1.15.0 and `server.json` untouched,
both drift assertions failed:

```
AssertionError: server.json PyPI entry 'property-shared' pins '1.14.2',
but pyproject.toml builds '1.15.0'
```

Each guard was then mutation-tested individually: reverting the changelog heading to
`## Unreleased` fails only the changelog guard; reverting *one* of the two
`server.json` fields fails only the PyPI-entry guard. All files restored.

## Verification

- Full suite: **1,612 passed / 26 skipped** (1,607 before).
  <br>**Correction (2026-08-31):** the parenthetical originally read "+4 new guards, +1 from the identifier check". That explanation was invented — this file collects exactly **4** tests, and I never established where the fifth came from. Both counts were observed correctly; only the account of the difference was wrong. Left unreconciled deliberately rather than delay the event-loop hotfix (#34).
- `uv build`: both artifacts at 1.15.0. Wheel carries `app`, `property_app`, `property_cli`, `property_core` and excludes `tools/` and `tests/`, as intended.
- `uv lock` diff is exactly one line — no dependency resolution moved.
- `git diff --stat main` touches no Dockerfile, fly config, `.github/`, `property_core/`, `app/`, `property_app/`, `property_cli/` or `tools/`.

## After merge

Tag `v1.15.0` on the merge commit, then publish the GitHub Release, which triggers
`release.yml`: PyPI publish, then both Fly deploys gated on `needs: publish`.
