### PR TITLE
build: prepare snapshot-ready images with serving disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased — snapshot image prerequisites
+
+- Both Docker recipes install the optional `snapshot` extra unconditionally.
+  Snapshot serving remains disabled; deploying and observing these dependencies
+  is a separate step from enabling the source (G3).
+- The optional extra also includes `botocore==1.43.83` for official request
+  signing in the separately reviewed private-delivery source. No required
+  library dependency or existing pinned dependency version changes.
+- No Fly configuration, worker count, Machine count, serving flag or version
+  changes. A built image is not evidence that production has been updated.
+
 ## v1.15.1 (2026-08-31) — hotfix: PPD comps no longer blocks the event loop
 
 **Upgrade if you run v1.15.0.** No API, response, error or data change; no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## Unreleased — snapshot image prerequisites
-
-- Both Docker recipes install the optional `snapshot` extra unconditionally.
-  Snapshot serving remains disabled; deploying and observing these dependencies
-  is a separate step from enabling the source (G3).
-- The optional extra also includes `botocore==1.43.83` for official request
-  signing in the separately reviewed private-delivery source. No required
-  library dependency or existing pinned dependency version changes.
-- No Fly configuration, worker count, Machine count, serving flag or version
-  changes. A built image is not evidence that production has been updated.
-
 ## v1.15.1 (2026-08-31) — hotfix: PPD comps no longer blocks the event loop
 
 **Upgrade if you run v1.15.0.** No API, response, error or data change; no

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --no-cache-dir uv
 
 # Copy dependency manifests first for better layer caching
 COPY pyproject.toml uv.lock README.md ./
-RUN uv sync --frozen --no-dev --extra api
+RUN uv sync --frozen --no-dev --extra api --extra snapshot
 
 # Planning disabled: scraping requires UK residential IP
 # RUN uv sync ... --extra planning && playwright install chromium

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir uv
 COPY pyproject.toml uv.lock README.md ./
 COPY property_core ./property_core
 COPY property_app ./property_app
-RUN uv sync --frozen --no-dev --extra apps
+RUN uv sync --frozen --no-dev --extra apps --extra snapshot
 
 EXPOSE 8080
 

--- a/docs/ops/ppd-snapshot-image-prerequisites.md
+++ b/docs/ops/ppd-snapshot-image-prerequisites.md
@@ -1,0 +1,41 @@
+# Snapshot image prerequisites — prepared, not deployed
+
+Both Docker recipes install the optional `snapshot` extra unconditionally.
+Snapshot serving remains disabled. Deploying and observing these dependencies
+is a separate step from enabling the source, under G3 in the routing spec.
+
+The extra contains DuckDB 1.5.5, zstandard 0.25.0 and botocore 1.43.83. The latter
+supplies official request signing for the separately reviewed private-delivery
+source. No required library dependency or existing pinned version changes.
+
+No Fly configuration, worker count, Machine count, serving flag, version or
+release changes. A locally built image is not evidence of deployment.
+
+## Built-image evidence, 2026-08-31
+
+Both images built on linux/amd64 from the dependency-only runtime tree. Each
+imports all three dependencies above on Python 3.11.16. The floating
+`python:3.11-slim` base resolved to manifest digest
+`sha256:1042b61448fef4ba92d16a8c7eb4996d027568ce64792a7877fd88511e0af7c6`.
+The development suite uses Python 3.11.13; do not conflate these patch versions.
+
+Offline checks use a synthetic one-row tar.zst, never the actual PPD data:
+
+- Flag off: real app lifespan starts and a transaction request returns the
+  identifiable live fixture once, with SPARQL provenance.
+- Healthy snapshot: real lifespan verifies, opens and serves the synthetic
+  snapshot with snapshot provenance and zero live fixture calls.
+- DuckDB blocked: typed `snapshot_extra_missing`, snapshot not routable, app
+  remains available and serves the identifiable live fixture.
+- zstandard blocked: extraction records `SnapshotExtraMissingError`, snapshot
+  not routable, app remains available and serves the live fixture.
+
+The API uses TestClient through its real lifespan and REST transactions route;
+the app uses FastMCP's dispatcher after the entrypoint's registration imports.
+Each mode runs in a fresh process; import blockers are self-checked. Containers
+have networking disabled, one CPU and a 512 MiB limit. These are dependency and
+fallback checks, not a full-size resource test or G1 pass.
+
+No deployed observation is claimed. G3 remains incomplete until these images
+are deployed and observed with the serving flag off. G1a, G1b and Stage 1 remain
+separate requirements.

