### PR TITLE
fix(api,mcp): run synchronous PPD comps off the event loop

### DIFF
--- a/app/api/v1/ppd.py
+++ b/app/api/v1/ppd.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from functools import partial
 from typing import Literal, Optional
 
+import anyio
 from fastapi import APIRouter, HTTPException, Query
 
 from app.schemas.ppd import (
@@ -227,16 +229,26 @@ async def comps(
             transaction_category = tc_clean.upper()
 
     try:
-        result = service.comps(
-            postcode=postcode,
-            property_type=property_type,
-            transaction_category=transaction_category,
-            filter_outliers=filter_outliers,
-            months=months,
-            limit=limit,
-            search_level=search_level,
-            address=address,
-            auto_escalate=auto_escalate,
+        # Offloaded: PPDService.comps is synchronous and blocks for the whole
+        # upstream round trip. Run on the event loop it stopped this worker
+        # answering anything else, /v1/health included -- see
+        # tests/test_event_loop_not_blocked_by_comps.py. anyio's default thread
+        # limiter bounds the pool, so this adds concurrency without unbounded
+        # threads. Exceptions propagate unchanged, so the handlers below keep
+        # their existing status codes.
+        result = await anyio.to_thread.run_sync(
+            partial(
+                service.comps,
+                postcode=postcode,
+                property_type=property_type,
+                transaction_category=transaction_category,
+                filter_outliers=filter_outliers,
+                months=months,
+                limit=limit,
+                search_level=search_level,
+                address=address,
+                auto_escalate=auto_escalate,
+            )
         )
     except PPDCoverageError as exc:
         # 422, not 404 or a partial 200: the request is unsatisfiable as stated,

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -197,16 +197,23 @@ async def property_comps(
     limit caps returned transactions (max 200). enrich_epc attaches EPC floor
     area and price-per-sqft to each transaction — slower but richer.
     """
+    import anyio
     from property_core import PPDService
-    result = PPDService().comps(
-        postcode=postcode,
-        months=months,
-        property_type=property_type,
-        transaction_category=transaction_category,
-        filter_outliers=filter_outliers,
-        search_level=search_level,
-        address=address,
-        limit=limit,
+
+    # Offloaded: PPDService.comps is synchronous. Called on the event loop it
+    # stalled every other MCP session and /v1/health for the whole upstream
+    # round trip -- see tests/test_event_loop_not_blocked_by_comps.py.
+    result = await anyio.to_thread.run_sync(
+        lambda: PPDService().comps(
+            postcode=postcode,
+            months=months,
+            property_type=property_type,
+            transaction_category=transaction_category,
+            filter_outliers=filter_outliers,
+            search_level=search_level,
+            address=address,
+            limit=limit,
+        )
     )
     if enrich_epc and result.transactions:
         from property_core import EPCClient

--- a/docs/ops/2026-08-30-property-shared-stall.md
+++ b/docs/ops/2026-08-30-property-shared-stall.md
@@ -1,5 +1,9 @@
 # property-shared stall, 2026-08-30
 
+**Status: OPEN.** It closes when the hotfix is deployed and client
+responsiveness is verified against the running service — not when the fix
+merges. The regression tests, PR #34 and this note are the durable record.
+
 Timestamped observations from the read-only diagnosis. Every figure here was
 read from the running system at the stated UTC time. This records evidence, not
 gate completion.
@@ -89,6 +93,28 @@ An earlier note in this diagnosis claimed Rightmove's location lookup was
 used a **sector**, which it is not designed to resolve. The production failures
 seen at 22:00:32Z were `LocationLookupError` for `'BB12 1AA'` — consistent with
 an unresolvable input rather than an outage.
+
+## Sibling endpoints — checked, not defective
+
+A first pass listed seven further call sites as "the identical defect" purely
+because they call synchronous code. **That was wrong.** A synchronous call is
+not the defect; a synchronous call from an `async def` handler is, because only
+then does it occupy the loop thread.
+
+`comps` was the **only** `async def` in the PPD router. `download_url`,
+`transactions`, `address_search`, `transaction_record` and `blocks` are plain
+`def`, which Starlette runs in its threadpool. The MCP sites — `ppd_transactions`
+in `app/mcp/server.py`, `analyse_blocks` and `search_ppd_transactions` in
+`property_app/tools.py` — are plain `def` tools, which FastMCP offloads the same
+way.
+
+Verified rather than reasoned: `tests/test_event_loop_not_blocked_by_comps.py`
+drives a slow stub through the real `/v1/ppd/transactions` route and through
+FastMCP's own tool dispatcher, asserting both that the stub actually ran for its
+full duration and that the loop stayed responsive throughout. Those tests would
+fail if a sibling were ever converted to `async def` without an offload.
+
+## Rightmove, continued
 
 What remains open, and is *not* claimed as a defect here: whether
 `rightmove_search` should reject a non-full-postcode input with a typed caller

--- a/docs/ops/2026-08-30-property-shared-stall.md
+++ b/docs/ops/2026-08-30-property-shared-stall.md
@@ -1,0 +1,96 @@
+# property-shared stall, 2026-08-30
+
+Timestamped observations from the read-only diagnosis. Every figure here was
+read from the running system at the stated UTC time. This records evidence, not
+gate completion.
+
+## Symptom
+
+From 22:00Z, `property-shared.fly.dev` stopped answering. TLS completed at Fly's
+edge in ~54 ms — the edge terminates TLS, so that proved only edge reachability
+— then no HTTP response arrived. `propertydata` and an independent control both
+returned 200 throughout.
+
+## Cause
+
+`PPDService.comps` is synchronous, and both `GET /v1/ppd/comps`
+(`app/api/v1/ppd.py`) and the MCP `property_comps` tool (`app/mcp/server.py`)
+called it directly from inside `async def`. The single uvicorn worker's event
+loop was therefore parked in a blocking socket read for the whole upstream
+SPARQL round trip, unable to run any other task — including `/v1/health`, a
+constant-returning coroutine that performs no I/O.
+
+Fly's health check allows 5 s. Live PPD queries observed during v1.15.0
+release testing took 60–120 s. The check timed out, the Machine was dropped
+from the proxy's candidate set, and requests then failed upstream with
+`could not find a good candidate within 40 attempts at load balancing`.
+
+`app/api/v1/rightmove.py` already offloaded its synchronous calls with
+`anyio.to_thread.run_sync`; the PPD router never did.
+
+## Evidence, with timestamps
+
+| UTC | Observation |
+|---|---|
+| 22:00:09 | Edge `/v1/health`: TLS 0.054 s, **ttfb 0.000**, timeout at 25 s. `propertydata` 200 in 0.076 s |
+| 22:00:41 | Machine `started`, check `passing`, `{"status":"ok"}`, updated 20 s prior |
+| 22:00:44–22:00:57 | Proxy `could not find a good candidate` from `iad`, `fra` |
+| 22:01:05 | `Health check 'servicecheck-00-http-8080' has failed` |
+| 22:02:10 | Check `is now passing` — flapping, not a hard failure |
+| 22:02:12 | Four `CallToolRequest` in flight, then 34 s of no application output |
+| 22:02:46 | Check fails again |
+| 22:05:38 | Check `passing` 38 s prior, while only 4 requests arrived in 80 s |
+| 22:08:58–22:13:58 | **45** proxy `no candidate` errors in one 5-minute window |
+| 22:10:44–22:11:40 | **8/8** probes to `127.0.0.1:8080/v1/health` **from inside the Machine** timed out at 6 s |
+| ~22:10 | `loadavg 0.00 0.00 0.00`; `MemFree` 1.74 GB of 2 GB; uptime 8885 s, idle 8802 s |
+| ~22:10 | `uvicorn` PID 635, **2 threads**, `state=S`; tid 635 `do_poll`, tid 785 `futex_wait_queue` |
+| ~22:10 | Listening socket `0.0.0.0:8080` accept queue **12**, draining to 1 by 22:12 |
+| 22:13:45 | App served `GET /v1/health 200` and `GET /metrics 200` — intermittent, not wedged |
+
+Zero CPU while serving nothing is the signature of a blocked event loop, not of
+saturation. No OOM, no restart, no exit: the process ran from boot throughout.
+
+## Worker count — evidence for property-shared only
+
+`Dockerfile` runs `CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0",
+"--port", "8080"]` with no `--workers`, so **`property-shared` ran a single
+uvicorn worker on one shared vCPU** at 2026-08-30T22:10Z, on image
+`deployment-01M1A31WVKD5S0QQ9XJ2CDG0NC`.
+
+**This is not G2.** It is one observation of one app at one time, read from the
+checked-in Dockerfile and the running Machine. G2 asks for the worker count to
+be verified as a rollout precondition across the targets it governs; nothing
+here establishes that for `propertydata`, and nothing here pins a count against
+future change. G2 remains open.
+
+## Fly configuration, unchanged by v1.15.0
+
+`property-shared` sets `[http_service.concurrency] type="requests",
+hard_limit=10, soft_limit=5`; `propertydata` sets no concurrency block. Both
+values predate this work — `hard_limit = 10` dates from `ff21f31`, 2026-01-21 —
+and `git diff v1.14.2 v1.15.0` over both Dockerfiles and both fly configs is
+empty. **No Fly limit, worker count or Machine count was changed**, so the
+hotfix can be assessed against an unchanged baseline. Whether the concurrency
+limit is right is a separate question, to be reassessed once the loop no longer
+blocks; it is backpressure and should not be removed blindly.
+
+## Rightmove — claim narrowed after an input control
+
+An earlier note in this diagnosis claimed Rightmove's location lookup was
+"broken globally". **That was wrong**, and the control that disproves it:
+
+| Input | Result |
+|---|---|
+| `SW1A 1AA` (full postcode) | `POSTCODE^837246`, 0.1 s |
+| `B5 4BX` (full postcode) | `POSTCODE^4991456`, 0.1 s |
+| `B5 7` (sector) | `None` |
+
+`lookup_postcode` resolves full postcodes correctly. The original observation
+used a **sector**, which it is not designed to resolve. The production failures
+seen at 22:00:32Z were `LocationLookupError` for `'BB12 1AA'` — consistent with
+an unresolvable input rather than an outage.
+
+What remains open, and is *not* claimed as a defect here: whether
+`rightmove_search` should reject a non-full-postcode input with a typed caller
+error instead of raising and rendering a large traceback per call. That needs
+its own valid-input controls before anything is asserted about it.

--- a/tests/test_event_loop_not_blocked_by_comps.py
+++ b/tests/test_event_loop_not_blocked_by_comps.py
@@ -185,3 +185,109 @@ async def test_the_mcp_tool_does_not_stall_the_loop_it_shares(monkeypatch):
         f"the event loop stalled for {worst:.2f}s during one property_comps "
         f"call; every other MCP session and /v1/health waits that long"
     )
+
+
+# ---------------------------------------------------------------------------
+# The siblings: synchronous handlers, which both dispatchers already offload.
+#
+# A synchronous *call* is not the defect. The defect is a synchronous call made
+# from an `async def` handler, because only then does it run on the loop
+# thread. `comps` was the only `async def` in the PPD router; every sibling is
+# a plain `def`, which Starlette runs in its threadpool, and FastMCP does the
+# same for a synchronous tool.
+#
+# These tests exist because that distinction is easy to assert and easy to get
+# wrong -- it was got wrong once already, when the siblings were listed as
+# defective on the strength of the call alone. They drive the real route and
+# the real tool dispatcher, so they would fail if a sibling were ever converted
+# to `async def` without an offload.
+# ---------------------------------------------------------------------------
+
+
+def _slow_search(*args, **kwargs) -> dict:
+    time.sleep(SLOW_SECONDS)
+    return {"count": 0, "limit": 5, "offset": 0, "results": [], "warnings": []}
+
+
+async def test_a_synchronous_rest_handler_does_not_block_the_loop(monkeypatch):
+    """`GET /v1/ppd/transactions` is `def`; Starlette offloads it for us."""
+    import httpx
+
+    from app.main import create_app
+    from property_core.ppd_service import PPDService
+
+    monkeypatch.setattr(PPDService, "search_transactions", _slow_search)
+
+    with _Server(create_app(), _free_port()) as server:
+        async with httpx.AsyncClient(base_url=server.base) as client:
+            slow = asyncio.ensure_future(
+                client.get(
+                    "/v1/ppd/transactions",
+                    params={"postcode_prefix": "B5", "limit": 5},
+                    timeout=30.0,
+                )
+            )
+            await asyncio.sleep(0.5)
+
+            started = time.monotonic()
+            health = await client.get("/v1/health", timeout=HEALTH_BUDGET_SECONDS + 4)
+            elapsed = time.monotonic() - started
+
+            assert health.status_code == 200, health.text
+            assert elapsed < HEALTH_BUDGET_SECONDS, (
+                f"/v1/health took {elapsed:.2f}s during a slow *synchronous* "
+                f"handler; it is no longer being offloaded"
+            )
+            # Anti-vacuity: if the stub never ran -- a 422 on params, a route
+            # that does not exist -- health would be fast for a reason that has
+            # nothing to do with offloading, and this test would prove nothing.
+            response = await slow
+            assert response.status_code == 200, response.text
+            assert time.monotonic() - started >= SLOW_SECONDS - 0.6, (
+                "the slow stub did not actually run; this test is vacuous"
+            )
+
+
+async def test_a_synchronous_mcp_tool_does_not_block_the_loop(monkeypatch):
+    """Driven through FastMCP's own dispatcher, not by calling the function."""
+    from fastmcp import Client
+
+    from app.mcp.server import mcp
+    from property_core.ppd_service import PPDService
+
+    monkeypatch.setattr(PPDService, "search_transactions", _slow_search)
+
+    gaps: list[float] = []
+
+    async def heartbeat() -> None:
+        last = time.monotonic()
+        while True:
+            await asyncio.sleep(0.05)
+            now = time.monotonic()
+            gaps.append(now - last)
+            last = now
+
+    async with Client(mcp) as client:
+        beat = asyncio.ensure_future(heartbeat())
+        await asyncio.sleep(0.3)
+        beats_before = len(gaps)
+        call_started = time.monotonic()
+        try:
+            await client.call_tool("ppd_transactions", {"postcode": "B5 4BX"})
+            elapsed = time.monotonic() - call_started
+            await asyncio.sleep(0.1)
+        finally:
+            beat.cancel()
+
+    assert beats_before >= 2, "heartbeat was not established; test proves nothing"
+    # Anti-vacuity: the tool must actually have reached the slow stub, or a
+    # quiet loop says nothing about offloading.
+    assert elapsed >= SLOW_SECONDS - 0.6, (
+        f"the tool returned in {elapsed:.2f}s; the slow stub did not run and "
+        f"this test is vacuous"
+    )
+    worst = max(gaps)
+    assert worst < HEALTH_BUDGET_SECONDS, (
+        f"the loop stalled for {worst:.2f}s dispatching a synchronous MCP tool; "
+        f"FastMCP is no longer offloading it"
+    )

--- a/tests/test_event_loop_not_blocked_by_comps.py
+++ b/tests/test_event_loop_not_blocked_by_comps.py
@@ -1,0 +1,187 @@
+"""Slow PPD comps must not block the event loop.
+
+Production incident, 2026-08-30 22:00-22:15Z. `property-shared` stopped
+answering: TLS completed at Fly's edge, then no HTTP response arrived. The
+Machine was healthy throughout -- no OOM, no restart, 1.74 GB of 2 GB free --
+and the load average was **0.00**. Zero CPU while serving nothing is the
+signature of a blocked event loop, not of saturation: the loop thread was
+parked in a synchronous socket read and could not run any other task.
+
+`PPDService.comps` is synchronous, and both `GET /v1/ppd/comps` and the MCP
+`property_comps` tool called it directly from inside `async def`. For the whole
+of an upstream SPARQL round trip, one comps request stopped the single uvicorn
+worker from serving anything at all -- including `/v1/health`, which is a
+constant-returning coroutine that does no I/O. Fly's health check then timed
+out against its 5 s limit, the Machine was dropped from the proxy's candidate
+set, and every request queued behind "could not find a good candidate".
+
+`app/api/v1/rightmove.py` already offloads its synchronous calls with
+`anyio.to_thread.run_sync`; the PPD router never did.
+
+These tests use a slow *stub* in place of the upstream call -- no Land Registry
+traffic -- and assert responsiveness, never the wall-clock of the slow call
+itself, so they measure the property that broke rather than a timing artefact.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+
+import pytest
+
+from property_core.models.ppd import PPDCompsQuery, PPDCompsResponse
+
+# Long enough that a blocked loop is unmistakable, short enough to keep the
+# suite fast. Health is asserted against a far smaller budget, so the two can
+# never be confused for one another.
+SLOW_SECONDS = 3.0
+HEALTH_BUDGET_SECONDS = 1.0
+
+pytestmark = pytest.mark.anyio
+
+
+def _stub_response(postcode: str) -> PPDCompsResponse:
+    return PPDCompsResponse(
+        query=PPDCompsQuery(postcode=postcode, months=24, search_level="sector"),
+        count=0,
+        thin_market=False,
+    )
+
+
+def _slow_comps(*args, **kwargs) -> PPDCompsResponse:
+    """Stands in for a slow upstream.
+
+    `time.sleep` is the honest stand-in for a blocking socket read: it holds the
+    calling thread without consuming CPU, which is what the incident showed.
+    """
+    time.sleep(SLOW_SECONDS)
+    return _stub_response(kwargs.get("postcode", "B5 7"))
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _Server:
+    """A real uvicorn server on a real port.
+
+    Deliberately not `TestClient`/ASGITransport: the incident was about the
+    server's own loop being unable to accept and answer a second connection, and
+    an in-process transport that shares the caller's loop cannot demonstrate
+    that. This is the closest reproduction of the deployed process -- one
+    uvicorn worker, one event loop -- that a test can be.
+    """
+
+    def __init__(self, app, port: int):
+        import uvicorn
+
+        self._server = uvicorn.Server(
+            uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+        )
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+        self.base = f"http://127.0.0.1:{port}"
+
+    def __enter__(self):
+        self._thread.start()
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if self._server.started:
+                return self
+            time.sleep(0.02)
+        raise RuntimeError("uvicorn did not start")
+
+    def __exit__(self, *exc):
+        self._server.should_exit = True
+        self._thread.join(timeout=30)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def test_health_answers_while_a_slow_comps_request_is_in_flight(monkeypatch):
+    """The reproduction: one slow comps must not take the whole worker down."""
+    import httpx
+
+    from app.main import create_app
+    from property_core.ppd_service import PPDService
+
+    monkeypatch.setattr(PPDService, "comps", _slow_comps)
+
+    with _Server(create_app(), _free_port()) as server:
+        async with httpx.AsyncClient(base_url=server.base) as client:
+            comps = asyncio.ensure_future(
+                client.get("/v1/ppd/comps", params={"postcode": "B5 7"}, timeout=30.0)
+            )
+            # Let the slow request reach the handler and start blocking.
+            await asyncio.sleep(0.5)
+
+            started = time.monotonic()
+            health = await client.get("/v1/health", timeout=HEALTH_BUDGET_SECONDS + 4)
+            elapsed = time.monotonic() - started
+
+            assert health.status_code == 200, health.text
+            assert elapsed < HEALTH_BUDGET_SECONDS, (
+                f"/v1/health took {elapsed:.2f}s while one comps request was in "
+                f"flight; the event loop is blocked by a synchronous call. Fly's "
+                f"health check allows 5s before removing the Machine."
+            )
+
+            assert (await comps).status_code == 200
+
+
+async def test_the_mcp_tool_does_not_stall_the_loop_it_shares(monkeypatch):
+    """The same defect on the other consumer.
+
+    Measured as a heartbeat rather than through a server: what harmed production
+    was the loop being unable to run *any* other task, and a heartbeat observes
+    that directly. A coroutine that yields every 50 ms cannot show a gap much
+    larger than that unless something ran synchronously to completion inside the
+    loop thread.
+    """
+    from app.mcp.server import property_comps
+    from property_core.ppd_service import PPDService
+
+    monkeypatch.setattr(PPDService, "comps", _slow_comps)
+
+    gaps: list[float] = []
+
+    async def heartbeat() -> None:
+        last = time.monotonic()
+        while True:
+            await asyncio.sleep(0.05)
+            now = time.monotonic()
+            gaps.append(now - last)
+            last = now
+
+    beat = asyncio.ensure_future(heartbeat())
+    # Let the heartbeat establish itself BEFORE the blocking call starts.
+    # Without this the loop never runs it, `gaps` stays empty, and an
+    # `if gaps else 0.0` fallback would report a perfect score for the very
+    # stall the test exists to catch.
+    await asyncio.sleep(0.3)
+    beats_before = len(gaps)
+    try:
+        await property_comps(postcode="B5 7")
+        # A stall is only *recorded* on the heartbeat's next wake, which cannot
+        # happen until the loop is free again. Cancelling straight after the
+        # call would discard the one gap that matters and report a clean run.
+        await asyncio.sleep(0.1)
+    finally:
+        beat.cancel()
+
+    assert beats_before >= 2, (
+        f"heartbeat only ran {beats_before}x before the call; it was not "
+        f"established, so this test could not have observed a stall"
+    )
+    worst = max(gaps)
+    assert worst < HEALTH_BUDGET_SECONDS, (
+        f"the event loop stalled for {worst:.2f}s during one property_comps "
+        f"call; every other MCP session and /v1/health waits that long"
+    )


### PR DESCRIPTION
Hotfix for the 2026-08-30 `property-shared` stall. **Two call sites, no config change, no deployment.**

## Cause

`PPDService.comps` is synchronous ([ppd_service.py:327](../blob/main/property_core/ppd_service.py#L327) — `def`, not `async def`), and both consumers called it directly from inside `async def`:

- `GET /v1/ppd/comps` — `app/api/v1/ppd.py`
- MCP `property_comps` — `app/mcp/server.py`

The single uvicorn worker's event loop was parked in a blocking socket read for the whole upstream SPARQL round trip, unable to run any other task — including `/v1/health`, a constant-returning coroutine that does no I/O.

Fly's health check allows 5 s. Live PPD queries observed during v1.15.0 release testing took 60–120 s. The check timed out, the Machine was dropped from the proxy's candidate set, and requests then failed with `could not find a good candidate within 40 attempts at load balancing`.

The diagnostic that rules out saturation: **load average 0.00** with 1.74 GB of 2 GB free, no OOM, no restart. Zero CPU while serving nothing is a blocked loop, not overload.

`app/api/v1/rightmove.py` already offloaded its synchronous calls with `anyio.to_thread.run_sync` — four call sites. The PPD router had **zero**.

## Reproduction, red first

No Land Registry traffic — a stub replaces the upstream call and sleeps, which is the honest stand-in for a blocking socket read (holds the thread, burns no CPU).

| Test | Before |
|---|---|
| Real uvicorn server; `/v1/health` requested while a slow comps call is in flight | **2.52 s** (budget 1.0 s) |
| Heartbeat measuring loop stall during the MCP tool | **3.05 s** |

Both green after the fix.

Two vacuity holes were found and closed while writing the second test — worth noting because both would have reported a clean run on the broken code:

1. The heartbeat had not started before the blocking call, so `gaps` was empty and `max(gaps) if gaps else 0.0` scored a perfect run. Now the heartbeat is established first and `beats_before >= 2` is asserted.
2. A stall is only *recorded* on the heartbeat's next wake, which cannot happen until the loop is free — cancelling straight after the call discarded the one gap that mattered. Now the loop is allowed to turn once before cancelling.

## The fix

Existing bounded pattern, matching `rightmove.py` (REST: `partial`) and `server.py` (MCP: `lambda`). anyio's default thread limiter bounds the pool, so this adds concurrency without unbounded threads.

Behaviour preserved: exceptions propagate unchanged through `to_thread.run_sync`, so `PPDCoverageError` → 422, `InvalidPostcodeError` → 422 and the `Exception` → 502 fallback all keep their status codes; the EPC enrichment step after the call is untouched.

## Deliberately unchanged

`hard_limit = 10` / `soft_limit = 5`, worker count and Machine count are **untouched**, so the fix can be judged against an unchanged baseline. Whether that limit is right is a separate question to reassess once the loop no longer blocks — it is backpressure, and removing it blindly would trade one failure mode for another.

## Correction: the siblings are NOT defective

An earlier revision of this description listed seven further call sites as "the identical defect", on the strength of their calling synchronous code. **That was wrong.** A synchronous call is not the defect — a synchronous call *from an `async def` handler* is, because only then does it occupy the loop thread.

`comps` is the **only** `async def` in the PPD router:

```
 34: def download_url(      129: def address_search(     276: def transaction_record(
 49: def transactions(      178: async def comps(        301: def blocks(
```

Starlette runs plain `def` handlers in its threadpool. The MCP sites are likewise plain `def` tools — `ppd_transactions` (`app/mcp/server.py:602`), `analyse_blocks` (`property_app/tools.py:468`), `search_ppd_transactions` (`property_app/tools.py:525`) — and FastMCP offloads those the same way.

Verified rather than reasoned. Two further tests drive a slow stub through the **real** `/v1/ppd/transactions` route and through **FastMCP's own dispatcher** (`Client(mcp).call_tool`), rather than calling the functions directly:

| Test | Result |
|---|---|
| Slow sync REST handler, `/v1/health` requested concurrently | health responsive |
| Slow sync MCP tool via FastMCP dispatcher, heartbeat | no stall |

Each asserts the stub genuinely ran for its full ~3 s **before** drawing any conclusion from a quiet loop, so neither can pass vacuously — the failure mode that already bit this test file twice. Both would fail if a sibling were ever converted to `async def` without an offload.

**No expansion of the fix: two demonstrated defects, two call sites changed.**

## Correction: the Rightmove claim was wrong

I previously reported Rightmove's location lookup as "broken globally". The input control disproves it:

| Input | Result |
|---|---|
| `SW1A 1AA` (full postcode) | `POSTCODE^837246`, 0.1 s |
| `B5 4BX` (full postcode) | `POSTCODE^4991456`, 0.1 s |
| `B5 7` (sector) | `None` |

`lookup_postcode` resolves full postcodes correctly. I had tested with a **sector**, which it is not designed to resolve. The production failures were `LocationLookupError` for `'BB12 1AA'` — consistent with unresolvable input, not an outage.

## Worker count is evidence, not G2

`docs/ops/2026-08-30-property-shared-stall.md` records that `property-shared` ran a **single** uvicorn worker at 2026-08-30T22:10Z on image `deployment-01M1A31WVKD5S0QQ9XJ2CDG0NC` (`CMD` has no `--workers`). That is one observation of one app at one time. It establishes nothing for `propertydata` and pins no count against future change. **G2 remains open.**

## Verification

Full suite **1,617 passed / 26 skipped** (4 new tests: 2 reproducing the defect, 2 clearing the siblings). No Dockerfile, fly config, dependency, secret or version change — `git diff --stat main` covers only the two handlers, one test file and one ops doc.

## Incident status

**OPEN.** It closes when this is deployed and client responsiveness is verified against the running service — not on merge. `docs/ops/2026-08-30-property-shared-stall.md`, this PR and the regression tests are the durable record.

Snapshot rollout remains paused. No deployment without approval.
