### PR TITLE
feat(ppd): boot-only verification tool for partial G1a evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Versioning here is not strict SemVer: breaking changes are documented in a
 v1.11.0, v1.10.0, v1.4.0) rather than forcing a major bump. This entry follows
 that established practice.
 
-## v1.16.0 (2026-08-31) — removed the published `dev` extra
+## v1.16.0 (2026-09-01) — removed the published `dev` extra; property-shared-only boot-only G1a verifier, serving off
 
 This repo had two differently-named "dev" dependency mechanisms: a published
 PyPI extra (`pip install property-shared[dev]`) holding repo-internal tooling
@@ -26,6 +26,23 @@ unchanged and still explicit.
   relied on `pip install property-shared[dev]` to get a local test/lint
   environment, clone the repo and run `uv sync` instead — dev tooling now
   installs automatically via `[dependency-groups]`.
+
+### Added
+
+- **`tools/ppd_snapshot/boot_only_verify.py`**, a standalone boot-only
+  verification tool copied into the `property-shared` image only — not
+  `propertydata`, not this release's public API. Invoked out of band via
+  `fly ssh console`, never wired into the app's lifespan or process state,
+  it materializes and validates one real snapshot through the existing
+  `SnapshotRuntime`/`SnapshotAdapter` path, then discards it, to measure
+  fetch/extraction/adapter-validation timing, peak transient disk, and
+  cold-run confirmation against the declared bundle size.
+  **`PPD_SNAPSHOT_ENABLED` remains off on both apps in this release, and
+  no snapshot credentials are installed.** Every result the tool produces
+  is explicitly labelled `evidence_scope: "partial_g1a"`,
+  `g1a_complete: false`, `stage_1_evidence: false`: it measures
+  materialization and validation, not the application startup lifecycle
+  G1a requires, and produces no Stage 1 real-traffic evidence.
 
 ## v1.15.3 (2026-08-31) — private Tigris snapshot delivery, serving off
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ RUN uv sync --frozen --no-dev --extra api --extra snapshot
 COPY app ./app
 COPY property_core ./property_core
 
+# G1a boot-only verification (docs/design/ppd-private-delivery.md step 4):
+# materializes and validates a real snapshot, off the app's own lifespan and
+# process state, invoked out of band via `fly ssh console`. Not wired into
+# CMD; the app never imports it. One file only -- not tools/ or property_cli/.
+COPY tools/ppd_snapshot/boot_only_verify.py ./boot_only_verify.py
+
 EXPOSE 8080
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/tests/snapshot/test_boot_only_verify.py
+++ b/tests/snapshot/test_boot_only_verify.py
@@ -1,0 +1,239 @@
+"""Boot-only verifier tests; loopback only, never Tigris or PPD.
+
+Reuses `tests/snapshot/image_smoke.py`'s synthetic snapshot fixture rather
+than building a second one.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from unittest.mock import Mock
+import importlib.util
+
+import pytest
+
+from property_core.snapshot.models import BootReport, Readiness
+from tests.snapshot.image_smoke import fixture as build_snapshot_fixture
+from tools.ppd_snapshot.boot_only_verify import (
+    VerificationRefused,
+    _is_cold_run_valid,
+    _prepare_verification_directory,
+    assert_disk_backed,
+    run_boot_only_verification,
+)
+
+requires_sdk = pytest.mark.skipif(
+    importlib.util.find_spec("botocore") is None
+    or importlib.util.find_spec("duckdb") is None
+    or importlib.util.find_spec("zstandard") is None,
+    reason="boot-only verification needs the snapshot extra",
+)
+
+
+@contextmanager
+def fixture_object_server(directory: Path):
+    """Serves files from `directory` by basename -- a minimal S3-shaped GET."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            name = self.path.rsplit("/", 1)[-1].split("?")[0]
+            file_path = directory / name
+            if not file_path.is_file():
+                self.send_response(404)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            body = file_path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    worker = Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        worker.join(timeout=2)
+
+
+def _ext4_mounts_for(path: Path) -> str:
+    return f"none {path} ext4 rw 0 0\n"
+
+
+def _tmpfs_mounts_for(path: Path) -> str:
+    return f"none {path} tmpfs rw 0 0\n"
+
+
+def _tigris_source(endpoint: str, **overrides):
+    from property_core.snapshot.s3_source import TigrisObjectSource
+
+    kwargs = dict(access_key="test-key", secret_key="test-secret",
+                 endpoint=endpoint, prefix="")
+    kwargs.update(overrides)
+    return TigrisObjectSource("ppd-test", **kwargs)
+
+
+# -- disk-backed assertion ---------------------------------------------------
+
+def test_disk_backed_assertion_refuses_tmpfs(tmp_path):
+    with pytest.raises(VerificationRefused, match="tmpfs"):
+        assert_disk_backed(tmp_path, _tmpfs_mounts_for(tmp_path))
+
+
+def test_disk_backed_assertion_accepts_ext4(tmp_path):
+    assert assert_disk_backed(tmp_path, _ext4_mounts_for(tmp_path)) == "ext4"
+
+
+def test_disk_backed_assertion_refuses_when_nothing_matches(tmp_path):
+    with pytest.raises(VerificationRefused, match="no mount entry"):
+        assert_disk_backed(tmp_path, "none /completely/unrelated ext4 rw 0 0\n")
+
+
+# -- verification-directory preparation --------------------------------------
+
+def test_verification_directory_must_not_collide_with_app_cache(tmp_path):
+    cache_dir = tmp_path / "app-cache"
+    cache_dir.mkdir()
+    with pytest.raises(VerificationRefused, match="PPD_SNAPSHOT_CACHE_DIR"):
+        _prepare_verification_directory(cache_dir / "nested" / "verify", cache_dir)
+
+
+def test_verification_directory_must_not_already_exist(tmp_path):
+    existing = tmp_path / "already-here"
+    existing.mkdir()
+    with pytest.raises(VerificationRefused, match="already exists"):
+        _prepare_verification_directory(existing, tmp_path / "cache")
+
+
+# -- cold-run validity --------------------------------------------------------
+
+def _report(*, reused_existing=False, bytes_downloaded=0) -> BootReport:
+    return BootReport(readiness=Readiness.READY, version="v1",
+                      fallback_to_live=False, reused_existing=reused_existing,
+                      bytes_downloaded=bytes_downloaded)
+
+
+def test_cold_run_invalid_when_reused():
+    report = _report(reused_existing=True, bytes_downloaded=1000)
+    assert _is_cold_run_valid(report, expected_bundle_bytes=1000) is False
+
+
+def test_cold_run_invalid_when_bytes_mismatch():
+    report = _report(reused_existing=False, bytes_downloaded=999)
+    assert _is_cold_run_valid(report, expected_bundle_bytes=1000) is False
+
+
+def test_cold_run_valid_when_matching():
+    report = _report(reused_existing=False, bytes_downloaded=1000)
+    assert _is_cold_run_valid(report, expected_bundle_bytes=1000) is True
+
+
+def test_cold_run_valid_without_an_expected_size_if_something_downloaded():
+    report = _report(reused_existing=False, bytes_downloaded=1)
+    assert _is_cold_run_valid(report, expected_bundle_bytes=None) is True
+
+
+# -- end-to-end against a loopback fixture -----------------------------------
+
+@requires_sdk
+def test_successful_run_validates_and_reports_a_cold_run(tmp_path):
+    fixture_dir = tmp_path / "fixture"
+    fixture_dir.mkdir()
+    build_snapshot_fixture(fixture_dir)
+
+    verify_dir = tmp_path / "verify-root" / "run"
+    verify_dir.parent.mkdir()
+    cache_dir = tmp_path / "app-cache"
+
+    with fixture_object_server(fixture_dir) as endpoint:
+        source = _tigris_source(endpoint)
+        result = run_boot_only_verification(
+            source, verify_dir=verify_dir, cache_dir=cache_dir,
+            expected_bundle_bytes=None, sample_interval=0.01,
+            mounts_text=_ext4_mounts_for(verify_dir.parent),
+        )
+
+    assert result["label"] == "boot-only verification measurement"
+    assert result["readiness"] == "ready"
+    assert result["validated"] is True
+    assert result["reused_existing"] is False
+    assert result["bytes_downloaded"] > 0
+    assert result["cold_run_valid"] is True
+    assert result["coverage_from"] == "2016-01-01"
+    assert result["coverage_to"] == "2026-06-30"
+    assert result["materialization_ms"] >= 0
+    assert result["validation_ms"] >= 0
+    assert result["peak_transient_disk_bytes"] > 0
+    assert result["process_peak_rss_bytes"] > 0
+
+
+@requires_sdk
+def test_run_cleans_up_the_verification_directory_on_success(tmp_path):
+    fixture_dir = tmp_path / "fixture"
+    fixture_dir.mkdir()
+    build_snapshot_fixture(fixture_dir)
+
+    verify_dir = tmp_path / "verify-root" / "run"
+    verify_dir.parent.mkdir()
+
+    with fixture_object_server(fixture_dir) as endpoint:
+        source = _tigris_source(endpoint)
+        run_boot_only_verification(
+            source, verify_dir=verify_dir, cache_dir=tmp_path / "app-cache",
+            sample_interval=0.01, mounts_text=_ext4_mounts_for(verify_dir.parent),
+        )
+
+    assert not verify_dir.exists()
+
+
+def test_run_cleans_up_the_verification_directory_on_failure(tmp_path):
+    """An unreachable source degrades to UNREADY; cleanup still runs."""
+    verify_dir = tmp_path / "verify-root" / "run"
+    verify_dir.parent.mkdir()
+
+    with fixture_object_server(tmp_path / "empty-does-not-exist") as endpoint:
+        source = _tigris_source(endpoint)
+        result = run_boot_only_verification(
+            source, verify_dir=verify_dir, cache_dir=tmp_path / "app-cache",
+            sample_interval=0.01, mounts_text=_ext4_mounts_for(verify_dir.parent),
+        )
+
+    assert result["validated"] is False
+    assert not verify_dir.exists()
+
+
+@requires_sdk
+def test_run_never_installs_into_process_state(tmp_path, monkeypatch):
+    """Confirms non-interference with `state` behaviourally, not just by
+    absence of an import: a successful run must never call `state.install`."""
+    import property_core.snapshot.state as state
+
+    install_spy = Mock(wraps=state.install)
+    monkeypatch.setattr(state, "install", install_spy)
+
+    fixture_dir = tmp_path / "fixture"
+    fixture_dir.mkdir()
+    build_snapshot_fixture(fixture_dir)
+
+    verify_dir = tmp_path / "verify-root" / "run"
+    verify_dir.parent.mkdir()
+
+    with fixture_object_server(fixture_dir) as endpoint:
+        source = _tigris_source(endpoint)
+        result = run_boot_only_verification(
+            source, verify_dir=verify_dir, cache_dir=tmp_path / "app-cache",
+            sample_interval=0.01, mounts_text=_ext4_mounts_for(verify_dir.parent),
+        )
+
+    assert result["validated"] is True
+    install_spy.assert_not_called()

