### PR TITLE
feat: add verified private Tigris snapshot delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## v1.15.3 (2026-08-31) — private Tigris snapshot delivery, serving off
+
+**Released with `PPD_SNAPSHOT_ENABLED` off on both apps.** Adds a read-only,
+signed `TigrisObjectSource` — the transport the PPD snapshot runtime will use
+to fetch a private, credentialed bundle instead of a public URL or local
+directory — but nothing routes to it yet: the flag stays unset, and every PPD
+surface keeps answering from the live source exactly as before this release.
+This is dependency-only and delivery-code-only, per the gated rollout in
+`docs/design/ppd-source-routing.md` §7 and
+`docs/design/ppd-private-delivery.md`; see those for the remaining gates
+(G1a, G1b, G2, Stage 1 exit) still required before any enablement.
+
+### Added
+
+- **`property_core.snapshot.s3_source.TigrisObjectSource`.** Official
+  `botocore` SigV4 signing (lazy-loaded from the optional `snapshot` extra);
+  explicit bucket-scoped credentials, no discovery or metadata-service lookup;
+  fixed HTTPS endpoint; no writes or retries; redirects rejected without
+  forwarding credentials; bare object names validated before every request.
+  Reuses the existing streamed HTTP transport, `read1` chunking, checksum,
+  length and timeout controls unchanged.
+- **Non-2xx responses from the source are now typed.** A 4xx/5xx from Tigris
+  raises `SnapshotSourceError` (previous cause preserved via `from exc`)
+  instead of leaking a raw `urllib.error.HTTPError` — timeouts are unaffected
+  and still translate to `DownloadDeadlineExceeded`.
+- New configuration, consulted only once a bucket is set:
+  `PPD_SNAPSHOT_S3_BUCKET`, `PPD_SNAPSHOT_S3_PREFIX` (default `ppd`, and now
+  falls back to that default when explicitly set empty, not just when unset),
+  `PPD_SNAPSHOT_S3_ACCESS_KEY_ID`, `PPD_SNAPSHOT_S3_SECRET_ACCESS_KEY`.
+  Configuring a bucket alongside `PPD_SNAPSHOT_DIR`/`PPD_SNAPSHOT_URL` is
+  rejected as ambiguous; `PPD_SNAPSHOT_DIR` and `PPD_SNAPSHOT_URL` together
+  keep the pre-existing precedence (`DIR` wins) unchanged.
+
+## v1.15.2 (2026-08-31) — dependency-only snapshot images, serving off
+
+**No API, response, error or data change.** Both production Dockerfiles
+(`property-shared` and `propertydata`) install the optional `snapshot`
+extra — `duckdb`, `zstandard`, `botocore` — so the deployed images are ready
+for private PPD snapshot delivery. `PPD_SNAPSHOT_ENABLED` remains unset on
+both apps: the snapshot runtime never boots, and the live source continues
+to serve every request exactly as before this release. No Fly config,
+worker, volume, secret or scale change. This is the dependency-only rollout
+gate (G3 requirement 1, `docs/design/ppd-source-routing.md`): the dependency
+change lands, deploys and is observed with the flag off before any snapshot
+code or enablement follows.
+
 ## v1.15.1 (2026-08-31) — hotfix: PPD comps no longer blocks the event loop
 
 **Upgrade if you run v1.15.0.** No API, response, error or data change; no

