### PR TITLE
chore: consolidate dev tooling into one dependency group, drop published dev extra

### DIFF
--- a/.claude/skills/add-data-source/SKILL.md
+++ b/.claude/skills/add-data-source/SKILL.md
@@ -87,4 +87,4 @@ Follow existing patterns (Rich tables, `_join_tokens()` for postcodes).
 - [ ] CLI command added to `property_cli/main.py`
 - [ ] Test created (at least one live test, gated with `RUN_LIVE_TESTS=1`)
 - [ ] Environment variables documented in CLAUDE.md and `.env.example`
-- [ ] All tests pass: `uv run pytest -v`
+- [ ] All validation passes: `./scripts/validate.sh`

--- a/.claude/skills/add-data-source/SKILL.md
+++ b/.claude/skills/add-data-source/SKILL.md
@@ -87,4 +87,4 @@ Follow existing patterns (Rich tables, `_join_tokens()` for postcodes).
 - [ ] CLI command added to `property_cli/main.py`
 - [ ] Test created (at least one live test, gated with `RUN_LIVE_TESTS=1`)
 - [ ] Environment variables documented in CLAUDE.md and `.env.example`
-- [ ] All tests pass: `uv run --extra dev pytest -v`
+- [ ] All tests pass: `uv run pytest -v`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.16.0 (2026-08-31) — removed the published `dev` extra
+
+**Breaking for anyone running `pip install property-shared[dev]`.** This repo
+had two differently-named "dev" dependency mechanisms: a published PyPI extra
+(`pip install property-shared[dev]`) holding repo-internal tooling (pytest,
+pre-commit, etc.) that no consumer of the library needs, and a separate,
+unpublished `[dependency-groups] dev` (installed by default with plain
+`uv run`/`uv sync`) holding one more repo-internal dependency (`tiktoken`).
+Consolidated into the single unpublished group; the published `dev` extra no
+longer exists. No fleet consumer (`uk-property-mcp`,
+`property-descriptions-mcp`) referenced it. If you relied on
+`pip install property-shared[dev]` to get a local test/lint environment,
+clone the repo and run `uv sync` instead — dev tooling now installs
+automatically.
+
+Documented commands updated accordingly: drop `--extra dev` from any
+`uv run`/`uv sync` invocation; the `api`/`apps`/`cli`/`snapshot` extras are
+unchanged and still explicit.
+
 ## v1.15.3 (2026-08-31) — private Tigris snapshot delivery, serving off
 
 **Released with `PPD_SNAPSHOT_ENABLED` off on both apps.** Adds a read-only,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,31 @@
 # Changelog
 
+Versioning here is not strict SemVer: breaking changes are documented in a
+`### Breaking Changes` section within a minor bump (see v1.13.0, v1.12.0,
+v1.11.0, v1.10.0, v1.4.0) rather than forcing a major bump. This entry follows
+that established practice.
+
 ## v1.16.0 (2026-08-31) — removed the published `dev` extra
 
-**Breaking for anyone running `pip install property-shared[dev]`.** This repo
-had two differently-named "dev" dependency mechanisms: a published PyPI extra
-(`pip install property-shared[dev]`) holding repo-internal tooling (pytest,
-pre-commit, etc.) that no consumer of the library needs, and a separate,
-unpublished `[dependency-groups] dev` (installed by default with plain
-`uv run`/`uv sync`) holding one more repo-internal dependency (`tiktoken`).
-Consolidated into the single unpublished group; the published `dev` extra no
-longer exists. No fleet consumer (`uk-property-mcp`,
-`property-descriptions-mcp`) referenced it. If you relied on
-`pip install property-shared[dev]` to get a local test/lint environment,
-clone the repo and run `uv sync` instead — dev tooling now installs
-automatically.
+This repo had two differently-named "dev" dependency mechanisms: a published
+PyPI extra (`pip install property-shared[dev]`) holding repo-internal tooling
+(pytest, pre-commit, etc.) that no consumer of the library needs, and a
+separate, unpublished `[dependency-groups] dev` (installed by default with
+plain `uv run`/`uv sync`) holding one more repo-internal dependency
+(`tiktoken`). Consolidated into the single unpublished group.
 