--- a/tests/snapshot/test_boot_only_verify.py
+++ b/tests/snapshot/test_boot_only_verify.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from threading import Thread
 from unittest.mock import Mock
 import importlib.util
+import time
 
 import pytest
 
@@ -34,12 +35,19 @@ requires_sdk = pytest.mark.skipif(
 
 
 @contextmanager
-def fixture_object_server(directory: Path):
-    """Serves files from `directory` by basename -- a minimal S3-shaped GET."""
+def fixture_object_server(directory: Path, delays: dict | None = None):
+    """Serves files from `directory` by basename -- a minimal S3-shaped GET.
+
+    `delays` (object name -> seconds) sleeps before responding to that one
+    object, so tests can make a specific phase (e.g. the bundle transfer)
+    deliberately slow without touching the runtime being verified.
+    """
+    delays = delays or {}
 
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self):
             name = self.path.rsplit("/", 1)[-1].split("?")[0]
+            time.sleep(delays.get(name, 0))
             file_path = directory / name
             if not file_path.is_file():
                 self.send_response(404)
@@ -83,6 +91,13 @@ def _tigris_source(endpoint: str, **overrides):
     return TigrisObjectSource("ppd-test", **kwargs)
 
 
+def _build_fixture(tmp_path: Path) -> Path:
+    fixture_dir = tmp_path / "fixture"
+    fixture_dir.mkdir()
+    build_snapshot_fixture(fixture_dir)
+    return fixture_dir
+
+
 # -- disk-backed assertion ---------------------------------------------------
 
 def test_disk_backed_assertion_refuses_tmpfs(tmp_path):
@@ -101,11 +116,21 @@ def test_disk_backed_assertion_refuses_when_nothing_matches(tmp_path):
 
 # -- verification-directory preparation --------------------------------------
 
-def test_verification_directory_must_not_collide_with_app_cache(tmp_path):
+def test_verification_directory_must_not_nest_inside_the_app_cache(tmp_path):
     cache_dir = tmp_path / "app-cache"
     cache_dir.mkdir()
-    with pytest.raises(VerificationRefused, match="PPD_SNAPSHOT_CACHE_DIR"):
+    with pytest.raises(VerificationRefused, match="sibling directories"):
         _prepare_verification_directory(cache_dir / "nested" / "verify", cache_dir)
