### PR TITLE
release: v1.15.2 — dependency-only snapshot images, serving off

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.15.1"
+version = "1.15.2"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates (England & Wales, GOV.UK Bearer API), rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.15.1",
+      "version": "1.15.2",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.15.1"
+version = "1.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Dependency-only, no behaviour change

Bumps `pyproject.toml`, `server.json` (both fields) and `uv.lock` to
1.15.2, landing PR#37's dependency-only image change
(`feat/ppd-snapshot-image-dependencies`, merged in `58957ff`) as a release.

Both production Dockerfiles install the optional `snapshot` extra
(`duckdb`, `zstandard`, `botocore`). `PPD_SNAPSHOT_ENABLED` stays unset on
both apps — the snapshot runtime never boots, and the live source continues
to serve every request exactly as before. No API, response, error, data,
Fly config, worker, volume, or secret change.

This is G3 requirement 1 from `docs/design/ppd-source-routing.md`:
*"The dependency-only image change must land, deploy and be observed with
`PPD_SNAPSHOT_ENABLED` off before any snapshot enablement."* Publishing
this release is that deploy; post-deploy observation follows separately.

## Verification

- Full unit + `tests/snapshot/` suite green on this branch.
- `uv lock` regenerated cleanly against the bumped version; no other
  dependency changed.