--- a/docs/ops/ppd-snapshot-image-prerequisites.md
+++ b/docs/ops/ppd-snapshot-image-prerequisites.md
@@ -39,3 +39,15 @@ fallback checks, not a full-size resource test or G1 pass.
 No deployed observation is claimed. G3 remains incomplete until these images
 are deployed and observed with the serving flag off. G1a, G1b and Stage 1 remain
 separate requirements.
+
+Reproduce after building both Dockerfiles (replace the example image tag):
+
+```sh
+docker run --rm --network none --memory 512m --cpus 1 \
+  --mount type=bind,src="$PWD/tests/snapshot/image_smoke.py",dst=/check.py,readonly \
+  <api-image-tag> python /check.py api
+```
+
+Use `app` instead of `api` for Dockerfile.app. The optional `include-private`
+argument also checks absent signing support once the separate private-source
+implementation is present. No credentials or live PPD calls are needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Needed only to read a local PPD snapshot. Deliberately NOT required
+# Needed only for the optional PPD snapshot source. Deliberately NOT required
 # dependencies: library and CLI consumers on the live SPARQL path must not pay
 # for a ~59 MB native wheel they never load.
 #
@@ -53,7 +53,9 @@ dependencies = [
 # arrives in 3.14) and neither production image installs the zstd binary, so
 # without this the runtime cannot open a real bundle at all. The extractor falls
 # back to a `zstd` binary if one is present, but does not rely on it.
-snapshot = ["duckdb==1.5.5", "zstandard==0.25.0"]
+# botocore supplies official SigV4 signing for private delivery. It is imported
+# lazily; no SDK credential discovery, retries or write client runs in the app.
+snapshot = ["duckdb==1.5.5", "zstandard==0.25.0", "botocore==1.43.83"]
 planning = [
   "playwright>=1.57.0",
   "openai>=1.83.0,<2",

--- a/tests/snapshot/image_smoke.py
+++ b/tests/snapshot/image_smoke.py
@@ -1,0 +1,160 @@
+"""Built-image check with synthetic data; never contacts PPD or uses credentials."""
+import hashlib
+import importlib.abc
+import json
+import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+# Match uvicorn's default app-dir insertion. This script is mounted at /check.py
+# while the API image intentionally runs its copied source tree from /app.
+sys.path.insert(0, os.getcwd())
+
+
+def fixture(root):
+    import duckdb
+    import zstandard
+    from property_core.snapshot.schema import REQUIRED_COLUMNS
+    directory = root / "year=2026"
+    directory.mkdir()
+    values = {"transaction_id": "SYNTHETIC", "postcode": "B5 7AA",
+              "outcode": "B5", "sector": "B5 7", "price": 100000,
+              "transfer_date": "2026-06-01", "property_type": "F",
+              "duration": "L", "ppd_category": "A", "new_build": False}
+    columns, parameters = [], []
+    for name, types in REQUIRED_COLUMNS.items():
+        columns.append(f"CAST(? AS {sorted(types)[0]}) AS {name}")
+        parameters.append(values.get(name))
+    con = duckdb.connect()
+    con.execute("CREATE TABLE fixture AS SELECT " + ",".join(columns), parameters)
+    con.execute(f"COPY fixture TO '{directory / 'data.parquet'}' (FORMAT PARQUET)")
+    con.close()
+    tar = root / "fixture.tar"
+    with tarfile.open(tar, "w") as archive:
+        archive.add(directory / "data.parquet", arcname="year=2026/data.parquet")
+    blob = zstandard.ZstdCompressor().compress(tar.read_bytes())
+    (root / "fixture.tar.zst").write_bytes(blob)
+    manifest = dict(snapshot_version="synthetic-v1", bundle_object="fixture.tar.zst",
+                    bundle_sha256=hashlib.sha256(blob).hexdigest(), bundle_bytes=len(blob),
+                    parquet_files=1, rows=1, coverage_from="2016-01-01",
+                    coverage_to="2026-06-30", provisional_from="2026-03-01",
+                    layout="year", duckdb_version=duckdb.__version__)
+    (root / "manifest.json").write_text(json.dumps(manifest))
+    (root / "current.json").write_text(json.dumps({"current_manifest": "manifest.json"}))
+
+
+def child(root, mode, target):
+    blocked = mode if mode in {"duckdb", "zstandard", "botocore"} else None
+    if blocked:
+        class Block(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, *args):
+                if fullname == blocked or fullname.startswith(blocked + "."):
+                    raise ModuleNotFoundError("blocked " + blocked)
+        sys.meta_path.insert(0, Block())
+        try:
+            __import__(blocked)
+        except ModuleNotFoundError:
+            pass
+        else:
+            raise AssertionError("blocker inactive")
+    os.environ["PPD_SNAPSHOT_ENABLED"] = "0" if mode == "off" else "1"
+    os.environ["PPD_SNAPSHOT_CACHE_DIR"] = str(root / ("store-" + mode))
+    os.environ["PPD_SNAPSHOT_DIR"] = str(root)
+    if mode == "botocore":
+        os.environ.pop("PPD_SNAPSHOT_DIR")
+        os.environ["PPD_SNAPSHOT_S3_BUCKET"] = "ppd-test"
+        os.environ["PPD_SNAPSHOT_S3_ACCESS_KEY_ID"] = "fake-key"
+        os.environ["PPD_SNAPSHOT_S3_SECRET_ACCESS_KEY"] = "fake-secret"
+
+    # Prove live fallback with an identifiable result, not a quiet empty reply.
+    from property_core.ppd_client import PricePaidDataClient, SearchPage
+    from property_core.models.ppd import PPDTransaction
+    from property_core.provenance import TransportEvidence
+    from property_core.snapshot import bootstrap
+    live_calls = []
+    def fake_live(self, **kwargs):
+        live_calls.append(kwargs)
+        return SearchPage(transactions=[PPDTransaction(transaction_id="LIVE-FIXTURE",
+                          postcode="B5 7AA", date="2026-06-01", price=100000)],
+                          evidence=TransportEvidence(raw_bindings_returned=1, fetch_limit=10))
+    PricePaidDataClient.search_with_evidence = fake_live
+
+    # Capture the exact missing-package error at the materialization boundary;
+    # normal bootstrap still handles it and the actual app lifespan continues.
+    failures = []
+    original = bootstrap._materialize
+    def record_failure():
+        try:
+            return original()
+        except Exception as exc:
+            failures.append(exc)
+            raise
+    bootstrap._materialize = record_failure
+    boot_warnings = []
+    class Capture(logging.Handler):
+        def emit(self, record):
+            boot_warnings.append(record.getMessage())
+    logging.getLogger("property_core.snapshot.boot").addHandler(Capture())
+
+    def check(payload):
+        snapshot = mode == "healthy"
+        assert bootstrap.snapshot_status()["routable"] is snapshot
+        assert payload["count"] == 1
+        assert payload["provenance"]["source"] == ("snapshot" if snapshot else "sparql")
+        assert len(live_calls) == (0 if snapshot else 1), live_calls
+
+    if target == "api":
+        from fastapi.testclient import TestClient
+        from app.main import app
+        with TestClient(app) as client:
+            assert client.get("/v1/health").status_code == 200
+            result = client.get("/v1/ppd/transactions", params={"postcode": "B5 7AA"})
+            assert result.status_code == 200, result.text
+            check(result.json())
+    else:
+        import anyio
+        from fastmcp import Client
+        from property_app.server import mcp
+        # Registration is performed by the deployed property-app entrypoint.
+        from property_app import tools
+        from property_app.dashboards import comps, listings, rental, unified, yield_view
+        async def run():
+            async with Client(mcp) as client:
+                result = await client.call_tool("ppd_transactions", {"postcode": "B5 7AA"})
+                assert not result.is_error
+                check(result.structured_content)
+        anyio.run(run)
+
+    if blocked == "zstandard":
+        # Runtime records extraction failure in its BootReport rather than raising.
+        assert any("SnapshotExtraMissingError" in m and "zstandard" in m for m in boot_warnings), boot_warnings
+    elif blocked:
+        assert len(failures) == 1, failures
+        assert failures[0].code == "snapshot_extra_missing"
+        assert failures[0].package == blocked
+    else:
+        assert not failures, failures
+    print(json.dumps({"image": target, "mode": mode, "passed": True,
+                      "live_fixture_calls": len(live_calls)}))
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "child":
+        child(Path(sys.argv[2]), sys.argv[3], sys.argv[4])
+    else:
+        import duckdb, zstandard, botocore
+        print(json.dumps({"python": sys.version.split()[0], "duckdb": duckdb.__version__,
+                          "zstandard": zstandard.__version__, "botocore": botocore.__version__}), flush=True)
+        with tempfile.TemporaryDirectory(prefix="ppd-image-smoke-") as temp:
+            root = Path(temp)
+            fixture(root)
+            modes = ("off", "healthy", "duckdb", "zstandard")
+            if sys.argv[2:] == ["include-private"]:
+                modes += ("botocore",)
+            for mode in modes:
+                subprocess.run([sys.executable, __file__, "child", str(root), mode, sys.argv[1]],
+                               check=True)

--- a/tests/snapshot/test_rollout_prerequisites.py
+++ b/tests/snapshot/test_rollout_prerequisites.py
@@ -20,10 +20,10 @@ What this file is good for: catching the ordinary mistake of enabling the flag
 in a Dockerfile or fly.toml without adding the extra alongside it. Cheap,
 immediate, and covers the path a change to this repository would take.
 
-`property_core.snapshot` needs `duckdb` and `zstandard`, both optional and both
-in the `snapshot` extra. Neither production image installs that extra today,
-which is correct while the flag is off — the runtime is never booted, so the
-packages are never imported.
+`property_core.snapshot` needs `duckdb` and `zstandard`, with `botocore` for
+private delivery, all optional in the `snapshot` extra. Both image recipes now
+install it with the flag still off. Actual built/deployed images need separate
+verification; this file cannot establish deployment state.
 
 The invariants below are CONDITIONAL: inert today, and firing on the commit that
 turns the feature on in checked-in config. They are deliberately not "assert the
@@ -152,6 +152,15 @@ def test_the_runtime_dependencies_live_only_in_the_snapshot_extra():
         )
 
 
+def test_official_signer_is_an_optional_snapshot_dependency_only():
+    config = tomllib.loads((REPO / "pyproject.toml").read_text())
+    extras = config["project"]["optional-dependencies"]
+    assert "botocore==1.43.83" in extras["snapshot"]
+    assert not any(dep.startswith("botocore") for dep in config["project"]["dependencies"])
+    assert not any(dep.startswith("botocore") for name, deps in extras.items()
+                   if name != "snapshot" for dep in deps)
+
+
 def test_the_definitive_gate_is_recorded_in_the_governing_specification():
     """The real gate lives in the spec; this lint is only its cheap shadow.
 
@@ -250,21 +259,18 @@ def test_the_gate_passes_when_the_flag_is_on_with_the_extra(tmp_path):
     assert _installs_snapshot_extra("Dockerfile.fake", root=tmp_path) is True
 
 
-def test_neither_image_installs_the_extra_today_and_that_is_correct():
-    """Records the current state explicitly, with the reason it is fine.
+def test_dependency_only_images_install_the_extra_with_the_flag_still_off():
+    """Install first, deploy and observe independently; never enable here.
 
-    Informational: the runtime is never booted while the flag is off, so the
-    packages are never imported. PR 4 / the rollout changes both sides together.
+    This only checks the recipe. Built-image imports and deployed observation
+    remain separate evidence requirements under G3.
     """
     installed = {name: _installs_snapshot_extra(dockerfile)
                  for name, dockerfile, _fly in IMAGES}
     enabled = {name: _flag_enabled(dockerfile, fly)
                for name, dockerfile, fly in IMAGES}
     assert enabled == {"property-shared": False, "propertydata": False}
-    assert installed == {"property-shared": False, "propertydata": False}, (
-        f"{installed} — if an image now installs the extra, the rollout has "
-        f"started and this record needs updating alongside it"
-    )
+    assert installed == {"property-shared": True, "propertydata": True}
 
 
 # --------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -99,6 +99,20 @@ wheels = [
 ]
 
 [[package]]