+
+
+def test_app_cache_must_not_nest_inside_the_verification_directory(tmp_path):
+    """The reverse direction: an app cache configured beneath the
+    verification directory must also be refused -- otherwise this module's
+    unconditional `rmtree(verify_dir)` would delete the application's store."""
+    verify_dir = tmp_path / "verify"
+    cache_dir = verify_dir / "nested-cache"
+    with pytest.raises(VerificationRefused, match="sibling directories"):
+        _prepare_verification_directory(verify_dir, cache_dir)
 
 
 def test_verification_directory_must_not_already_exist(tmp_path):
@@ -143,13 +168,35 @@ def test_cold_run_valid_without_an_expected_size_if_something_downloaded():
     assert _is_cold_run_valid(report, expected_bundle_bytes=None) is True
 
 
+def test_cli_exposes_no_expected_bundle_bytes_escape_hatch():
+    """The deployed CLI must always require the declared bundle size --
+    confirmed by the parser itself accepting no such flag, not just by
+    convention."""
+    from tools.ppd_snapshot.boot_only_verify import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--verify-dir", "/tmp/x", "--expected-bundle-bytes", "0"])
+
+
+# -- every result carries explicit evidence-scope labelling -------------------
+
+def test_refusal_result_carries_evidence_scope_labels(tmp_path):
+    """Even a refusal before anything is materialized must say what this
+    tool can never provide -- not just a generic label."""
+    from tools.ppd_snapshot.boot_only_verify import _base_result
+
+    result = _base_result()
+    assert result["evidence_scope"] == "partial_g1a"
+    assert result["g1a_complete"] is False
+    assert result["stage_1_evidence"] is False
+
+
 # -- end-to-end against a loopback fixture -----------------------------------
 
 @requires_sdk
 def test_successful_run_validates_and_reports_a_cold_run(tmp_path):
-    fixture_dir = tmp_path / "fixture"
-    fixture_dir.mkdir()
-    build_snapshot_fixture(fixture_dir)
+    fixture_dir = _build_fixture(tmp_path)
 
     verify_dir = tmp_path / "verify-root" / "run"
     verify_dir.parent.mkdir()
@@ -163,7 +210,9 @@ def test_successful_run_validates_and_reports_a_cold_run(tmp_path):
             mounts_text=_ext4_mounts_for(verify_dir.parent),
         )
 
-    assert result["label"] == "boot-only verification measurement"
+    assert result["evidence_scope"] == "partial_g1a"
+    assert result["g1a_complete"] is False
+    assert result["stage_1_evidence"] is False
     assert result["readiness"] == "ready"
     assert result["validated"] is True
     assert result["reused_existing"] is False
@@ -173,15 +222,18 @@ def test_successful_run_validates_and_reports_a_cold_run(tmp_path):
     assert result["coverage_to"] == "2026-06-30"
     assert result["materialization_ms"] >= 0
     assert result["validation_ms"] >= 0
+    assert result["fetch_ms"] is not None and result["fetch_ms"] >= 0
+    assert result["extraction_ms"] is not None and result["extraction_ms"] >= 0
+    assert result["overlap_window_ms"] == result["extraction_ms"]
     assert result["peak_transient_disk_bytes"] > 0
     assert result["process_peak_rss_bytes"] > 0
+    assert result["cleanup_ok"] is True
+    assert result["cleanup_error"] is None
 
 
 @requires_sdk
 def test_run_cleans_up_the_verification_directory_on_success(tmp_path):
-    fixture_dir = tmp_path / "fixture"
-    fixture_dir.mkdir()
-    build_snapshot_fixture(fixture_dir)
+    fixture_dir = _build_fixture(tmp_path)
 
     verify_dir = tmp_path / "verify-root" / "run"
     verify_dir.parent.mkdir()
@@ -197,7 +249,8 @@ def test_run_cleans_up_the_verification_directory_on_success(tmp_path):
 
 
 def test_run_cleans_up_the_verification_directory_on_failure(tmp_path):
-    """An unreachable source degrades to UNREADY; cleanup still runs."""
+    """An unreachable source degrades to UNREADY; cleanup still runs, and
+    every field the base result carries is still present."""
     verify_dir = tmp_path / "verify-root" / "run"
     verify_dir.parent.mkdir()
 
@@ -209,7 +262,41 @@ def test_run_cleans_up_the_verification_directory_on_failure(tmp_path):
         )
 
     assert result["validated"] is False
+    assert result["evidence_scope"] == "partial_g1a"
+    assert result["cleanup_ok"] is True
     assert not verify_dir.exists()
+    # Nothing was ever fetched or extracted -- both phases correctly absent,
+    # not a stale zero.
+    assert result["fetch_ms"] is None
+    assert result["extraction_ms"] is None
+
+
+def test_cleanup_failure_is_recorded_explicitly_not_swallowed(tmp_path, monkeypatch):
+    """A removal failure must surface in the result, never be hidden behind
+    `ignore_errors=True` while the run is still reported as validated."""
+    import tools.ppd_snapshot.boot_only_verify as module
+
+    verify_dir = tmp_path / "verify-root" / "run"
+    verify_dir.parent.mkdir()
+
+    def failing_rmtree(_path, **_kwargs):
+        raise OSError("simulated: device busy")
+
+    monkeypatch.setattr(module.shutil, "rmtree", failing_rmtree)
+
+    with fixture_object_server(tmp_path / "empty-does-not-exist") as endpoint:
+        source = _tigris_source(endpoint)
+        result = run_boot_only_verification(
+            source, verify_dir=verify_dir, cache_dir=tmp_path / "app-cache",
+            sample_interval=0.01, mounts_text=_ext4_mounts_for(verify_dir.parent),
+        )
+
+    assert result["cleanup_ok"] is False
+    assert "simulated: device busy" in result["cleanup_error"]
+    # The directory the failed rmtree was supposed to remove is exactly the
+    # one this run created -- prove the tool is not silently pointed
+    # elsewhere by asserting it still exists (the mock never removed it).
+    assert verify_dir.exists()
 
 
 @requires_sdk
@@ -221,9 +308,7 @@ def test_run_never_installs_into_process_state(tmp_path, monkeypatch):
     install_spy = Mock(wraps=state.install)
     monkeypatch.setattr(state, "install", install_spy)
 
-    fixture_dir = tmp_path / "fixture"
-    fixture_dir.mkdir()
-    build_snapshot_fixture(fixture_dir)
+    fixture_dir = _build_fixture(tmp_path)
 
     verify_dir = tmp_path / "verify-root" / "run"
     verify_dir.parent.mkdir()
@@ -237,3 +322,97 @@ def test_run_never_installs_into_process_state(tmp_path, monkeypatch):
 
     assert result["validated"] is True
     install_spy.assert_not_called()