-Documented commands updated accordingly: drop `--extra dev` from any
-`uv run`/`uv sync` invocation; the `api`/`apps`/`cli`/`snapshot` extras are
+Documented commands updated accordingly: full validation now runs via
+`./scripts/validate.sh`; drop `--extra dev` from any remaining `uv
+run`/`uv sync` invocation; the `api`/`apps`/`cli`/`snapshot` extras are
 unchanged and still explicit.
+
+### Breaking Changes
+- **Packaging** — the published `dev` extra (`pip install
+  property-shared[dev]`) no longer exists. No fleet consumer
+  (`uk-property-mcp`, `property-descriptions-mcp`) referenced it. If you
+  relied on `pip install property-shared[dev]` to get a local test/lint
+  environment, clone the repo and run `uv sync` instead — dev tooling now
+  installs automatically via `[dependency-groups]`.
 
 ## v1.15.3 (2026-08-31) — private Tigris snapshot delivery, serving off
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@ Property Shared is a FastAPI service + pure-Python core library for UK property 
 uv sync
 
 # Run API server
-uv run --env-file .env property-api              # production mode
-uv run --env-file .env uvicorn app.main:app --reload  # dev mode with reload
+uv run --extra api --env-file .env property-api              # production mode
+uv run --extra api --env-file .env uvicorn app.main:app --reload  # dev mode with reload
 
 # Run CLI (core mode - no server needed)
 uv run --extra cli property-cli meta
@@ -38,14 +38,11 @@ uv run --extra cli property-cli analysis rental "NG1 1AA"
 # CLI targeting running API (add --api-url)
 uv run --extra cli property-cli ppd comps "SW1A 1AA" --api-url http://localhost:8000
 
-# Tests — pytest installs by default via [dependency-groups]; the four
-# extras below are still required: `api` provides fastapi (test_http_metrics,
-# test_mcp_server), `apps` provides fastmcp[apps], `cli` provides typer.
-# Add `--extra snapshot` as well, or the ~200 tests under tests/snapshot/ that
-# need DuckDB SKIP rather than fail (they use importorskip), and a green run
-# says nothing about them.
-uv run --extra api --extra apps --extra cli --extra snapshot pytest  # unit tests (mocked)
-RUN_LIVE_TESTS=1 uv run --extra api --extra apps --extra cli --extra snapshot pytest
+# Full validation (lockfile check, pre-commit, all extras, full suite) —
+# run this, don't hand-assemble the extras yourself; it's the same
+# entrypoint CI and the release gate use.
+./scripts/validate.sh                        # unit tests (mocked)
+RUN_LIVE_TESTS=1 ./scripts/validate.sh        # + live network tests
 
 # Single test
 uv run --extra api --extra apps --extra cli pytest tests/test_ppd_service_live.py -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ Property Shared is a FastAPI service + pure-Python core library for UK property 
 ## Commands
 
 ```bash
-# Install dependencies (with dev extras)
-uv sync --extra dev
+# Install dependencies (dev tooling installs by default via [dependency-groups])
+uv sync
 
 # Run API server
 uv run --env-file .env property-api              # production mode
@@ -38,16 +38,17 @@ uv run --extra cli property-cli analysis rental "NG1 1AA"
 # CLI targeting running API (add --api-url)
 uv run --extra cli property-cli ppd comps "SW1A 1AA" --api-url http://localhost:8000
 
-# Tests — all four extras are required: `api` provides fastapi (test_http_metrics,
+# Tests — pytest installs by default via [dependency-groups]; the four
+# extras below are still required: `api` provides fastapi (test_http_metrics,
 # test_mcp_server), `apps` provides fastmcp[apps], `cli` provides typer.
 # Add `--extra snapshot` as well, or the ~200 tests under tests/snapshot/ that
 # need DuckDB SKIP rather than fail (they use importorskip), and a green run
 # says nothing about them.
-uv run --extra dev --extra api --extra apps --extra cli --extra snapshot pytest  # unit tests (mocked)
-RUN_LIVE_TESTS=1 uv run --extra dev --extra api --extra apps --extra cli --extra snapshot pytest
+uv run --extra api --extra apps --extra cli --extra snapshot pytest  # unit tests (mocked)
+RUN_LIVE_TESTS=1 uv run --extra api --extra apps --extra cli --extra snapshot pytest
 
 # Single test
-uv run --extra dev --extra api --extra apps --extra cli pytest tests/test_ppd_service_live.py -v
+uv run --extra api --extra apps --extra cli pytest tests/test_ppd_service_live.py -v
 ```
 
 ## Git safety

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -82,15 +82,16 @@ Three-layer pattern:
 
 **Unit tests** (mocked, default):
 ```bash
-uv run --extra dev --extra api --extra apps --extra cli pytest -v
+uv run --extra api --extra apps --extra cli pytest -v
 ```
 
 **Live integration tests** (real network calls):
 ```bash
-RUN_LIVE_TESTS=1 uv run --extra dev --extra api --extra apps --extra cli pytest -v
+RUN_LIVE_TESTS=1 uv run --extra api --extra apps --extra cli pytest -v
 ```
 