--- a/docs/design/ppd-private-delivery.md
+++ b/docs/design/ppd-private-delivery.md
@@ -1,0 +1,83 @@
+# Private snapshot delivery — approved rollout implementation
+
+Owner: Paul Boucherat. Approved in the rollout session on 2026-08-31.
+Implements the permitted scope in `ppd-artifact-distribution-decision.md`;
+does not relax the rev-8 routing specification or its rollout gates.
+
+## Scope and account
+
+A dedicated private Tigris bucket in the owner's Fly-linked `personal`
+organisation. Dedicated name: `ppd-snapshots-20260831`. Confirm ownership
+and non-existence before creation. Use the Tigris CLI authenticated through
+Fly.io OAuth, not `fly storage create`: provisioning must not implicitly attach
+credentials to either production app. Disable object ACL overrides and public
+listing; anonymous reads must be rejected.
+
+Initial artifact: `v20260828T194003Z`, 279109872 bytes,
+SHA-256 `50f802b29d9802ee42319122214aeb0adc6761e96c4f6c9ddd0498500bb9072c`.
+Upload only its bundle, immutable manifest and `current.json`, under `ppd/`.
+Verify the remote bundle by a streamed read and SHA-256 before publishing the
+pointer. Do not upload raw CSVs or the address-bearing query results.
+
+## Authentication and transport
+
+Use a distinct bucket-scoped publisher key and distinct bucket-scoped ReadOnly
+keys for the two apps. No org-admin application credential. Never print secrets
+or put them in code, build context, logs, URLs or Git. Application credentials
+are installed explicitly as namespaced Fly secrets only at the delivery rollout
+step; publishing credentials are never installed on an application.
+Until that step, credentials are held in the owner's desktop secret store,
+under service `ppd-snapshot/tigris`, never in a repo or scratch environment file.
+
+The optional `snapshot` extra gains the official AWS `botocore` signing library.
+It is lazy-loaded only when a Tigris source is selected. No handwritten signing
+implementation, background key discovery or metadata-service credential lookup.
+Use SigV4 Authorization headers, HTTPS and `https://t3.storage.dev`, region `auto`.
+The source accepts validated bare object names, never a manifest-provided URL.
+Reject redirects rather than forward credentials to another destination.
+
+Use the existing streamed HTTP implementation and `read1` behaviour: bounded
+control reads, incremental bundle hashing, byte-length check, socket timeout,
+and total-download/stall detection retain their existing guarantees. No new
+retry loop. Verification, safe extraction and the queryability gate are reused.
+
+Configuration: `PPD_SNAPSHOT_S3_BUCKET`, `PPD_SNAPSHOT_S3_PREFIX` (default `ppd`),
+`PPD_SNAPSHOT_S3_ACCESS_KEY_ID`, `PPD_SNAPSHOT_S3_SECRET_ACCESS_KEY`. Refuse
+ambiguous source selection. Missing configuration, rejected credentials,
+unreachable storage or invalid bytes leave snapshot routing unavailable and the
+server serving live, not empty successful results. No public bundle route.
+
+## Retention and audit
+
+Keep the initial artifact and pointer. Later immutable releases may be added by
+the approved publisher; no automated deletion or lifecycle expiry in this first
+rollout. Any cleanup is a separately reviewed operation; never delete the
+currently advertised version or assume bucket deletion revokes credentials.
+Machine-local retention remains one ephemeral materialization, per rev 8.
+
+Record provider request IDs where available, object names, byte lengths,
+digests, UTC timestamps, publishing actor, ACL/role checks and the deployed
+image/Machine identities in sanitised ops evidence. Never claim complete
+request-level access auditing unless actually available. Credential revocation
+requires provider confirmation, not deletion of a local file.
+
+## Verification and rollout sequence
+
+1. Test signing, confinement, redirect rejection, bounded reads, timeout/error
+   propagation and absent-extra failure against local fixtures; no PPD traffic.
+2. Provision and verify private delivery; record actual role grants, anonymous
+   rejection and positive authenticated reads. Publish the pointer last.
+3. Build both images, smoke-test optional imports and failure-to-live semantics.
+   Deploy and observe dependencies with snapshot serving off (G3). Provisioning
+   and image preparation are independent; neither enables snapshot serving.
+4. Measure actual boot on the target with serving disabled until G1a/G2/G3 pass.
+   A control-only shadow mode must materialize without replacing live responses;
+   do not enable the serving flag to work around the missing Stage 1 runner.
+5. Complete Stage 1 and its artifact-bound Instance. Upstream 429/timeout is an
+   inconclusive comparison, not a passing divergence check. Reuse the live
+   result already being returned; do not double live queries on sampled calls.
+6. Enable `property-shared` opt-in only after the gates pass. `propertydata`
+   requires its separate G1b; passing G1a grants nothing for that app.
+
+No volume, increased Machine count, worker change, widened concurrency limit,
+hot refresh, public hosting or new PPD request semantics are introduced here.