+
+
+@requires_sdk
+def test_process_rss_is_sampled_after_adapter_validation_not_before(tmp_path, monkeypatch):
+    """DuckDB validation memory must be included in process_peak_rss_bytes --
+    proven by ordering (getrusage called after _validate), since a magnitude
+    assertion against a KB-scale fixture would be unreliable."""
+    import property_core.snapshot.adapter as adapter_module
+    import tools.ppd_snapshot.boot_only_verify as module
+
+    call_order = []
+
+    original_validate = adapter_module.SnapshotAdapter._validate
+
+    def recording_validate(self):
+        call_order.append("validate")
+        return original_validate(self)
+
+    original_getrusage = module.resource.getrusage
+
+    def recording_getrusage(*args, **kwargs):
+        call_order.append("getrusage")
+        return original_getrusage(*args, **kwargs)
+
+    monkeypatch.setattr(adapter_module.SnapshotAdapter, "_validate", recording_validate)
+    monkeypatch.setattr(module.resource, "getrusage", recording_getrusage)
+
+    fixture_dir = _build_fixture(tmp_path)
+    verify_dir = tmp_path / "verify-root" / "run"
+    verify_dir.parent.mkdir()
+
+    with fixture_object_server(fixture_dir) as endpoint:
+        source = _tigris_source(endpoint)
+        result = run_boot_only_verification(
+            source, verify_dir=verify_dir, cache_dir=tmp_path / "app-cache",
+            sample_interval=0.01, mounts_text=_ext4_mounts_for(verify_dir.parent),
+        )
+
+    assert result["validated"] is True
+    assert "validate" in call_order and "getrusage" in call_order
+    assert call_order.index("validate") < call_order.index("getrusage"), (
+        "process_peak_rss_bytes must be read after adapter validation, "
+        f"not before: {call_order}"
+    )
+
+
+@requires_sdk
+def test_phase_timings_bind_to_the_correct_phase(tmp_path, monkeypatch):
+    """Deliberately slows fetch, extraction and adapter-validation by
+    different, distinguishable amounts, and proves each reported timing
+    binds to its own phase rather than to the run as a whole."""
+    import property_core.snapshot.adapter as adapter_module
+
+    fixture_dir = _build_fixture(tmp_path)
+    bundle_name = "fixture.tar.zst"
+
+    original_validate = adapter_module.SnapshotAdapter._validate
+
+    def slow_validate(self):
+        time.sleep(0.10)
+        return original_validate(self)
+
+    monkeypatch.setattr(adapter_module.SnapshotAdapter, "_validate", slow_validate)
+
+    verify_dir = tmp_path / "verify-root" / "run"
+    verify_dir.parent.mkdir()
+
+    with fixture_object_server(fixture_dir, delays={bundle_name: 0.30}) as endpoint:
+        source = _tigris_source(endpoint)
+        result = run_boot_only_verification(
+            source, verify_dir=verify_dir, cache_dir=tmp_path / "app-cache",
+            expected_bundle_bytes=None, sample_interval=0.01,
+            mounts_text=_ext4_mounts_for(verify_dir.parent),
+        )
+
+    assert result["validated"] is True
+
+    # Fetch was slowed by 0.30s -- must dominate.
+    assert result["fetch_ms"] >= 250
+    # Extraction was not slowed (only the download response was delayed);
+    # it must be well below the injected fetch delay, not smeared across it.
+    assert result["extraction_ms"] is not None
+    assert result["extraction_ms"] < 150
+    # Validation was slowed by 0.10s, independently of fetch/extraction.
+    assert result["validation_ms"] >= 80
+    assert result["validation_ms"] < result["fetch_ms"]
+
+    # materialization_ms wraps only runtime.boot() (fetch + extract), and
+    # must NOT include the adapter-validation delay that happens afterward.
+    assert result["materialization_ms"] >= result["fetch_ms"]
+    assert result["materialization_ms"] < result["fetch_ms"] + 150
+
+    # overlap_window_ms is defined as exactly extraction_ms.
+    assert result["overlap_window_ms"] == result["extraction_ms"]

--- a/tools/ppd_snapshot/boot_only_verify.py
+++ b/tools/ppd_snapshot/boot_only_verify.py
@@ -4,16 +4,17 @@ routing any live request to it.
     fly ssh console -a property-shared
     python /app/boot_only_verify.py --verify-dir /tmp/ppd-verify-$(date +%s)
 
-Provides **partial** G1a evidence -- materialization and adapter-open/
+Provides **partial** G1a evidence -- fetch, extraction and adapter-open/
 validation timing, peak transient disk, and cold-run confirmation -- for a
-real Machine against real object storage. It is not a completed G1a
-measurement: the governing specification
+real Machine against real object storage. Every result this module produces
+carries `evidence_scope: "partial_g1a"`, `g1a_complete: false` and
+`stage_1_evidence: false` explicitly, because it is not a completed G1a
+measurement and can never become one: the governing specification
 (``docs/design/ppd-source-routing.md``) requires *application*
 time-to-readiness -- full ASGI startup, async lifespan, single-flight lock
 behaviour under the real deployed worker count -- which a standalone process
-cannot produce no matter how its output is labelled. Label results
-accordingly; do not present ``materialization_ms`` as application
-time-to-ready.
+cannot produce no matter how its output is labelled. It is also not Stage 1
+evidence: no real-traffic sample, no divergence classification.
 
 **Isolation from the live server, by construction.** This module never
 imports ``property_core.snapshot.state`` and is meant to run as an entirely
@@ -24,12 +25,16 @@ existing materialization path unchanged: ``SnapshotRuntime.boot()`` for
 fetch/verify/extract (with its own already-enforced
 ``preflight_disk_space`` free-space precondition), then
 ``SnapshotAdapter.open`` for the same structural + queryable validation the
-live path performs.
+live path performs. Fetch and extraction boundaries are timed by wrapping
+the exact functions ``SnapshotRuntime`` calls (``download_verified``,
+``safe_extract``) for the duration of one run -- not by changing what they
+do, and not by touching ``runtime.py`` itself.
 
 **Verification-only.** The materialized snapshot is always removed at the
 end of a run, successful or not -- this is a measurement, not a cache, and
-never shares a directory with the application's own
-``PPD_SNAPSHOT_CACHE_DIR``.
+never shares a directory with, or nests either way with, the application's
+own ``PPD_SNAPSHOT_CACHE_DIR``. A cleanup failure is reported explicitly
+(``cleanup_ok: false``), never silently swallowed.
 """
 
 from __future__ import annotations
@@ -41,12 +46,14 @@ import resource
 import shutil
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import Any, Iterator, Optional, Sequence
 
 #: The initial artifact's declared bundle size (design doc, "Scope and
 #: account"). A cold run must download exactly this many bytes; anything
-#: else means the bundle changed or the run was not genuinely cold.
+#: else means the bundle changed or the run was not genuinely cold. Not
+#: overridable from the CLI -- see `_is_cold_run_valid` and `main`.
 EXPECTED_BUNDLE_BYTES = 279_109_872
 
 
@@ -100,13 +107,25 @@ def assert_disk_backed(path: Path, mounts_text: Optional[str] = None) -> str:
 
 
 def _prepare_verification_directory(path: Path, cache_dir: Path) -> None:
-    """Create a unique, empty verification directory. Never the app's store."""
+    """Create a unique, empty verification directory.
+
+    Refuses nesting with the application's own store in **either**
+    direction: the verifier inside the app's cache would let a future
+    change reuse the app's materialization; the app's cache inside the
+    verifier would put it inside a directory this module unconditionally
+    `rmtree`s at the end of the run. Sibling directories only.
+    """
     resolved = path.resolve()
     cache_resolved = cache_dir.resolve()