-All four extras are required: `api` provides fastapi (needed by `test_http_metrics.py`
+pytest installs by default via `[dependency-groups]`. All three extras above
+are still required: `api` provides fastapi (needed by `test_http_metrics.py`
 and `test_mcp_server.py`), `apps` provides fastmcp[apps], `cli` provides typer.
 
 Tests skip gracefully on 503/network errors.

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -80,19 +80,17 @@ Three-layer pattern:
 
 ## Testing
 
-**Unit tests** (mocked, default):
+**Full validation** (lockfile check, pre-commit, all extras, full suite) —
+run this rather than hand-assembling extras; it's the same entrypoint CI and
+the release gate use:
 ```bash
-uv run --extra api --extra apps --extra cli pytest -v
+./scripts/validate.sh                    # unit tests (mocked)
+RUN_LIVE_TESTS=1 ./scripts/validate.sh    # + live network tests
 ```
 
-**Live integration tests** (real network calls):
-```bash
-RUN_LIVE_TESTS=1 uv run --extra api --extra apps --extra cli pytest -v
-```
-
-pytest installs by default via `[dependency-groups]`. All three extras above
-are still required: `api` provides fastapi (needed by `test_http_metrics.py`
-and `test_mcp_server.py`), `apps` provides fastmcp[apps], `cli` provides typer.
+`scripts/validate.sh` installs `api` (fastapi, needed by `test_http_metrics.py`
+and `test_mcp_server.py`), `apps` (fastmcp[apps]), `cli` (typer), and
+`snapshot`. pytest itself installs by default via `[dependency-groups]`.
 
 Tests skip gracefully on 503/network errors.
 

--- a/README.md
+++ b/README.md
@@ -199,13 +199,14 @@ Land Registry PPD and Rightmove work without credentials.
 uv sync
 
 # Run API with reload
-uv run uvicorn app.main:app --reload
+uv run --extra api uvicorn app.main:app --reload
 
-# Run tests (mocked, no network)
-uv run pytest -v
+# Full validation (lockfile check, pre-commit, all extras, full suite) —
+# same entrypoint CI and the release gate use
+./scripts/validate.sh
 
-# Run live integration tests (real network calls)
-RUN_LIVE_TESTS=1 uv run pytest -v
+# + live integration tests (real network calls)
+RUN_LIVE_TESTS=1 ./scripts/validate.sh
 ```
 
 Deployed at `https://property-shared.fly.dev` with API docs at `/docs` and MCP endpoint at `/mcp`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pip install property-shared
 uv add property-shared
 ```
 
-Extras: `[cli]` for CLI, `[api]` for HTTP server, `[dev]` for tests.
+Extras: `[cli]` for CLI, `[api]` for HTTP server.
 
 ```bash
 pip install property-shared[cli]
@@ -195,17 +195,17 @@ Land Registry PPD and Rightmove work without credentials.
 ## Development
 
 ```bash
-# Install with dev extras
-uv sync --extra dev
+# Install dependencies (dev tooling installs by default via [dependency-groups])
+uv sync
 
 # Run API with reload
 uv run uvicorn app.main:app --reload
 
 # Run tests (mocked, no network)
-uv run --extra dev pytest -v
+uv run pytest -v
 
 # Run live integration tests (real network calls)
-RUN_LIVE_TESTS=1 uv run --extra dev pytest -v
+RUN_LIVE_TESTS=1 uv run pytest -v
 ```
 
 Deployed at `https://property-shared.fly.dev` with API docs at `/docs` and MCP endpoint at `/mcp`.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -4,7 +4,9 @@
 1) Create a `.env` file in the repo root (gitignored) and set `EPC_API_TOKEN` if you
    want EPC enabled. Omit optional variables entirely rather than assigning them
    empty — `KEY=` is an empty string, not unset, and defeats code defaults.
