### PR TITLE
release: v1.15.1 — hotfix for the PPD comps event-loop stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## v1.15.1 (2026-08-31) — hotfix: PPD comps no longer blocks the event loop
+
+**Upgrade if you run v1.15.0.** No API, response, error or data change; no
+dependency, image, flag or configuration change. One defect, two call sites.
+
+### Fixed
+
+- **`PPDService.comps` ran on the event loop and stalled the whole worker.**
+  It is synchronous, and both `GET /v1/ppd/comps` and the MCP `property_comps`
+  tool called it directly from inside `async def`. For the whole of an upstream
+  Land Registry round trip the single uvicorn worker could not run any other
+  task — including `/v1/health`, a constant-returning coroutine that performs
+  no I/O. Live PPD queries take 60–120 s; Fly's health check allows 5 s, so the
+  check timed out, the Machine left the proxy's candidate set, and requests
+  queued behind `could not find a good candidate`. Observed in production on
+  2026-08-30 as a total stall of `property-shared` with **load average 0.00**
+  and 1.74 GB of 2 GB free — zero CPU while serving nothing is a blocked loop,
+  not overload.
+
+  Both call sites now use the bounded `anyio.to_thread.run_sync` pattern that
+  `app/api/v1/rightmove.py` already used. Exceptions propagate unchanged, so
+  every status code, response shape and the EPC enrichment step are identical.
+
+### Not changed
+
+- **Only `comps` was defective.** It was the only `async def` handler in the
+  PPD router; the sibling endpoints and MCP tools are plain `def`, which
+  Starlette and FastMCP already run in a threadpool. Tests drive a slow stub
+  through the real route and through FastMCP's own dispatcher to demonstrate
+  that rather than assert it, and would fail if a sibling were ever converted
+  to `async def` without an offload.
+- Fly concurrency limits, worker count, Machine count, Docker dependencies and
+  `PPD_SNAPSHOT_ENABLED` are untouched, so the fix is observable against an
+  unchanged baseline. Whether `hard_limit = 10` is right is a separate question
+  to reassess now that the loop no longer blocks — it is backpressure, not a
+  bug.
+
+Incident record, with timestamped evidence:
+`docs/ops/2026-08-30-property-shared-stall.md`.
+
+
 ## v1.15.0 (2026-08-30) — PPD snapshot source routing + live-path correctness containment
 
 **Five implementation PRs** (#24-#28) and **four rollout-preparation PRs**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.15.0"
+version = "1.15.1"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates (England & Wales, GOV.UK Bearer API), rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/uv.lock
+++ b/uv.lock
@@ -1217,7 +1217,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.15.0"
+version = "1.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Version bump only, on top of #34. **No Dockerfile, fly config, dependency, secret, flag, worker or Machine change** — the fix must be observable against an unchanged baseline.

## What ships

The single defect from #34: `PPDService.comps` is synchronous and was called directly from inside `async def` in both `GET /v1/ppd/comps` and the MCP `property_comps` tool, so it ran on the event loop and stalled the entire single-worker process for each upstream round trip — `/v1/health` included. Both call sites now use the bounded `anyio.to_thread.run_sync` pattern `app/api/v1/rightmove.py` already used.

No API, response, error or data change. Exceptions propagate unchanged, so every status code, response shape and the EPC enrichment step are identical.

## Version fields

| File | Field |
|---|---|
| `pyproject.toml` | `project.version` → 1.15.1 |
| `uv.lock` | one-line diff, no dependency drift |
| `server.json` | top-level `version` **and** the PyPI entry's `version` |
| `CHANGELOG.md` | section dated `v1.15.1 (2026-08-31)` |

All four verified together by `tests/test_release_manifest_version.py`, added in v1.15.0 precisely so this bump could not drift silently.

## Gating condition

Full suite from a **clean checkout** (fresh `git clone` of the merged branch, separate venv) on **Python 3.11.13** — the production image's interpreter:

```
1617 passed, 26 skipped in 65.69s
```

Identical to the 3.12 result. `uv build` produces both artifacts at 1.15.1.

## Deliberately unchanged

`hard_limit = 10` / `soft_limit = 5`, worker count (1), Machine count (1), both Dockerfiles' `uv sync` lines, and `PPD_SNAPSHOT_ENABLED` (absent, so off). Whether the concurrency limit is right is a separate question to reassess now that the loop no longer blocks — it is backpressure, not a bug, and removing it blindly would trade one failure mode for another.

**Snapshot rollout remains paused.** Neither image installs the `snapshot` extra; gates G1a, G1b, G2 and G3 are untouched and unmet.

## After merge

Tag `v1.15.1` on the merge commit, publish the GitHub Release, which triggers `release.yml`: PyPI publish, then both Fly deploys gated on `needs: publish`.

## Incident status

**OPEN** until deployed responsiveness and the maintainer's real-client checks are confirmed. `docs/ops/2026-08-30-property-shared-stall.md` is the durable record.