+name = "botocore"
+version = "1.43.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/6f/cf16418004c832e6eb9abc6905fa323a3bf96a76ca7f2e97858801a4103e/botocore-1.43.83.tar.gz", hash = "sha256:d9389b3b74400c34219965a2fb858c1d48744718865ee0496fd03bd5b21b943f", size = 16010078, upload-time = "2026-08-28T19:35:46.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/50/332d6713fa09b05ff0882f5d194569fa70d1c8735aca9829b1286fef32ba/botocore-1.43.83-py3-none-any.whl", hash = "sha256:bf75a6cf587c22d968e43e79fe122c39f82deafbe9c3422bc5d3e80b6210fc98", size = 15704489, upload-time = "2026-08-28T19:35:40.603Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -865,6 +879,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "jsonref"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1257,6 +1280,7 @@ planning = [
     { name = "playwright" },
 ]
 snapshot = [
+    { name = "botocore" },
     { name = "duckdb" },
     { name = "zstandard" },
 ]
@@ -1269,6 +1293,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.14.3" },
+    { name = "botocore", marker = "extra == 'snapshot'", specifier = "==1.43.83" },
     { name = "duckdb", marker = "extra == 'snapshot'", specifier = "==1.5.5" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.128.0" },
     { name = "fastmcp", marker = "extra == 'api'", specifier = ">=3.2.4" },


### PR DESCRIPTION
## Scope

First rollout prerequisite only: both Docker recipes install `--extra snapshot`
unconditionally, with `PPD_SNAPSHOT_ENABLED` still off. The extra adds the official
botocore 1.43.83 signer in preparation for the separate private-delivery PR.
Existing locked package versions are unchanged; botocore and jmespath are added.

No source routing, boot-runtime code, Fly config, secret, worker count, Machine
count, release or version change. No deployment performed. The image change must
deploy and be observed independently before any source enablement.

## Evidence

- Full suite on Python 3.11.13: **1618 passed, 26 skipped**.
- `uv lock --check --offline --python 3.11`: 111 packages, in sync.
- Both actual Docker images built and imported duckdb 1.5.5, zstandard 0.25.0,
  botocore 1.43.83 on Python **3.11.16** (the floating base's resolved patch).
- Each image passed four offline modes: flag off with identifiable live
  fixture, healthy synthetic snapshot, DuckDB unavailable, zstandard unavailable.
- Missing dependency keeps snapshot routing unavailable while real REST/MCP
  dispatch returns the identifiable live fixture. Blockers self-check and run
  in fresh child processes; healthy control proves the synthetic bundle is usable.
- Offline containers: one CPU, 512 MiB, no network. Not a full-size G1 test.
- The checks are retained as `tests/snapshot/image_smoke.py`; runbook command in
  `docs/ops/ppd-snapshot-image-prerequisites.md`.

Dependency-only image IDs (runtime tree from commit 650c6db; later commits add
only docs/test harness):

- API: `sha256:323a67b3760e0bc41d0589976a64dee92028af6cc0dd9acc8c0220ada6a254e1`
- App: `sha256:de516f2fa201234fe652178601f72e33f59dc85b620df4aef9caa554b028746c`

An initial Unreleased changelog heading tripped the existing release-version
guard. The preparation record moved to the ops document; the guard and published
release notes remain unchanged. All final tests pass.

## Hold

Review before merge/deploy. No auto-merge or bot review requested. G3 deployed
observation, G1a/G1b and Stage 1 remain unfulfilled. This PR enables no feature.