-2) Install dependencies: `uv sync` (dev tooling installs by default via `[dependency-groups]`).
+2) Install dependencies: `uv sync --extra api --extra cli` (covers the API and
+   every CLI command below; dev tooling installs by default via
+   `[dependency-groups]`).
 3) Run the API: `uv run property-api` (or `uv run uvicorn app.main:app --reload`).
 4) Open the demo UI: http://localhost:8000/demo.
 
@@ -315,9 +317,11 @@ Listing detail results include `raw` with the full `PAGE_MODEL.propertyData` dic
 
 ## Live Tests
 
-Live tests make real network calls and are gated:
+Live tests make real network calls and are gated. Run the full validation
+entrypoint (same one CI and the release gate use, which installs the
+required extras) with the flag set:
 ```bash
-RUN_LIVE_TESTS=1 uv run pytest -q tests
+RUN_LIVE_TESTS=1 ./scripts/validate.sh
 ```
 The suite skips if credentials are missing or upstream services return 503.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -4,7 +4,7 @@
 1) Create a `.env` file in the repo root (gitignored) and set `EPC_API_TOKEN` if you
    want EPC enabled. Omit optional variables entirely rather than assigning them
    empty — `KEY=` is an empty string, not unset, and defeats code defaults.
-2) Install dependencies: `uv sync --extra dev`.
+2) Install dependencies: `uv sync` (dev tooling installs by default via `[dependency-groups]`).
 3) Run the API: `uv run property-api` (or `uv run uvicorn app.main:app --reload`).
 4) Open the demo UI: http://localhost:8000/demo.
 
@@ -317,7 +317,7 @@ Listing detail results include `raw` with the full `PAGE_MODEL.propertyData` dic
 
 Live tests make real network calls and are gated:
 ```bash
-RUN_LIVE_TESTS=1 uv run --extra dev pytest -q tests
+RUN_LIVE_TESTS=1 uv run pytest -q tests
 ```
 The suite skips if credentials are missing or upstream services return 503.
 

--- a/property_app/CLAUDE.md
+++ b/property_app/CLAUDE.md
@@ -13,7 +13,7 @@ MCP_TRANSPORT=http uv run --extra apps property-app               # HTTP
 uv run --extra apps fastmcp dev apps property_app/server.py:mcp   # dev preview in browser
 
 # Tests
-uv run --extra dev pytest tests/test_app_*.py -v
+uv run pytest tests/test_app_*.py -v
 
 # Deploy
 fly deploy --config fly.app.toml

--- a/property_app/CLAUDE.md
+++ b/property_app/CLAUDE.md
@@ -13,7 +13,7 @@ MCP_TRANSPORT=http uv run --extra apps property-app               # HTTP
 uv run --extra apps fastmcp dev apps property_app/server.py:mcp   # dev preview in browser
 
 # Tests
-uv run pytest tests/test_app_*.py -v
+uv run --extra apps pytest tests/test_app_*.py -v
 
 # Deploy
 fly deploy --config fly.app.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.15.3"
+version = "1.16.0"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates (England & Wales, GOV.UK Bearer API), rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"
@@ -60,12 +60,6 @@ planning = [
   "playwright>=1.57.0",
   "openai>=1.83.0,<2",
 ]