--- a/docs/ops/2026-08-31-private-snapshot-delivery.md
+++ b/docs/ops/2026-08-31-private-snapshot-delivery.md
@@ -1,0 +1,74 @@
+# Private snapshot delivery — 2026-08-31
+
+Status: private artifact published and read-verified; production not changed.
+Implements [the approved delivery design](../design/ppd-private-delivery.md).
+This is not a G1 or Stage 1 pass and does not authorise snapshot serving.
+
+## Provisioning and credentials
+
+Tigris CLI 3.10.0, authenticated to the owner's Fly-linked personal organisation,
+created `ppd-snapshots-20260831` with private access at 02:10:53Z.
+No `fly storage create` was used. Both apps' secret names and digests were
+compared before/after creation and were unchanged. No application credentials
+have been installed in Fly by this rollout session.
+
+Three active keys have one bucket role each, verified through the provider:
+
+| Desktop secret-store entry | Role | SHA-256 ID fingerprint prefix |
+| --- | --- | --- |
+| ppd-publisher-20260831 | Editor | 28f0cfb23ca7 |
+| ppd-property-shared-20260831 | ReadOnly | 054715071f55 |
+| ppd-propertydata-20260831 | ReadOnly | 5d43733c3a1e |
+
+Service: `ppd-snapshot/tigris`. Values are in the owner's desktop secret store,
+not Git, environment files or build context. No publisher key belongs on an app.
+
+Policy status returned `IsPublic=false`; object ACL overrides are disabled.
+The ACL grants FULL_CONTROL to the owner and the exact Tigris organisation-admin
+group `https://groups.tigris.dev/org/admins`, not AllUsers or AuthenticatedUsers.
+The first inspection incorrectly rejected every group URI; the actual grantee
+was then inspected, not assumed public. This organisation-admin group is also
+shown in [Tigris's provider-authored ACL explanation](https://dev.to/tigrisdata/sharing-files-with-the-model-context-protocol-178e).
+
+## Published objects
+
+Only these objects exist under `ppd/`. The bundle was fully read through the
+property-shared ReadOnly key and SHA-256 checked before the manifest and pointer
+were published. Each object's anonymous GET returned 403 after its authenticated
+read succeeded. The propertydata ReadOnly key separately read the manifest.
+
+| Object | Bytes | SHA-256 | Readback request ID |
+| --- | ---: | --- | --- |
+| snapshot-v20260828T194003Z.tar.zst | 279109872 | 50f802b29d9802ee42319122214aeb0adc6761e96c4f6c9ddd0498500bb9072c | 1788143473792276247 |
+| manifest-v20260828T194003Z.json | 412 | 2e01062317e477b407f2fc0683744c2a135d11e6e7169471d5666634d307715f | 1788143507150342352 |
+| current.json | 60 | acfb96adf8231421564e4a45bb3ed711568fd0e251ed2b7f1b231ea2c3aa0abf | 1788143507821544456 |
+
+The first upload's verification script used `iter_chunks` on the raw response
+returned by the body context manager and failed. The bundle had been written;
+neither manifest nor pointer had. The corrected checker streamed `read(size)`,
+verified the existing bundle without overwriting it, then published the two
+missing objects. No raw CSV, build report or query result was uploaded.
+These request IDs are individual observations, not complete access auditing.
+
+## Real-source local acceptance
+
+The new signed source fetched the pointer and manifest successfully. One full
+boot from Tigris through SnapshotRuntime and SnapshotAdapter downloaded exactly
+279109872 bytes, verified the digest and opened the 10,394,935-row snapshot.
+A 20-row B5 district query returned only B5 outcodes.
+
+- Local laptop cold boot plus adapter validation: 33.417 seconds.
+- Subsequent query: 28.665 ms.
+- Process peak RSS: 263192 KiB, not an app-process or Machine total.
+- Runtime total: 33267.4 ms. No Land Registry request was made.
+
+This does not satisfy the 30-second Fly readiness gate. It includes the actual
+private transport, but neither Fly's network nor its filesystem or app lifespan.
+Do not substitute this figure for G1a/G1b or for Stage 1 traffic evidence.
+
+## Next boundary
+
+The dependency-only image change must be reviewed, deployed and observed with
+the serving flag off. Private-source code is a separate change on top of it.
+Real G1a/G1b measurements and the missing production shadow runner remain ahead;
+no serving enablement, Volume, scale, concurrency or worker change occurred.

--- a/property_core/snapshot/__init__.py
+++ b/property_core/snapshot/__init__.py
@@ -27,6 +27,7 @@ from property_core.snapshot.errors import (
     SnapshotQueryError,
     SnapshotRowCountError,
     SnapshotSchemaError,
+    SnapshotSourceError,
 )
 from property_core.snapshot.fetch import DownloadResult, download_verified
 from property_core.snapshot.lock import LockTimeout, single_flight
@@ -42,6 +43,7 @@ from property_core.snapshot.source import (
     ObjectSource,
 )
 from property_core.snapshot.store import SnapshotStore
+from property_core.snapshot.s3_source import TigrisObjectSource
 
 __all__ = [
     "ArchiveRejected",
@@ -66,6 +68,8 @@ __all__ = [
     "SnapshotRowCountError",
     "SnapshotSchemaError",
     "SnapshotStore",
+    "SnapshotSourceError",
+    "TigrisObjectSource",
     "VerificationRecord",
     "download_verified",
     "safe_extract",

--- a/property_core/snapshot/bootstrap.py
+++ b/property_core/snapshot/bootstrap.py
@@ -53,14 +53,17 @@ def _build_source() -> Any:
     directory = os.getenv(SNAPSHOT_DIR_ENV)
     url = os.getenv(SNAPSHOT_URL_ENV)
     bucket = os.getenv(SNAPSHOT_BUCKET_ENV)
-    if sum(bool(value) for value in (directory, url, bucket)) > 1:
-        raise RuntimeError("configure exactly one PPD snapshot source")
+    if bucket and (directory or url):
+        raise RuntimeError(
+            f"{SNAPSHOT_BUCKET_ENV} cannot be combined with {SNAPSHOT_DIR_ENV} or "
+            f"{SNAPSHOT_URL_ENV}; configure exactly one PPD snapshot source"
+        )
     if bucket:
         from property_core.snapshot.s3_source import TigrisObjectSource
 
         return TigrisObjectSource(
             bucket,
-            prefix=os.getenv("PPD_SNAPSHOT_S3_PREFIX", "ppd"),
+            prefix=os.getenv("PPD_SNAPSHOT_S3_PREFIX") or "ppd",
             access_key=os.getenv("PPD_SNAPSHOT_S3_ACCESS_KEY_ID", ""),
             secret_key=os.getenv("PPD_SNAPSHOT_S3_SECRET_ACCESS_KEY", ""),
         )

--- a/property_core/snapshot/bootstrap.py
+++ b/property_core/snapshot/bootstrap.py
@@ -36,6 +36,7 @@ log = logging.getLogger("property_core.snapshot.boot")
 #: path can be exercised without any network or cloud resource.
 SNAPSHOT_URL_ENV = "PPD_SNAPSHOT_URL"
 SNAPSHOT_DIR_ENV = "PPD_SNAPSHOT_DIR"
+SNAPSHOT_BUCKET_ENV = "PPD_SNAPSHOT_S3_BUCKET"
 #: Where it is materialized. Ephemeral: Fly's default rootfs, wiped on restart.
 SNAPSHOT_CACHE_ENV = "PPD_SNAPSHOT_CACHE_DIR"
 DEFAULT_CACHE_DIR = "/tmp/ppd-snapshot"
@@ -50,12 +51,24 @@ def _build_source() -> Any:
     from property_core.snapshot.source import HttpObjectSource, LocalDirectorySource
 
     directory = os.getenv(SNAPSHOT_DIR_ENV)
+    url = os.getenv(SNAPSHOT_URL_ENV)
+    bucket = os.getenv(SNAPSHOT_BUCKET_ENV)
+    if sum(bool(value) for value in (directory, url, bucket)) > 1:
+        raise RuntimeError("configure exactly one PPD snapshot source")
+    if bucket:
+        from property_core.snapshot.s3_source import TigrisObjectSource
+
+        return TigrisObjectSource(
+            bucket,
+            prefix=os.getenv("PPD_SNAPSHOT_S3_PREFIX", "ppd"),
+            access_key=os.getenv("PPD_SNAPSHOT_S3_ACCESS_KEY_ID", ""),
+            secret_key=os.getenv("PPD_SNAPSHOT_S3_SECRET_ACCESS_KEY", ""),
+        )
     if directory:
         return LocalDirectorySource(Path(directory))
-    url = os.getenv(SNAPSHOT_URL_ENV)
     if not url:
         raise RuntimeError(
-            f"{SNAPSHOT_URL_ENV} or {SNAPSHOT_DIR_ENV} must be set when "
+            f"{SNAPSHOT_URL_ENV}, {SNAPSHOT_DIR_ENV} or {SNAPSHOT_BUCKET_ENV} must be set when "
             f"PPD_SNAPSHOT_ENABLED is on"
         )
     return HttpObjectSource(url)

--- a/property_core/snapshot/errors.py
+++ b/property_core/snapshot/errors.py
@@ -11,6 +11,13 @@ from typing import Any
 from property_core.exceptions import PPDError, SnapshotFailure
 
 
+class SnapshotSourceError(SnapshotFailure):
+    """Private source configuration or object addressing was rejected."""
+
+    code = "snapshot_source_invalid"
+    retryable = False
+
+
 class SnapshotExtraMissingError(SnapshotFailure):
     """A snapshot feature was used without the optional dependency installed.
 

--- a/property_core/snapshot/s3_source.py
+++ b/property_core/snapshot/s3_source.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import ipaddress
 import re
+import urllib.error
 import urllib.parse
 import urllib.request
 
 from property_core.snapshot.errors import SnapshotExtraMissingError, SnapshotSourceError
 from property_core.snapshot.models import validate_component
-from property_core.snapshot.source import HttpObjectSource
+from property_core.snapshot.source import DEFAULT_TIMEOUT, HttpObjectSource
 
 TIGRIS_ENDPOINT = "https://t3.storage.dev"
 
@@ -43,7 +44,7 @@ class TigrisObjectSource(HttpObjectSource):
 
     def __init__(self, bucket: str, *, access_key: str, secret_key: str,
                  prefix: str = "ppd", endpoint: str = TIGRIS_ENDPOINT,
-                 socket_timeout: float = 10.0):
+                 socket_timeout: float = DEFAULT_TIMEOUT):
         if not re.fullmatch(r"[a-z0-9][a-z0-9-]{1,61}[a-z0-9]", bucket):
             raise SnapshotSourceError("invalid snapshot bucket name")
         if not access_key or not secret_key:
@@ -84,4 +85,10 @@ class TigrisObjectSource(HttpObjectSource):
         return request
 
     def _open(self, name: str):
-        return self._opener.open(self._request(name), timeout=self.socket_timeout)
+        request = self._request(name)
+        try:
+            return self._opener.open(request, timeout=self.socket_timeout)
+        except urllib.error.HTTPError as exc:
+            raise SnapshotSourceError(
+                f"snapshot source returned HTTP {exc.code} for {name!r}"
+            ) from exc

--- a/property_core/snapshot/s3_source.py
+++ b/property_core/snapshot/s3_source.py
@@ -1,0 +1,87 @@
+"""Read-only Tigris delivery, signed by the official AWS SDK.
+
+The existing HTTP stream/verifier retains ownership of download budgets and
+length checks. Credentials are headers, never URLs. No credential discovery,
+metadata-service lookup, retries or cloud writes occur in this source.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import urllib.parse
+import urllib.request
+
+from property_core.snapshot.errors import SnapshotExtraMissingError, SnapshotSourceError
+from property_core.snapshot.models import validate_component
+from property_core.snapshot.source import HttpObjectSource
+
+TIGRIS_ENDPOINT = "https://t3.storage.dev"
+
+
+def _component(value: str, field: str) -> str:
+    try:
+        return validate_component(value, field, reserved=False)
+    except ValueError:
+        # Do not echo arbitrary input (which might itself contain credentials).
+        raise SnapshotSourceError(f"{field} must be a safe path component") from None
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        fp.close()
+        raise SnapshotSourceError("snapshot source redirected; credentials not forwarded")
+
+
+class TigrisObjectSource(HttpObjectSource):
+    """A bucket/prefix-scoped signed GET source; no write interface.
+
+    Production uses the fixed Tigris HTTPS endpoint. An explicit loopback HTTP
+    endpoint is permitted for real-boundary tests; no endpoint comes from a
+    manifest or an environment variable.
+    """
+
+    def __init__(self, bucket: str, *, access_key: str, secret_key: str,
+                 prefix: str = "ppd", endpoint: str = TIGRIS_ENDPOINT,
+                 socket_timeout: float = 10.0):
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]{1,61}[a-z0-9]", bucket):
+            raise SnapshotSourceError("invalid snapshot bucket name")
+        if not access_key or not secret_key:
+            raise SnapshotSourceError("snapshot access key and secret are required")
+        parts = [_component(part, "snapshot prefix")
+                 for part in prefix.split("/")] if prefix else []
+        parsed = urllib.parse.urlsplit(endpoint)
+        try:
+            loopback = ipaddress.ip_address(parsed.hostname or "").is_loopback
+        except ValueError:
+            loopback = False
+        if endpoint != TIGRIS_ENDPOINT and not (
+                parsed.scheme == "http" and loopback and parsed.path == ""
+                and not parsed.username and not parsed.password
+                and not parsed.query and not parsed.fragment):
+            raise SnapshotSourceError("snapshot endpoint must be the Tigris HTTPS endpoint")
+        try:
+            from botocore.auth import S3SigV4Auth
+            from botocore.awsrequest import AWSRequest
+            from botocore.credentials import Credentials
+        except ImportError as exc:
+            raise SnapshotExtraMissingError(
+                package="botocore", feature="private snapshot delivery"
+            ) from exc
+        self._signer = S3SigV4Auth(Credentials(access_key, secret_key), "s3", "auto")
+        self._aws_request = AWSRequest
+        self._opener = urllib.request.build_opener(_NoRedirect())
+        base = "/".join([endpoint, bucket] + parts)
+        super().__init__(base, socket_timeout=socket_timeout)
+
+    def _request(self, name: str):
+        request = super()._request(_component(name, "snapshot object"))
+        signed = self._aws_request(method="GET", url=request.full_url,
+                                   headers=dict(request.header_items()))
+        self._signer.add_auth(signed)
+        for key, value in signed.headers.items():
+            request.add_header(key, value)
+        return request
+
+    def _open(self, name: str):
+        return self._opener.open(self._request(name), timeout=self.socket_timeout)

--- a/property_core/snapshot/source.py
+++ b/property_core/snapshot/source.py
@@ -138,13 +138,15 @@ class HttpObjectSource:
         return urllib.request.Request(self._url(name),
                                       headers={"User-Agent": self.user_agent})
 
+    def _open(self, name: str):
+        return urllib.request.urlopen(self._request(name), timeout=self.socket_timeout)
+
     def read_bytes(self, name: str, *, max_bytes: Optional[int] = None) -> bytes:
         cap = MAX_CONTROL_BYTES if max_bytes is None else max_bytes
         # Two separate seams: waiting for the response, then reading its body.
         # A stalled body times out in the second even though the first succeeded.
         with _timeouts_typed(f"request for {name!r}", self.socket_timeout):
-            resp = urllib.request.urlopen(self._request(name),
-                                          timeout=self.socket_timeout)
+            resp = self._open(name)
         with resp:
             with _timeouts_typed(f"read of {name!r}", self.socket_timeout):
                 # Read one byte past the cap so an oversized control object is an
@@ -159,8 +161,7 @@ class HttpObjectSource:
         # stream. A server that never sends headers times out HERE, before any
         # stream exists, so the translation cannot live only in _HttpStream.read.
         with _timeouts_typed(f"request for {name!r}", self.socket_timeout):
-            resp = urllib.request.urlopen(self._request(name),
-                                          timeout=self.socket_timeout)
+            resp = self._open(name)
         return _HttpStream(resp, socket_timeout=self.socket_timeout)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.15.2"
+version = "1.15.3"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates (England & Wales, GOV.UK Bearer API), rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.15.2",
+      "version": "1.15.3",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/tests/snapshot/test_private_delivery.py
+++ b/tests/snapshot/test_private_delivery.py
@@ -1,0 +1,220 @@
+"""Private-delivery boundary tests; loopback only, never Tigris or PPD."""
+
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+import importlib.util
+import subprocess
+import sys
+import time
+
+from property_core.snapshot.errors import DownloadDeadlineExceeded
+
+import pytest
+
+from property_core.snapshot.bootstrap import _build_source
+from property_core.snapshot.s3_source import SnapshotSourceError, TigrisObjectSource
+
+requires_sdk = pytest.mark.skipif(importlib.util.find_spec("botocore") is None,
+                                  reason="private delivery needs the snapshot extra")
+
+@contextmanager
+def object_server(body=b'{"current_manifest":"manifest-v1.json"}', *, redirect=None,
+                  delay=0):
+    calls = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            calls.append((self.path, dict(self.headers)))
+            if redirect is not None:
+                self.send_response(302)
+                self.send_header("Location", redirect)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            time.sleep(delay)
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            try:
+                self.wfile.write(body)
+            except BrokenPipeError:
+                pass  # a timeout test deliberately closed the client
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    worker = Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", calls
+    finally:
+        server.shutdown()
+        server.server_close()
+        worker.join(timeout=2)
+
+
+@requires_sdk
+def test_signed_control_get_reads_through_http_boundary():
+    with object_server() as (endpoint, calls):
+        source = TigrisObjectSource(
+            "ppd-test", access_key="test-key", secret_key="test-secret",
+            endpoint=endpoint,
+        )
+        assert source.read_bytes("current.json") == b'{"current_manifest":"manifest-v1.json"}'
+    assert len(calls) == 1
+    path, headers = calls[0]
+    assert path == "/ppd-test/ppd/current.json"
+    assert headers["Authorization"].startswith("AWS4-HMAC-SHA256 ")
+    assert "Credential=test-key/" in headers["Authorization"]
+    assert "/auto/s3/aws4_request" in headers["Authorization"]
+    assert "test-secret" not in str(calls)
+    assert "?" not in path  # credentials/signatures are never URL parameters
+
+
+@requires_sdk
+def test_boot_selects_private_source_without_credential_discovery(monkeypatch):
+    monkeypatch.delenv("PPD_SNAPSHOT_URL", raising=False)
+    monkeypatch.delenv("PPD_SNAPSHOT_DIR", raising=False)
+    monkeypatch.setenv("PPD_SNAPSHOT_S3_BUCKET", "ppd-test")
+    monkeypatch.setenv("PPD_SNAPSHOT_S3_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("PPD_SNAPSHOT_S3_SECRET_ACCESS_KEY", "test-secret")
+    source = _build_source()
+    assert isinstance(source, TigrisObjectSource)
+    assert source.base_url == "https://t3.storage.dev/ppd-test/ppd"
+
+
+@pytest.mark.parametrize("name", ["../secret", "/secret", "x/y", "x?token=y", "", "x#frag"])
+@requires_sdk
+def test_manifest_names_cannot_escape_signed_source(name):
+    with object_server() as (endpoint, calls):
+        source = TigrisObjectSource("ppd-test", access_key="test-key",
+                                    secret_key="test-secret", endpoint=endpoint)
+        with pytest.raises(SnapshotSourceError):
+            source.read_bytes(name)
+    assert calls == []
+
+
+@requires_sdk
+def test_redirect_never_forwards_signed_credentials():
+    with object_server() as (target, target_calls):
+        with object_server(redirect=target + "/stolen") as (endpoint, calls):
+            source = TigrisObjectSource("ppd-test", access_key="test-key",
+                                        secret_key="test-secret", endpoint=endpoint)
+            with pytest.raises(SnapshotSourceError, match="credentials not forwarded"):
+                source.read_bytes("current.json")
+    assert len(calls) == 1
+    assert target_calls == []
+
+
+@requires_sdk
+def test_bundle_stream_is_chunked_and_exposes_length():
+    payload = b"01234567" * 131072
+    with object_server(body=payload) as (endpoint, calls):
+        source = TigrisObjectSource("ppd-test", access_key="test-key",
+                                    secret_key="test-secret", endpoint=endpoint)
+        with source.open_stream("snapshot-v1.tar.zst") as stream:
+            assert stream.declared_length == len(payload)
+            chunks = []
+            while chunk := stream.read(16384):
+                assert len(chunk) <= 16384
+                chunks.append(chunk)
+    assert b"".join(chunks) == payload
+    assert len(calls) == 1
+
+
+@requires_sdk
+@pytest.mark.parametrize("method", ["read_bytes", "open_stream"])
+def test_signed_header_timeout_is_typed_and_not_retried(method):
+    with object_server(delay=0.2) as (endpoint, calls):
+        source = TigrisObjectSource("ppd-test", access_key="test-key",
+                                    secret_key="test-secret", endpoint=endpoint,
+                                    socket_timeout=0.04)
+        with pytest.raises(DownloadDeadlineExceeded) as caught:
+            getattr(source, method)("current.json")
+    assert len(calls) == 1
+    assert "test-key" not in str(caught.value)
+    assert "test-secret" not in str(caught.value)
+
+
+@requires_sdk
+def test_control_body_has_the_existing_size_limit():
+    with object_server(body=b"123456789") as (endpoint, calls):
+        source = TigrisObjectSource("ppd-test", access_key="test-key",
+                                    secret_key="test-secret", endpoint=endpoint)
+        with pytest.raises(ValueError, match="exceeds 8 bytes"):
+            source.read_bytes("current.json", max_bytes=8)
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("missing", ["PPD_SNAPSHOT_S3_ACCESS_KEY_ID",
+                                     "PPD_SNAPSHOT_S3_SECRET_ACCESS_KEY"])
+def test_missing_explicit_credentials_do_not_fall_back_to_aws_environment(monkeypatch, missing):
+    for name in ("PPD_SNAPSHOT_DIR", "PPD_SNAPSHOT_URL", missing):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("PPD_SNAPSHOT_S3_BUCKET", "ppd-test")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ambient-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+    with pytest.raises(SnapshotSourceError, match="access key and secret are required"):
+        _build_source()
+
+
+def test_ambiguous_source_configuration_is_refused(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_URL", "https://example.invalid")
+    monkeypatch.setenv("PPD_SNAPSHOT_S3_BUCKET", "ppd-test")
+    with pytest.raises(RuntimeError, match="exactly one"):
+        _build_source()
+
+
+def test_no_sdk_installed_is_actionable_and_flag_off_is_inert():
+    code = '''
+import importlib.abc, sys, os, socket
+class BlockSDK(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, *args):
+        if fullname == "botocore" or fullname.startswith("botocore."):
+            raise ModuleNotFoundError("blocked botocore")
+sys.meta_path.insert(0, BlockSDK())
+try:
+    import botocore
+except ModuleNotFoundError:
+    pass
+else:
+    raise AssertionError("blocker not armed")
+from property_core.snapshot.s3_source import TigrisObjectSource
+from property_core.snapshot.errors import SnapshotExtraMissingError
+try:
+    TigrisObjectSource("ppd-test", access_key="test-key", secret_key="test-secret")
+except SnapshotExtraMissingError as exc:
+    assert exc.code == "snapshot_extra_missing"
+    assert exc.package == "botocore"
+else:
+    raise AssertionError("missing SDK accepted")
+from property_core.snapshot.bootstrap import boot_once, snapshot_status
+os.environ["PPD_SNAPSHOT_ENABLED"] = "0"
+def no_network(*args, **kwargs):
+    raise AssertionError("network attempted with flag off")
+socket.socket = no_network
+boot_once()
+assert snapshot_status()["routable"] is False
+assert not any(n == "botocore" or n.startswith("botocore.") for n in sys.modules)
+'''
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_redirect_closes_the_rejected_response():
+    import io
+    from property_core.snapshot.s3_source import _NoRedirect
+    body = io.BytesIO(b"redirect response")
+    with pytest.raises(SnapshotSourceError):
+        _NoRedirect().redirect_request(None, body, 302, "Found", {}, "https://other.invalid")
+    assert body.closed
+
+
+def test_public_source_and_error_are_exported():
+    import property_core.snapshot as snapshot
+    for name, expected in (("TigrisObjectSource", TigrisObjectSource),
+                           ("SnapshotSourceError", SnapshotSourceError)):
+        assert name in snapshot.__all__
+        assert getattr(snapshot, name) is expected

--- a/tests/snapshot/test_private_delivery.py
+++ b/tests/snapshot/test_private_delivery.py
@@ -20,7 +20,7 @@ requires_sdk = pytest.mark.skipif(importlib.util.find_spec("botocore") is None,
 
 @contextmanager
 def object_server(body=b'{"current_manifest":"manifest-v1.json"}', *, redirect=None,
-                  delay=0):
+                  delay=0, status=200):
     calls = []
 
     class Handler(BaseHTTPRequestHandler):
@@ -33,6 +33,11 @@ def object_server(body=b'{"current_manifest":"manifest-v1.json"}', *, redirect=N
                 self.end_headers()
                 return
             time.sleep(delay)
+            if status != 200:
+                self.send_response(status)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
             self.send_response(200)
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
@@ -80,6 +85,19 @@ def test_boot_selects_private_source_without_credential_discovery(monkeypatch):
     monkeypatch.setenv("PPD_SNAPSHOT_S3_BUCKET", "ppd-test")
     monkeypatch.setenv("PPD_SNAPSHOT_S3_ACCESS_KEY_ID", "test-key")
     monkeypatch.setenv("PPD_SNAPSHOT_S3_SECRET_ACCESS_KEY", "test-secret")
+    source = _build_source()
+    assert isinstance(source, TigrisObjectSource)
+    assert source.base_url == "https://t3.storage.dev/ppd-test/ppd"
+
+
+@requires_sdk
+def test_boot_treats_blank_prefix_as_unset(monkeypatch):
+    monkeypatch.delenv("PPD_SNAPSHOT_URL", raising=False)
+    monkeypatch.delenv("PPD_SNAPSHOT_DIR", raising=False)
+    monkeypatch.setenv("PPD_SNAPSHOT_S3_BUCKET", "ppd-test")
+    monkeypatch.setenv("PPD_SNAPSHOT_S3_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("PPD_SNAPSHOT_S3_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setenv("PPD_SNAPSHOT_S3_PREFIX", "")
     source = _build_source()
     assert isinstance(source, TigrisObjectSource)
     assert source.base_url == "https://t3.storage.dev/ppd-test/ppd"
@@ -139,6 +157,22 @@ def test_signed_header_timeout_is_typed_and_not_retried(method):
 
 
 @requires_sdk
+@pytest.mark.parametrize("method", ["read_bytes", "open_stream"])
+def test_signed_http_error_is_typed_and_preserves_cause(method):
+    import urllib.error
+
+    with object_server(status=403) as (endpoint, calls):
+        source = TigrisObjectSource("ppd-test", access_key="test-key",
+                                    secret_key="test-secret", endpoint=endpoint)
+        with pytest.raises(SnapshotSourceError) as caught:
+            getattr(source, method)("current.json")
+    assert len(calls) == 1
+    assert "403" in str(caught.value)
+    assert isinstance(caught.value.__cause__, urllib.error.HTTPError)
+    assert caught.value.__cause__.code == 403
+
+
+@requires_sdk
 def test_control_body_has_the_existing_size_limit():
     with object_server(body=b"123456789") as (endpoint, calls):
         source = TigrisObjectSource("ppd-test", access_key="test-key",
@@ -164,6 +198,25 @@ def test_ambiguous_source_configuration_is_refused(monkeypatch):
     monkeypatch.setenv("PPD_SNAPSHOT_URL", "https://example.invalid")
     monkeypatch.setenv("PPD_SNAPSHOT_S3_BUCKET", "ppd-test")
     with pytest.raises(RuntimeError, match="exactly one"):
+        _build_source()
+
+
+def test_dir_and_url_together_keeps_legacy_directory_precedence(monkeypatch, tmp_path):
+    from property_core.snapshot.source import LocalDirectorySource
+
+    monkeypatch.delenv("PPD_SNAPSHOT_S3_BUCKET", raising=False)
+    monkeypatch.setenv("PPD_SNAPSHOT_DIR", str(tmp_path))
+    monkeypatch.setenv("PPD_SNAPSHOT_URL", "https://example.invalid")
+    source = _build_source()
+    assert isinstance(source, LocalDirectorySource)
+    assert source.root == tmp_path
+
+
+def test_dir_and_bucket_together_is_refused(monkeypatch, tmp_path):
+    monkeypatch.delenv("PPD_SNAPSHOT_URL", raising=False)
+    monkeypatch.setenv("PPD_SNAPSHOT_DIR", str(tmp_path))
+    monkeypatch.setenv("PPD_SNAPSHOT_S3_BUCKET", "ppd-test")
+    with pytest.raises(RuntimeError, match="cannot be combined"):
         _build_source()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.15.2"
+version = "1.15.3"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Stacked change — after dependency-only images

Adds a read-only Tigris ObjectSource through the existing HTTP verifier seam.
Official botocore SigV4 signing; lazy import; explicit bucket-scoped credentials;
fixed HTTPS endpoint; no credential discovery or retries; no writes; redirects
rejected and response closed; bare object components validated before requests.
The existing read1 streaming, checksum, length, timeout and extraction controls
remain in place. Source selection refuses ambiguous configurations.

Serving remains disabled. No production secret, image, config, volume, worker,
scale, release or version change. This is not the missing production shadow
implementation and does not bypass any rollout gate.

## Approved hosting completed separately

Bucket `ppd-snapshots-20260831`, private, no object ACL overrides. Created directly
through authenticated Tigris CLI, not Fly app-context provisioning. Both apps'
secret names/digests unchanged after creation. Publisher Editor and two distinct
app ReadOnly keys have verified bucket-only grants, stored in the desktop secret
store; no credentials committed or put in environment files, request URLs or
build context. Private recovery files were removed after secret-store readback
confirmed successful persistence.

Exactly three objects, pointer published last. Bundle **279109872 bytes**, SHA256
`50f802b29d9802ee42319122214aeb0adc6761e96c4f6c9ddd0498500bb9072c`.
Remote readback matched every byte/digest; each known object returned anonymous
403; both application credentials authenticated successfully. No raw CSV or
query-result upload. Sanitised ops record includes request IDs and the initial
readback-checker error/recovery (existing bundle verified, never overwritten).

## Verification

- Full suite Python 3.11.13: **1637 passed, 26 skipped** (19 private-delivery cases
  on top of the dependency branch's 1618).
- Positive signed loopback requests; malformed names rejected before fetch;
  no credential forwarding on redirect; response close; chunking/control caps;
  real header timeouts; explicit credentials; missing signer; flag-off isolation.
- Both actual candidate images pass five offline modes: off, healthy,
  missing DuckDB, missing zstandard, missing botocore. Real REST/MCP dispatch,
  identifiable live fixture, fresh self-checked import-blocker processes.
- New source authenticated against real private pointer/manifest; one complete
  local boot from Tigris through Runtime and Adapter validated the 10,394,935-row
  artifact. B5 district query returned 20 B5-only results in 28.665 ms.
- Local cold boot+validation **33.417 s**. This is **NOT** a passing 30 s G1
  measurement: wrong host/network/app context, and above target in this run.
- No Land Registry calls. No claims about current upstream throttling.

## Hold

Review after the dependency-only PR; deploy/observe dependencies with the flag
off before delivery enablement. G1a/G1b, G2 evidence reconciliation and production
shadow/Instance/exit remain required. Nothing in this PR turns serving on.