-    if resolved == cache_resolved or cache_resolved in resolved.parents:
+    nested = (
+        resolved == cache_resolved
+        or cache_resolved in resolved.parents
+        or resolved in cache_resolved.parents
+    )
+    if nested:
         raise VerificationRefused(
-            f"{path} collides with the application's own "
-            f"PPD_SNAPSHOT_CACHE_DIR ({cache_dir}); use a separate directory"
+            f"{path} and the application's PPD_SNAPSHOT_CACHE_DIR "
+            f"({cache_dir}) must be sibling directories, not nested either way"
         )
     if resolved.exists():
         raise VerificationRefused(
@@ -143,9 +162,11 @@ class _DiskAndMemorySampler:
     """Polls verification-directory size and Machine-wide available memory.
 
     A background thread, not a hook into the runtime: the fetch/extract code
-    this wraps does blocking I/O with no yield points to sample from instead,
-    and the live server process keeps running concurrently on the same
-    Machine, so its memory pressure is part of the real headroom picture.
+    this wraps does blocking I/O with no yield points to sample from
+    instead. Must stay active through adapter-open validation, not just
+    materialization -- DuckDB's own memory use during validation is part of
+    the real headroom picture, and the live server process keeps running
+    concurrently on the same Machine throughout.
     """
 
     def __init__(self, directory: Path, interval: float = 0.2):
@@ -198,18 +219,88 @@ class _DiskAndMemorySampler:
         return self._min_available_memory_bytes
 
 
+class _PhaseTimes:
+    """Fetch and extraction wall-clock time, bound to the real boundaries."""
+
+    def __init__(self) -> None:
+        self.fetch_ms: Optional[float] = None
+        self.extraction_ms: Optional[float] = None
+
+
+@contextmanager
+def _instrumented_install_phases() -> Iterator[_PhaseTimes]:
+    """Times the exact fetch and extraction calls `SnapshotRuntime` makes.
+
+    Patches the names `property_core.snapshot.runtime` imported them under,
+    for the lifetime of this context only, then restores them -- this times
+    the real functions on their real call, it does not change what they do.
+    Neither is called at all on a reused-materialization boot, which
+    correctly leaves both fields `None` rather than reporting a phase that
+    did not run.
+
+    The bundle/extraction disk-overlap window the design doc asks about
+    (G1a) is, by `SnapshotRuntime._install`'s own structure, the extraction
+    call's duration: the bundle is fully on disk before extraction starts,
+    and is unlinked immediately after extraction returns. `overlap_window_ms`
+    is reported as exactly `extraction_ms` for that reason, not measured
+    independently.
+    """
+    import property_core.snapshot.runtime as runtime_module
+
+    times = _PhaseTimes()
+    original_download = runtime_module.download_verified
+    original_extract = runtime_module.safe_extract
+
+    def timed_download(*args: Any, **kwargs: Any) -> Any:
+        started = time.perf_counter()
+        try:
+            return original_download(*args, **kwargs)
+        finally:
+            times.fetch_ms = round((time.perf_counter() - started) * 1000, 1)
+
+    def timed_extract(*args: Any, **kwargs: Any) -> Any:
+        started = time.perf_counter()
+        try:
+            return original_extract(*args, **kwargs)
+        finally:
+            times.extraction_ms = round((time.perf_counter() - started) * 1000, 1)
+
+    runtime_module.download_verified = timed_download
+    runtime_module.safe_extract = timed_extract
+    try:
+        yield times
+    finally:
+        runtime_module.download_verified = original_download
+        runtime_module.safe_extract = original_extract
+
+
 def _is_cold_run_valid(report: Any, expected_bundle_bytes: Optional[int]) -> bool:
     """Whether this run is trustworthy as G1a cold-materialization evidence.
 
-    A reused materialization, or a transfer short of the full bundle, is not
-    a measurement of the thing G1a asks about -- record it as invalid rather
-    than silently accepting it.
+    A reused materialization, or a transfer short of (or over) the full
+    bundle, is not a measurement of the thing G1a asks about -- record it as
+    invalid rather than silently accepting it.
     """
     if report.reused_existing:
         return False
     if expected_bundle_bytes is not None:
         return report.bytes_downloaded == expected_bundle_bytes
     return report.bytes_downloaded > 0
+
+
+def _base_result() -> dict:
+    """Every result this module ever returns carries this, unconditionally.
+
+    Not computed from the run's outcome: this tool structurally cannot
+    produce a completed G1a measurement (no application startup lifecycle)
+    or Stage 1 evidence (no real traffic, no divergence classification),
+    whether this particular run succeeds, fails, or is refused outright.
+    """
+    return {
+        "evidence_scope": "partial_g1a",
+        "g1a_complete": False,
+        "stage_1_evidence": False,
+    }
 
 
 def run_boot_only_verification(
@@ -239,15 +330,39 @@ def run_boot_only_verification(
     assert_disk_backed(verify_dir.parent, mounts_text)
     _prepare_verification_directory(verify_dir, cache_dir)
 
-    result: dict[str, Any] = {"label": "boot-only verification measurement"}
+    result = _base_result()
     try:
         store = SnapshotStore(verify_dir)
         runtime = SnapshotRuntime(source=source, store=store)
 
-        with _DiskAndMemorySampler(verify_dir, interval=sample_interval) as sampler:
+        # Disk/memory sampling and fetch/extract phase timing both stay
+        # active through adapter-open validation, not just materialization --
+        # DuckDB's own memory use during validation is otherwise invisible,
+        # and process_peak_rss_bytes is read only after this block exits.
+        with _DiskAndMemorySampler(verify_dir, interval=sample_interval) as sampler, \
+             _instrumented_install_phases() as phase_times:
             started = time.perf_counter()
             report = runtime.boot()
-            materialization_ms = (time.perf_counter() - started) * 1000
+            materialization_ms = round((time.perf_counter() - started) * 1000, 1)
+
+            if report.ready and report.snapshot_dir and report.version:
+                record = store.verified_record(report.version)
+                if record is None:
+                    result["validated"] = False
+                    result["validation_error"] = (
+                        "no verification record for the materialized version"
+                    )
+                else:
+                    validation_started = time.perf_counter()
+                    with SnapshotAdapter.open(
+                            Path(report.snapshot_dir), record) as adapter:
+                        result["validated"] = True
+                        result["validation_ms"] = round(
+                            (time.perf_counter() - validation_started) * 1000, 1)
+                        result["coverage_from"] = adapter.coverage_from
+                        result["coverage_to"] = adapter.coverage_to
+            else:
+                result["validated"] = False
 
         result.update({
             "readiness": report.readiness.value,
@@ -258,7 +373,10 @@ def run_boot_only_verification(
             "source_error": report.source_error,
             "warnings": list(report.warnings),
             "runtime_timings_ms": dict(report.timings_ms),
-            "materialization_ms": round(materialization_ms, 1),
+            "fetch_ms": phase_times.fetch_ms,
+            "extraction_ms": phase_times.extraction_ms,
+            "overlap_window_ms": phase_times.extraction_ms,
+            "materialization_ms": materialization_ms,
             "peak_transient_disk_bytes": sampler.peak_disk_bytes,
             "machine_min_available_memory_bytes": sampler.min_available_memory_bytes,
             "process_peak_rss_bytes":
@@ -266,33 +384,19 @@ def run_boot_only_verification(
             "expected_bundle_bytes": expected_bundle_bytes,
             "cold_run_valid": _is_cold_run_valid(report, expected_bundle_bytes),
         })
-
-        if not report.ready or not report.snapshot_dir or not report.version:
-            result["validated"] = False
-            return result
-
-        record = store.verified_record(report.version)
-        if record is None:
-            result["validated"] = False
-            result["validation_error"] = (
-                "no verification record for the materialized version"
-            )
-            return result
-
-        validation_started = time.perf_counter()
-        with SnapshotAdapter.open(Path(report.snapshot_dir), record) as adapter:
-            result.update({
-                "validated": True,
-                "validation_ms":
-                    round((time.perf_counter() - validation_started) * 1000, 1),
-                "coverage_from": adapter.coverage_from,
-                "coverage_to": adapter.coverage_to,
-            })
         return result
     finally:
-        # Verification-only: never leave a materialized snapshot behind, and
-        # touch nothing on the Machine's filesystem beyond this one directory.
-        shutil.rmtree(verify_dir, ignore_errors=True)
+        # Verification-only: never leave a materialized snapshot behind. A
+        # removal failure is reported, never swallowed -- `ignore_errors`
+        # would let this tool claim success while leaving the artifact
+        # behind on the Machine's disk.
+        try:
+            shutil.rmtree(verify_dir)
+            result["cleanup_ok"] = True
+            result["cleanup_error"] = None
+        except Exception as exc:  # noqa: BLE001 -- recorded, not raised
+            result["cleanup_ok"] = False
+            result["cleanup_error"] = f"{type(exc).__name__}: {exc}"
 
 
 def _build_cli_source() -> Any:
@@ -323,11 +427,11 @@ def build_parser() -> argparse.ArgumentParser:
              "created fresh and removed at the end of this run",
     )
     parser.add_argument("--report", help="also write the JSON report here")
-    parser.add_argument(
-        "--expected-bundle-bytes", type=int, default=EXPECTED_BUNDLE_BYTES,
-        help="required bytes_downloaded for a valid cold run "
-             "(0 disables the exact-size check)",
-    )
+    # Deliberately no --expected-bundle-bytes flag: the CLI always requires
+    # the declared EXPECTED_BUNDLE_BYTES exactly. A configurable escape
+    # hatch here would let a production invocation report cold_run_valid
+    # from merely `bytes_downloaded > 0`, which is not what G1a asks for.
+    # `run_boot_only_verification` still takes the parameter for tests.
     return parser
 
 
@@ -336,7 +440,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     args = build_parser().parse_args(argv)
     cache_dir = Path(os.environ.get(SNAPSHOT_CACHE_ENV, DEFAULT_CACHE_DIR))
-    expected = args.expected_bundle_bytes or None
 
     try:
         source = _build_cli_source()
@@ -344,11 +447,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             source,
             verify_dir=Path(args.verify_dir),
             cache_dir=cache_dir,
-            expected_bundle_bytes=expected,
+            expected_bundle_bytes=EXPECTED_BUNDLE_BYTES,
         )
     except VerificationRefused as exc:
-        result = {"label": "boot-only verification measurement",
-                  "refused": str(exc)}
+        result = {**_base_result(), "refused": str(exc)}
         print(json.dumps(result, indent=2))
         if args.report:
             Path(args.report).write_text(json.dumps(result, indent=2))
@@ -357,7 +459,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     print(json.dumps(result, indent=2))
     if args.report:
         Path(args.report).write_text(json.dumps(result, indent=2))
-    return 0 if result.get("validated") and result.get("cold_run_valid") else 1
+    ok = (result.get("validated") and result.get("cold_run_valid")
+          and result.get("cleanup_ok", True))
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tools/ppd_snapshot/boot_only_verify.py
+++ b/tools/ppd_snapshot/boot_only_verify.py
@@ -1,0 +1,364 @@
+"""Boot-only verification: materialize and validate a real snapshot without
+routing any live request to it.
+
+    fly ssh console -a property-shared
+    python /app/boot_only_verify.py --verify-dir /tmp/ppd-verify-$(date +%s)
+
+Provides **partial** G1a evidence -- materialization and adapter-open/
+validation timing, peak transient disk, and cold-run confirmation -- for a
+real Machine against real object storage. It is not a completed G1a
+measurement: the governing specification
+(``docs/design/ppd-source-routing.md``) requires *application*
+time-to-readiness -- full ASGI startup, async lifespan, single-flight lock
+behaviour under the real deployed worker count -- which a standalone process
+cannot produce no matter how its output is labelled. Label results
+accordingly; do not present ``materialization_ms`` as application
+time-to-ready.
+
+**Isolation from the live server, by construction.** This module never
+imports ``property_core.snapshot.state`` and is meant to run as an entirely
+separate process from the deployed app (invoked out of band, e.g. via
+``fly ssh console``) -- it cannot install an adapter live requests would ever
+see, and ``PPD_SNAPSHOT_ENABLED`` is never read or set here. It reuses the
+existing materialization path unchanged: ``SnapshotRuntime.boot()`` for
+fetch/verify/extract (with its own already-enforced
+``preflight_disk_space`` free-space precondition), then
+``SnapshotAdapter.open`` for the same structural + queryable validation the
+live path performs.
+
+**Verification-only.** The materialized snapshot is always removed at the
+end of a run, successful or not -- this is a measurement, not a cache, and
+never shares a directory with the application's own
+``PPD_SNAPSHOT_CACHE_DIR``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import resource
+import shutil
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+#: The initial artifact's declared bundle size (design doc, "Scope and
+#: account"). A cold run must download exactly this many bytes; anything
+#: else means the bundle changed or the run was not genuinely cold.
+EXPECTED_BUNDLE_BYTES = 279_109_872
+
+
+class VerificationRefused(RuntimeError):
+    """A precondition failed before anything was materialized."""
+
+
+def _filesystem_type(path: Path, mounts_text: Optional[str] = None) -> str:
+    """The filesystem type backing `path`, by longest mount-point match.
+
+    Reads `/proc/mounts` unless `mounts_text` is given (for tests). Refuses
+    rather than guessing when the table can't be read or nothing matches --
+    silently assuming disk-backed would defeat the point of the check.
+    """
+    if mounts_text is None:
+        try:
+            mounts_text = Path("/proc/mounts").read_text()
+        except OSError as exc:
+            raise VerificationRefused(f"cannot read /proc/mounts: {exc}") from exc
+    resolved = str(path.resolve())
+    best_match = ""
+    best_type = ""
+    for line in mounts_text.splitlines():
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        mount_point, fs_type = parts[1], parts[2]
+        stripped = mount_point.rstrip("/") or "/"
+        if resolved == stripped or resolved.startswith(stripped + "/"):
+            if len(stripped) >= len(best_match):
+                best_match, best_type = stripped, fs_type
+    if not best_type:
+        raise VerificationRefused(f"no mount entry matches {resolved}")
+    return best_type
+
+
+def assert_disk_backed(path: Path, mounts_text: Optional[str] = None) -> str:
+    """Refuse a tmpfs/ramfs-backed verification root.
+
+    G1a's disk and RAM figures mean something different than they appear to
+    unless the materialization root is confirmed disk-backed first (design
+    doc, G1a).
+    """
+    fs_type = _filesystem_type(path, mounts_text)
+    if fs_type in ("tmpfs", "ramfs"):
+        raise VerificationRefused(
+            f"{path} is backed by {fs_type!r}, not disk -- G1a requires a "
+            f"disk-backed materialization root"
+        )
+    return fs_type
+
+
+def _prepare_verification_directory(path: Path, cache_dir: Path) -> None:
+    """Create a unique, empty verification directory. Never the app's store."""
+    resolved = path.resolve()
+    cache_resolved = cache_dir.resolve()
+    if resolved == cache_resolved or cache_resolved in resolved.parents:
+        raise VerificationRefused(
+            f"{path} collides with the application's own "
+            f"PPD_SNAPSHOT_CACHE_DIR ({cache_dir}); use a separate directory"
+        )
+    if resolved.exists():
+        raise VerificationRefused(
+            f"{path} already exists -- the verification directory must start "
+            f"empty and unique per run"
+        )
+    resolved.mkdir()
+
+
+def _directory_bytes(path: Path) -> int:
+    total = 0
+    if not path.exists():
+        return 0
+    for entry in path.rglob("*"):
+        try:
+            if entry.is_file():
+                total += entry.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _available_memory_bytes() -> Optional[int]:
+    try:
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+class _DiskAndMemorySampler:
+    """Polls verification-directory size and Machine-wide available memory.
+
+    A background thread, not a hook into the runtime: the fetch/extract code
+    this wraps does blocking I/O with no yield points to sample from instead,
+    and the live server process keeps running concurrently on the same
+    Machine, so its memory pressure is part of the real headroom picture.
+    """
+
+    def __init__(self, directory: Path, interval: float = 0.2):
+        self._directory = directory
+        self._interval = interval
+        self._stop = threading.Event()
+        self._peak_disk_bytes = 0
+        self._min_available_memory_bytes: Optional[int] = None
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _sample_once(self) -> None:
+        current = _directory_bytes(self._directory)
+        if current > self._peak_disk_bytes:
+            self._peak_disk_bytes = current
+        available = _available_memory_bytes()
+        if available is not None and (
+            self._min_available_memory_bytes is None
+            or available < self._min_available_memory_bytes
+        ):
+            self._min_available_memory_bytes = available
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self._sample_once()
+            except Exception:  # noqa: BLE001 -- sampling must not abort the boot
+                pass
+            self._stop.wait(self._interval)
+
+    def __enter__(self) -> "_DiskAndMemorySampler":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+        # One final sample: a fast run can finish between poll intervals and
+        # otherwise report a peak of zero.
+        try:
+            self._sample_once()
+        except Exception:  # noqa: BLE001
+            pass
+
+    @property
+    def peak_disk_bytes(self) -> int:
+        return self._peak_disk_bytes
+
+    @property
+    def min_available_memory_bytes(self) -> Optional[int]:
+        return self._min_available_memory_bytes
+
+
+def _is_cold_run_valid(report: Any, expected_bundle_bytes: Optional[int]) -> bool:
+    """Whether this run is trustworthy as G1a cold-materialization evidence.
+
+    A reused materialization, or a transfer short of the full bundle, is not
+    a measurement of the thing G1a asks about -- record it as invalid rather
+    than silently accepting it.
+    """
+    if report.reused_existing:
+        return False
+    if expected_bundle_bytes is not None:
+        return report.bytes_downloaded == expected_bundle_bytes
+    return report.bytes_downloaded > 0
+
+
+def run_boot_only_verification(
+    source: Any,
+    *,
+    verify_dir: Path,
+    cache_dir: Path,
+    expected_bundle_bytes: Optional[int] = EXPECTED_BUNDLE_BYTES,
+    sample_interval: float = 0.2,
+    mounts_text: Optional[str] = None,
+) -> dict:
+    """Materialize and validate one snapshot through `source`, then discard it.
+
+    Never imports ``property_core.snapshot.state`` and never installs
+    anything a live request could be routed to -- by construction, not by
+    convention.
+    """
+    from property_core.snapshot.adapter import SnapshotAdapter
+    from property_core.snapshot.runtime import SnapshotRuntime
+    from property_core.snapshot.store import SnapshotStore
+
+    if not verify_dir.parent.is_dir():
+        raise VerificationRefused(
+            f"{verify_dir.parent} does not exist; create the parent "
+            f"directory first"
+        )
+    assert_disk_backed(verify_dir.parent, mounts_text)
+    _prepare_verification_directory(verify_dir, cache_dir)
+
+    result: dict[str, Any] = {"label": "boot-only verification measurement"}
+    try:
+        store = SnapshotStore(verify_dir)
+        runtime = SnapshotRuntime(source=source, store=store)
+
+        with _DiskAndMemorySampler(verify_dir, interval=sample_interval) as sampler:
+            started = time.perf_counter()
+            report = runtime.boot()
+            materialization_ms = (time.perf_counter() - started) * 1000
+
+        result.update({
+            "readiness": report.readiness.value,
+            "version": report.version,
+            "reused_existing": report.reused_existing,
+            "bytes_downloaded": report.bytes_downloaded,
+            "behind_advertised_release": report.behind_advertised_release,
+            "source_error": report.source_error,
+            "warnings": list(report.warnings),
+            "runtime_timings_ms": dict(report.timings_ms),
+            "materialization_ms": round(materialization_ms, 1),
+            "peak_transient_disk_bytes": sampler.peak_disk_bytes,
+            "machine_min_available_memory_bytes": sampler.min_available_memory_bytes,
+            "process_peak_rss_bytes":
+                resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024,
+            "expected_bundle_bytes": expected_bundle_bytes,
+            "cold_run_valid": _is_cold_run_valid(report, expected_bundle_bytes),
+        })
+
+        if not report.ready or not report.snapshot_dir or not report.version:
+            result["validated"] = False
+            return result
+
+        record = store.verified_record(report.version)
+        if record is None:
+            result["validated"] = False
+            result["validation_error"] = (
+                "no verification record for the materialized version"
+            )
+            return result
+
+        validation_started = time.perf_counter()
+        with SnapshotAdapter.open(Path(report.snapshot_dir), record) as adapter:
+            result.update({
+                "validated": True,
+                "validation_ms":
+                    round((time.perf_counter() - validation_started) * 1000, 1),
+                "coverage_from": adapter.coverage_from,
+                "coverage_to": adapter.coverage_to,
+            })
+        return result
+    finally:
+        # Verification-only: never leave a materialized snapshot behind, and
+        # touch nothing on the Machine's filesystem beyond this one directory.
+        shutil.rmtree(verify_dir, ignore_errors=True)
+
+
+def _build_cli_source() -> Any:
+    """The real Tigris source, built exactly as the deployed app would build it."""
+    from property_core.snapshot.bootstrap import _build_source
+    from property_core.snapshot.s3_source import TigrisObjectSource
+
+    try:
+        source = _build_source()
+    except RuntimeError as exc:
+        raise VerificationRefused(str(exc)) from exc
+    if not isinstance(source, TigrisObjectSource):
+        raise VerificationRefused(
+            f"PPD_SNAPSHOT_S3_BUCKET must be set for boot-only verification; "
+            f"resolved a {type(source).__name__} instead"
+        )
+    return source
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python boot_only_verify.py",
+        description=__doc__,
+    )
+    parser.add_argument(
+        "--verify-dir", required=True,
+        help="a not-yet-existing directory on a disk-backed filesystem; "
+             "created fresh and removed at the end of this run",
+    )
+    parser.add_argument("--report", help="also write the JSON report here")
+    parser.add_argument(
+        "--expected-bundle-bytes", type=int, default=EXPECTED_BUNDLE_BYTES,
+        help="required bytes_downloaded for a valid cold run "
+             "(0 disables the exact-size check)",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    from property_core.snapshot.bootstrap import DEFAULT_CACHE_DIR, SNAPSHOT_CACHE_ENV
+
+    args = build_parser().parse_args(argv)
+    cache_dir = Path(os.environ.get(SNAPSHOT_CACHE_ENV, DEFAULT_CACHE_DIR))
+    expected = args.expected_bundle_bytes or None
+
+    try:
+        source = _build_cli_source()
+        result = run_boot_only_verification(
+            source,
+            verify_dir=Path(args.verify_dir),
+            cache_dir=cache_dir,
+            expected_bundle_bytes=expected,
+        )
+    except VerificationRefused as exc:
+        result = {"label": "boot-only verification measurement",
+                  "refused": str(exc)}
+        print(json.dumps(result, indent=2))
+        if args.report:
+            Path(args.report).write_text(json.dumps(result, indent=2))
+        return 2
+
+    print(json.dumps(result, indent=2))
+    if args.report:
+        Path(args.report).write_text(json.dumps(result, indent=2))
+    return 0 if result.get("validated") and result.get("cold_run_valid") else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Hold — do not merge without separate approval

This is Phase C of the PPD snapshot rollout plan (`docs/ops/2026-08-31-ppd-snapshot-rollout.md`,
`docs/design/ppd-private-delivery.md` step 4). Prepared and reviewed like
#37/#38 were, but per the rollout plan is **not merged automatically** —
merge requires the same explicit go-ahead those PRs did. No snapshot
serving is enabled here, no credentials are installed, and nothing is
wired into the deploy path.

## What this adds

`tools/ppd_snapshot/boot_only_verify.py`: a standalone script that
materializes and validates one real snapshot through the **existing**
`SnapshotRuntime`/`SnapshotAdapter` path — no new fetch, verify, extract or
free-space-preflight logic, all reused unchanged — then discards it. Meant
to run as its own process on the real `property-shared` Machine (`fly ssh
console`), never wired into the app's lifespan.

**Isolation by construction, not convention**: the module never imports
`property_core.snapshot.state`, so it cannot install anything a live
request could be routed to, regardless of environment or caller.
`PPD_SNAPSHOT_ENABLED` is never read or set here.

**Filesystem isolation**: refuses a tmpfs/ramfs-backed verification path,
refuses to reuse or collide with the app's own `PPD_SNAPSHOT_CACHE_DIR`,
requires the verification directory to start empty and unique, and always
removes it at the end of a run (success or failure).

**Cold-run validity**: reads `BootReport.reused_existing` and
`bytes_downloaded` (not `behind_advertised_release`, which can differ) and
marks a run invalid as G1a evidence unless the materialization was
genuinely cold and downloaded the full expected bundle
(279,109,872 bytes, the design doc's initial artifact).

**Instrumentation**: phase timing (materialization, adapter-open/
validation), peak transient disk via background polling, Machine-wide
available memory alongside the verifier's own peak RSS (the live server
keeps running concurrently on the same Machine).

**Explicitly partial G1a evidence**, stated in its own docstring and every
report it produces: this measures materialization and validation, not the
application startup lifecycle (uvicorn boot, async lifespan, single-flight
lock behaviour under the real deployed worker count) the governing spec
requires for a completed gate.

**Delivery**: one explicit `COPY tools/ppd_snapshot/boot_only_verify.py`
into `Dockerfile` (property-shared) only — not the whole `tools/` tree,
not `property_cli/`, and no `Dockerfile.app` change. This milestone
targets `property-shared`'s G1a; `propertydata`'s G1b is a later, separate
gate.

## Verification

- `tests/snapshot/test_boot_only_verify.py`: 13 new tests — disk-backed
  assertion (accepts/refuses via synthetic mount tables, no real tmpfs
  needed), verification-directory collision/pre-existence refusal,
  cold-run validity logic, and two end-to-end runs against a loopback
  fixture server (reusing `image_smoke.py`'s synthetic snapshot builder)
  covering success, failure-path cleanup, and a behavioural check
  (`Mock(wraps=state.install)`) that `state.install` is never called.
- Full suite: `bash scripts/validate.sh` — 1655 passed, 26 skipped
  (up from 1642; +13 for this PR).
- Built the `property-shared` image locally: confirmed
  `/app/boot_only_verify.py` present, `--help` runs (imports resolve
  inside the real image), and the no-config case refuses cleanly with a
  typed JSON report rather than a raw traceback.
- `Dockerfile.app` diff is empty.