-dev = [
-  "pytest>=9.0.2",
-  "python-dotenv>=1.0.1",
-  "openapi-python-client>=0.28.1",
-  "pre-commit==4.6.2",
-]
 api = [
   "fastapi>=0.128.0",
   "uvicorn>=0.40.0",
@@ -105,6 +99,13 @@ addopts = "-ra"
 testpaths = ["tests"]
 
 [dependency-groups]
+# Repo-internal tooling only — never published, installed by default with
+# plain `uv run`/`uv sync`. Consumers of the published package (extras above)
+# never need any of this. tiktoken backs scripts/measure_mcp_quality.py.
 dev = [
+    "pytest>=9.0.2",
+    "python-dotenv>=1.0.1",
+    "openapi-python-client>=0.28.1",
+    "pre-commit==4.6.2",
     "tiktoken>=0.12.0",
 ]

--- a/scripts/diagnose_comps_filters.py
+++ b/scripts/diagnose_comps_filters.py
@@ -5,9 +5,9 @@ proposed defaults (residential standard sales only, outlier-filtered). Run this
 before and after the data-parity fix to see the delta.
 
 Usage:
-    uv run --extra dev python scripts/diagnose_comps_filters.py
-    uv run --extra dev python scripts/diagnose_comps_filters.py NG1 2NS
-    uv run --extra dev python scripts/diagnose_comps_filters.py SW1A 1AA --level district
+    uv run python scripts/diagnose_comps_filters.py
+    uv run python scripts/diagnose_comps_filters.py NG1 2NS
+    uv run python scripts/diagnose_comps_filters.py SW1A 1AA --level district
 """
 from __future__ import annotations
 

--- a/scripts/measure_epc_tokens.py
+++ b/scripts/measure_epc_tokens.py
@@ -7,7 +7,7 @@ Tests four candidate response shapes against a real postcode:
   4. slim_list_capped  — slim_list capped at N certs
 
 Run:
-    uv run --env-file .env --extra dev python scripts/measure_epc_tokens.py
+    uv run --env-file .env python scripts/measure_epc_tokens.py
 """
 
 from __future__ import annotations

--- a/scripts/measure_mcp_quality.py
+++ b/scripts/measure_mcp_quality.py
@@ -10,9 +10,9 @@ Output: prints a structured report and writes JSON to /tmp/mcp_quality_<timestam
 so before/after comparisons are easy.
 
 Usage:
-    uv run --env-file .env --extra dev --extra apps python scripts/measure_mcp_quality.py
-    uv run --env-file .env --extra dev --extra apps python scripts/measure_mcp_quality.py --label before
-    uv run --env-file .env --extra dev --extra apps python scripts/measure_mcp_quality.py --label after
+    uv run --env-file .env --extra apps python scripts/measure_mcp_quality.py
+    uv run --env-file .env --extra apps python scripts/measure_mcp_quality.py --label before
+    uv run --env-file .env --extra apps python scripts/measure_mcp_quality.py --label after
 
 The --label tags the output file (e.g. /tmp/mcp_quality_before.json).
 """

--- a/scripts/rightmove_address_dump.py
+++ b/scripts/rightmove_address_dump.py
@@ -1,10 +1,10 @@
 """Dump the raw address dict from a Rightmove PAGE_MODEL to check for UPRN.
 
 Usage:
-    uv run --extra dev python scripts/rightmove_address_dump.py <property_url_or_id>
+    uv run python scripts/rightmove_address_dump.py <property_url_or_id>
 
 Example:
-    uv run --extra dev python scripts/rightmove_address_dump.py 123456789
+    uv run python scripts/rightmove_address_dump.py 123456789
 """
 
 from __future__ import annotations

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -9,6 +9,6 @@ cd "$SCRIPT_DIR/.." || { echo "cannot resolve repo root from script location" >&
 [ "$(git rev-parse --show-toplevel 2>/dev/null)" = "$PWD" ] || { echo "not at a git repo root" >&2; exit 1; }
 
 uv lock --check
-uv run --locked --extra dev pre-commit run --all-files
-uv sync --locked --extra dev --extra api --extra apps --extra cli --extra snapshot
+uv run --locked pre-commit run --all-files
+uv sync --locked --extra api --extra apps --extra cli --extra snapshot
 uv run --locked pytest

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.15.3",
+  "version": "1.16.0",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.15.3",
+      "version": "1.16.0",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/uv.lock
+++ b/uv.lock
@@ -1301,7 +1301,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.15.3"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1331,12 +1331,6 @@ cli = [
 demo = [
     { name = "python-multipart" },
 ]
-dev = [
-    { name = "openapi-python-client" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "python-dotenv" },
-]
 planning = [
     { name = "openai" },
     { name = "playwright" },
@@ -1349,6 +1343,10 @@ snapshot = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "openapi-python-client" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "python-dotenv" },
     { name = "tiktoken" },
 ]
 
@@ -1363,15 +1361,11 @@ requires-dist = [
     { name = "httpx", specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "openai", marker = "extra == 'planning'", specifier = ">=1.83.0,<2" },
-    { name = "openapi-python-client", marker = "extra == 'dev'", specifier = ">=0.28.1" },
     { name = "playwright", marker = "extra == 'planning'", specifier = ">=1.57.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.6.2" },
     { name = "prefab-ui", marker = "extra == 'apps'", specifier = "==0.19.0" },
     { name = "prometheus-client", marker = "extra == 'api'", specifier = "==0.24.1" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-settings", specifier = "==2.12.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
-    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.1" },
     { name = "python-multipart", marker = "extra == 'demo'", specifier = ">=0.0.9" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.9.0" },
@@ -1380,10 +1374,16 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "zstandard", marker = "extra == 'snapshot'", specifier = "==0.25.0" },
 ]
-provides-extras = ["snapshot", "planning", "dev", "api", "cli", "demo", "apps"]
+provides-extras = ["snapshot", "planning", "api", "cli", "demo", "apps"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "tiktoken", specifier = ">=0.12.0" }]
+dev = [
+    { name = "openapi-python-client", specifier = ">=0.28.1" },
+    { name = "pre-commit", specifier = "==4.6.2" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "tiktoken", specifier = ">=0.12.0" },
+]
 
 [[package]]
 name = "py-key-value-aio"


### PR DESCRIPTION
## Summary
- Consolidate `pytest`, `python-dotenv`, `openapi-python-client`, `pre-commit`, and `tiktoken` into the single unpublished `[dependency-groups].dev` (installs by default with plain `uv run`/`uv sync`). Remove the published `[project.optional-dependencies].dev` extra — confirmed via the built wheel's own METADATA that no extra named `dev` and no dev tooling remains in `Requires-Dist` at all.
- No fleet consumer (`uk-property-mcp`, `property-descriptions-mcp`) referenced `property-shared[dev]`.
- Version bumped to **1.16.0**. Checked for an explicit SemVer claim in the repo (none found) and checked actual practice: five prior entries (v1.13.0, v1.12.0, v1.11.0, v1.10.0, v1.4.0) already document breaking changes via a `### Breaking Changes` CHANGELOG section within a minor bump rather than forcing a major bump — v1.13.0's REST/MCP/CLI parameter removal is the clearest precedent. Kept 1.16.0 to match that established practice; the policy is now documented explicitly at the top of `CHANGELOG.md`.
- All full-validation instructions across `CLAUDE.md`, `GUIDELINES.md`, `README.md`, `USER_GUIDE.md`, and the `add-data-source` skill now point at `./scripts/validate.sh` instead of restating the multi-extra pytest command in four different places.
- Fixed pre-existing missing extras this pass surfaced: `property-api`/`uvicorn` needed `--extra api`; `USER_GUIDE.md`'s Setup step needed `--extra cli` for its ~40 bare CLI examples; `property_app/CLAUDE.md`'s test line needed `--extra apps`.
- `scripts/measure_epc_tokens.py`: dropped its own stale `--extra dev` reference.

Stacked cleanly on #41 (merged) — this PR's diff against `main` is exactly this change, nothing from #41.

## Test plan
- [x] `./scripts/validate.sh` from a clean environment (no preinstalled pre-commit, no prior `.venv`), invoked from an unrelated cwd: 1642 passed, 0 failed, including `test_release_manifest_version.py` 4/4 against v1.16.0.
- [x] Wheel metadata (`uv build --wheel`): no `dev` in `Provides-Extra`, no dev tooling anywhere in `Requires-Dist`.
- [x] `uv run --extra apps pytest tests/test_app_tools.py -v`: 22 passed; the same command without `--extra apps` fails 22/22 with `ModuleNotFoundError`, confirming the doc fix was necessary.
- [x] `uv run --extra api python -c "import app.main"`: succeeds; without `--extra api` it raises `ModuleNotFoundError: No module named 'fastapi'`, confirming that doc fix too.
- [x] `uv sync --extra api --extra cli` (USER_GUIDE.md's corrected setup step) then `uv run property-cli meta`: returns correctly.

No merge yet — opening for review.