### PR TITLE
feat(ops): read-only Fly observability collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ scripts/*
 !scripts/measure_mcp_quality.py
 !scripts/epc_token_test.py
 !scripts/rightmove_address_dump.py
+!scripts/fly_observability_snapshot.py
 !scripts/validate.sh

--- a/scripts/fly_observability_snapshot.py
+++ b/scripts/fly_observability_snapshot.py
@@ -1,0 +1,1380 @@
+"""Read-only observability snapshot for a Fly.io app.
+
+Replaces dashboard screenshots with repeatable, timestamped evidence: one
+invocation writes a stable-schema JSON report plus a Markdown interpretation,
+so a before/during/after comparison is a diff rather than a memory of what a
+graph looked like.
+
+Two sources, both read-only:
+
+  * documented `flyctl` JSON commands (`status`, `checks list`, `image show`,
+    and — only when asked for — a bounded `logs --no-tail`);
+  * Fly's Prometheus-compatible HTTP API at
+    `https://api.fly.io/prometheus/<org>/api/v1/{query,query_range}`.
+
+Every metric name and every PromQL expression in `SERIES` was verified against
+the live API for `app="property-shared"` on 2026-09-01 before being written
+here (see `DASHBOARD_GAP_NOTE` for what was deliberately *not* included).
+
+Three properties this script exists to hold, because the evidence is worthless
+without them:
+
+  1. **`0` and "no data" are different answers.** An absent series is reported
+     as `no_data` with a null value, never as zero. `fly_app_concurrency` has
+     no series for this app, and a report that renders that as `0 connections`
+     is a lie about idle traffic.
+  2. **Partial failure stays partial.** One dead command or one unavailable
+     series becomes a typed entry in the report; it never aborts the run and
+     never silently becomes a number.
+  3. **The token never lands anywhere.** It is read into memory, used only as
+     an `Authorization` header, and scrubbed out of every string — including
+     exception text — before anything is written or printed.
+
+Usage:
+    uv run python scripts/fly_observability_snapshot.py \\
+        --app property-shared --org personal --window 30m \\
+        --output docs/ops/evidence/2026-09-01-baseline.json
+
+    # opt in to a bounded, sanitised log excerpt
+    ... --include-logs 50
+
+Auth: reads `FLY_API_TOKEN` or `FLY_ACCESS_TOKEN` if set, otherwise captures
+`fly auth token` into memory. The token is never passed as a command argument.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import string
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+SCHEMA_VERSION = "1"
+PROMETHEUS_BASE = "https://api.fly.io/prometheus"
+REDACTION_PLACEHOLDER = "<redacted>"
+DEFAULT_TIMEOUT = 30.0
+
+# flyctl authenticates with a macaroon. It is sent as `Authorization: FlyV1
+# <token>`; `Bearer <token>` is rejected with 401 "something went wrong
+# resolving organization", which reads like a permissions problem rather than
+# an auth-scheme one, so it is worth stating plainly here.
+AUTH_SCHEME = "FlyV1"
+
+DASHBOARD_GAP_NOTE = (
+    "No Grafana dashboard titled 'BOUCH MCP Fleet' is checked in anywhere under "
+    "the mcpfleet workspace; the only checked-in dashboard is "
+    "monitoring/grafana-dashboard.json ('Property Shared API'), whose PromQL "
+    "targets metric names that do not exist in Fly's Prometheus "
+    "(http_request_duration_seconds_*, http_requests_inprogress, "
+    "http_response_size_bytes_*, external_request_duration_seconds_*). That "
+    "dashboard is written for a prometheus_fastapi_instrumentator naming scheme "
+    "the deployed app does not use. No series here is sourced from it. The "
+    "app_custom series below are taken from the live Fly label index and from "
+    "the checked-in definitions in app/core/metrics.py, not from any dashboard."
+)
+
+Fetch = Callable[[str, dict[str, str], float], "tuple[int, bytes]"]
+Runner = Callable[["list[str]", float], "tuple[int, str, str]"]
+
+
+class ReadOnlyViolation(RuntimeError):
+    """Raised when a flyctl invocation is not on the read-only allowlist."""
+
+
+# ---------------------------------------------------------------------------
+# Read-only enforcement
+# ---------------------------------------------------------------------------
+
+# Allowlist rather than a denylist: a new mutating flyctl verb must not become
+# permitted just because nobody remembered to forbid it.
+READ_ONLY_COMMANDS: tuple[tuple[str, ...], ...] = (
+    ("status",),
+    ("checks", "list"),
+    ("image", "show"),
+    ("logs",),
+    ("version",),
+)
+
+
+def assert_read_only(argv: Sequence[str]) -> None:
+    """Allow only documented read-only flyctl invocations.
+
+    `argv` excludes the `fly`/`flyctl` binary itself.
+    """
+    words = [a for a in argv if not a.startswith("-")]
+    for allowed in READ_ONLY_COMMANDS:
+        if tuple(words[: len(allowed)]) == allowed:
+            return
+    raise ReadOnlyViolation(
+        f"refusing to run non-read-only flyctl command: {' '.join(argv)!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+# Fly macaroons are `fm2_...`, optionally behind the `FlyV1` scheme word. Both
+# shapes are scrubbed even when the caller did not name the token, because the
+# leak that matters is the one nobody anticipated — urllib, for instance, puts
+# the failing URL into the exception it raises.
+_TOKEN_PATTERNS = (
+    re.compile(r"FlyV1\s+\S+"),
+    re.compile(r"\bfm[12]_[A-Za-z0-9_\-=]+"),
+)
+
+
+def redact(text: str, secrets: Iterable[str] = ()) -> str:
+    """Remove known secrets and anything macaroon-shaped from `text`."""
+    for secret in secrets:
+        if secret:
+            text = text.replace(secret, REDACTION_PLACEHOLDER)
+    for pattern in _TOKEN_PATTERNS:
+        text = pattern.sub(REDACTION_PLACEHOLDER, text)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Metric specifications
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """One series to collect.
+
+    `promql` is a `string.Template` with `$app`, `$window` and `$prefix`
+    placeholders, so the braces of a PromQL label matcher need no escaping.
+    """
+
+    key: str
+    title: str
+    promql: str
+    unit: str
+    kind: str = "instant"
+    provenance: str = "fly_builtin"
+    derived: bool = False
+    derivation: str = ""
+    note: str = ""
+
+    def render(self, *, app: str, window: str, prefix: str) -> str:
+        return string.Template(self.promql).safe_substitute(
+            app=app, window=window, prefix=prefix
+        )
+
+
+_FS_FREE = (
+    'fly_instance_filesystem_blocks_free{app="$app"} '
+    '* fly_instance_filesystem_block_size{app="$app"}'
+)
+
+SERIES: tuple[MetricSpec, ...] = (
+    # -- identity and liveness -------------------------------------------
+    MetricSpec(
+        key="instance_up",
+        title="Instance up",
+        promql='fly_instance_up{app="$app"}',
+        unit="bool",
+    ),
+    MetricSpec(
+        key="instance_info",
+        title="Machine identity",
+        promql='fly_instance_info{app="$app"}',
+        unit="info",
+        note="Labels carry instance (Machine ID), cpu_kind, cpu_count, memory_mb, process_group.",
+    ),
+    MetricSpec(
+        key="instance_uptime_seconds",
+        title="Instance uptime",
+        promql='fly_instance_uptime_seconds{app="$app"}',
+        unit="seconds",
+        note="Resets on Machine restart — the cheapest check that a restart actually happened.",
+    ),
+    MetricSpec(
+        key="scrape_up",
+        title="Metrics scrape up",
+        promql='up{app="$app"}',
+        unit="bool",
+        note="0 here means Fly could not scrape the app's /metrics; app_custom series then go stale.",
+    ),
+    # -- concurrency and load --------------------------------------------
+    MetricSpec(
+        key="app_concurrency",
+        title="App concurrency",
+        promql='fly_app_concurrency{app="$app"}',
+        unit="connections",
+        note=(
+            "Verified absent for property-shared and propertydata on 2026-09-01 while "
+            "present for five other fleet apps. Expect no_data, and do not read it as zero."
+        ),
+    ),
+    MetricSpec(
+        key="load_average_5m",
+        title="Load average (5m)",
+        promql='fly_instance_load_average{app="$app",minutes="5"}',
+        unit="load",
+    ),
+    MetricSpec(
+        key="load_average_5m_peak",
+        title="Load average (5m) peak over window",
+        promql='max_over_time(fly_instance_load_average{app="$app",minutes="5"}[$window])',
+        unit="load",
+        derived=True,
+        derivation="max_over_time over the collection window of the kernel 5-minute load average.",
+    ),
+    # -- CPU ---------------------------------------------------------------
+    MetricSpec(
+        key="cpu_busy_pct",
+        title="CPU busy",
+        promql=(
+            '100 * (1 - sum(rate(fly_instance_cpu{app="$app",mode="idle"}[$window])) '
+            '/ sum(rate(fly_instance_cpu{app="$app"}[$window])))'
+        ),
+        unit="percent",
+        derived=True,
+        derivation=(
+            "100 * (1 - idle_rate / total_rate) across all cpu modes and cpu_ids over the window."
+        ),
+    ),
+    MetricSpec(
+        key="cpu_throttle",
+        title="CPU throttle",
+        promql='fly_instance_cpu_throttle{app="$app"}',
+        unit="count",
+    ),
+    # -- memory ------------------------------------------------------------
+    MetricSpec(
+        key="memory_total",
+        title="Machine memory total",
+        promql='fly_instance_memory_mem_total{app="$app"}',
+        unit="bytes",
+    ),
+    MetricSpec(
+        key="memory_available",
+        title="Machine memory available",
+        promql='fly_instance_memory_mem_available{app="$app"}',
+        unit="bytes",
+    ),
+    MetricSpec(
+        key="memory_available_min",
+        title="Machine memory available, minimum over window",
+        promql='min_over_time(fly_instance_memory_mem_available{app="$app"}[$window])',
+        unit="bytes",
+        derived=True,
+        derivation="min_over_time of MemAvailable over the window — the Machine-wide low-water mark.",
+        note="This is the G1a Machine-wide available-memory figure, not process RSS.",
+    ),
+    MetricSpec(
+        key="instance_exit_oom",
+        title="OOM exits",
+        promql='fly_instance_exit_oom{app="$app"}',
+        unit="count",
+        note="Absent unless an OOM kill has occurred; no_data here is the healthy reading.",
+    ),
+    # -- root filesystem (the G1a disk constraint) -------------------------
+    MetricSpec(
+        key="rootfs_free_bytes",
+        title="Root filesystem free",
+        promql=_FS_FREE,
+        unit="bytes",
+        derived=True,
+        derivation="blocks_free * block_size, per mount. Mount label identifies the filesystem.",
+        note=(
+            "Fly's ephemeral rootfs reports as mount /.fly-upper-layer. This is the free-space "
+            "figure the snapshot preflight (bundle_bytes * 2.5) is measured against."
+        ),
+    ),
+    MetricSpec(
+        key="rootfs_free_bytes_min",
+        title="Root filesystem free, minimum over window",
+        promql=f"min_over_time(({_FS_FREE})[$window:1m])",
+        unit="bytes",
+        derived=True,
+        derivation=(
+            "min_over_time of (blocks_free * block_size) sampled at 1m over the window. "
+            "The low-water mark; peak transient disk use is total minus this."
+        ),
+    ),
+    MetricSpec(
+        key="rootfs_total_bytes",
+        title="Root filesystem total",
+        promql=(
+            'fly_instance_filesystem_blocks{app="$app"} '
+            '* fly_instance_filesystem_block_size{app="$app"}'
+        ),
+        unit="bytes",
+        derived=True,
+        derivation="blocks * block_size, per mount.",
+    ),
+    # -- network -----------------------------------------------------------
+    MetricSpec(
+        key="net_recv_bytes_rate",
+        title="Network received",
+        promql='sum(rate(fly_instance_net_recv_bytes{app="$app",device="eth0"}[$window]))',
+        unit="bytes/sec",
+        derived=True,
+        derivation="rate() of the eth0 counter over the window, summed.",
+    ),
+    MetricSpec(
+        key="net_sent_bytes_rate",
+        title="Network sent",
+        promql='sum(rate(fly_instance_net_sent_bytes{app="$app",device="eth0"}[$window]))',
+        unit="bytes/sec",
+        derived=True,
+        derivation="rate() of the eth0 counter over the window, summed.",
+    ),
+    # -- HTTP: Fly proxy, app side and edge side ---------------------------
+    MetricSpec(
+        key="app_http_responses_by_status",
+        title="App HTTP responses by status",
+        promql='sum by (status) (increase(fly_app_http_responses_count{app="$app"}[$window]))',
+        unit="responses",
+        derived=True,
+        derivation="increase() of the Fly proxy app-side response counter over the window, by status.",
+    ),
+    MetricSpec(
+        key="edge_http_responses_by_status",
+        title="Edge HTTP responses by status",
+        promql='sum by (status) (increase(fly_edge_http_responses_count{app="$app"}[$window]))',
+        unit="responses",
+        derived=True,
+        derivation="increase() of the Fly edge response counter over the window, by status.",
+        note="Edge series carry no instance label — they are per-PoP, not per-Machine.",
+    ),
+    MetricSpec(
+        key="app_http_p95",
+        title="App HTTP p95 latency",
+        promql=(
+            "histogram_quantile(0.95, sum by (le) "
+            '(rate(fly_app_http_response_time_seconds_bucket{app="$app"}[$window])))'
+        ),
+        unit="seconds",
+        derived=True,
+        derivation="histogram_quantile(0.95) over the Fly proxy app-side latency histogram.",
+    ),
+    MetricSpec(
+        key="app_http_p99",
+        title="App HTTP p99 latency",
+        promql=(
+            "histogram_quantile(0.99, sum by (le) "
+            '(rate(fly_app_http_response_time_seconds_bucket{app="$app"}[$window])))'
+        ),
+        unit="seconds",
+        derived=True,
+        derivation="histogram_quantile(0.99) over the Fly proxy app-side latency histogram.",
+    ),
+    MetricSpec(
+        key="edge_http_p95",
+        title="Edge HTTP p95 latency",
+        promql=(
+            "histogram_quantile(0.95, sum by (le) "
+            '(rate(fly_edge_http_response_time_seconds_bucket{app="$app"}[$window])))'
+        ),
+        unit="seconds",
+        derived=True,
+        derivation="histogram_quantile(0.95) over the Fly edge latency histogram.",
+    ),
+    MetricSpec(
+        key="hard_limit_reached",
+        title="Concurrency hard limit reached",
+        promql='sum(increase(fly_app_hard_limit_reached_count{app="$app"}[$window]))',
+        unit="events",
+        derived=True,
+        derivation="increase() over the window.",
+    ),
+    MetricSpec(
+        key="soft_limit_reached",
+        title="Concurrency soft limit reached",
+        promql='sum(increase(fly_app_soft_limit_reached_count{app="$app"}[$window]))',
+        unit="events",
+        derived=True,
+        derivation="increase() over the window.",
+    ),
+    # -- app-exposed process and application metrics -----------------------
+    MetricSpec(
+        key="process_rss",
+        title="Process RSS",
+        promql='process_resident_memory_bytes{app="$app"}',
+        unit="bytes",
+        provenance="app_custom",
+        note="Scraped from the app's own /metrics; single uvicorn process (see gate G2).",
+    ),
+    MetricSpec(
+        key="process_rss_peak",
+        title="Process RSS peak over window",
+        promql='max_over_time(process_resident_memory_bytes{app="$app"}[$window])',
+        unit="bytes",
+        provenance="app_custom",
+        derived=True,
+        derivation="max_over_time of the scraped RSS gauge over the window.",
+        note=(
+            "Bounded below by the scrape interval: a spike shorter than one scrape is invisible "
+            "here. Not a substitute for measuring RSS inside the process under test."
+        ),
+    ),
+    MetricSpec(
+        key="process_open_fds",
+        title="Open file descriptors",
+        promql='process_open_fds{app="$app"}',
+        unit="count",
+        provenance="app_custom",
+    ),
+    MetricSpec(
+        key="app_requests_by_route",
+        title="App requests by surface/route/status class",
+        promql=(
+            "sum by (surface, route, status_class) "
+            '(increase(${prefix}_http_requests_total{app="$app"}[$window]))'
+        ),
+        unit="requests",
+        provenance="app_custom",
+        derived=True,
+        derivation="increase() of the app's own request counter over the window.",
+    ),
+    MetricSpec(
+        key="app_request_p95",
+        title="App-measured request p95 latency",
+        promql=(
+            "histogram_quantile(0.95, sum by (le) "
+            '(rate(${prefix}_http_request_duration_seconds_bucket{app="$app"}[$window])))'
+        ),
+        unit="seconds",
+        provenance="app_custom",
+        derived=True,
+        derivation="histogram_quantile(0.95) over the app's own request-duration histogram.",
+    ),
+    MetricSpec(
+        key="app_tool_calls",
+        title="MCP tool calls by tool and status",
+        promql=(
+            "sum by (tool, status) "
+            '(increase(${prefix}_tool_calls_total{app="$app"}[$window]))'
+        ),
+        unit="calls",
+        provenance="app_custom",
+        derived=True,
+        derivation="increase() of the MCP tool-call counter over the window.",
+        note=(
+            "Verified to have no live series for property-shared on 2026-09-01 despite "
+            "the duration histogram existing — the counter is stale, not zero."
+        ),
+    ),
+    MetricSpec(
+        key="app_client_connections",
+        title="MCP client handshakes by client",
+        promql=(
+            "sum by (client_name) "
+            '(increase(${prefix}_client_connections_total{app="$app"}[$window]))'
+        ),
+        unit="handshakes",
+        provenance="app_custom",
+        derived=True,
+        derivation="increase() of the MCP initialize-handshake counter over the window.",
+    ),
+)
+
+# Range series exist so the report carries shape, not just endpoints — a flat
+# line and a spike that returned to baseline produce the same instant reading.
+RANGE_SERIES: tuple[MetricSpec, ...] = (
+    MetricSpec(
+        key="range_memory_available",
+        title="Machine memory available over time",
+        promql='fly_instance_memory_mem_available{app="$app"}',
+        unit="bytes",
+        kind="range",
+    ),
+    MetricSpec(
+        key="range_rootfs_free",
+        title="Root filesystem free over time",
+        promql=_FS_FREE,
+        unit="bytes",
+        kind="range",
+        derived=True,
+        derivation="blocks_free * block_size, per mount, sampled across the window.",
+    ),
+    MetricSpec(
+        key="range_process_rss",
+        title="Process RSS over time",
+        promql='process_resident_memory_bytes{app="$app"}',
+        unit="bytes",
+        kind="range",
+        provenance="app_custom",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SeriesResult:
+    """The outcome of collecting one series.
+
+    `status` is one of `ok`, `no_data` or `error`. `value` is populated only
+    when the result is a single sample; it is `None` for `no_data`, for `error`
+    and for multi-sample results, so a caller can never read a missing series
+    as a number.
+    """
+
+    key: str
+    title: str
+    promql: str
+    unit: str
+    status: str
+    samples: list[dict[str, Any]] = field(default_factory=list)
+    value: float | None = None
+    error: str | None = None
+    kind: str = "instant"
+    provenance: str = "fly_builtin"
+    derived: bool = False
+    derivation: str = ""
+    note: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "title": self.title,
+            "promql": self.promql,
+            "unit": self.unit,
+            "kind": self.kind,
+            "status": self.status,
+            "value": self.value,
+            "samples": self.samples,
+            "error": self.error,
+            "provenance": self.provenance,
+            "derived": self.derived,
+            "derivation": self.derivation,
+            "note": self.note,
+        }
+
+
+def _from_spec(spec: MetricSpec, promql: str, **kwargs: Any) -> SeriesResult:
+    return SeriesResult(
+        key=spec.key,
+        title=spec.title,
+        promql=promql,
+        unit=spec.unit,
+        kind=spec.kind,
+        provenance=spec.provenance,
+        derived=spec.derived,
+        derivation=spec.derivation,
+        note=spec.note,
+        **kwargs,
+    )
+
+
+def _labels(metric: dict[str, str]) -> dict[str, str]:
+    return {k: v for k, v in metric.items() if k != "__name__"}
+
+
+def parse_instant_response(
+    spec: MetricSpec, payload: dict[str, Any], promql: str | None = None
+) -> SeriesResult:
+    """Turn a Prometheus instant-query payload into a typed result."""
+    promql = promql if promql is not None else spec.promql
+
+    if payload.get("status") != "success":
+        detail = payload.get("error") or payload.get("errorType") or "unknown error"
+        return _from_spec(spec, promql, status="error", error=f"prometheus: {detail}")
+
+    result = payload.get("data", {}).get("result", []) or []
+    if not result:
+        return _from_spec(spec, promql, status="no_data")
+
+    samples: list[dict[str, Any]] = []
+    for entry in result:
+        raw = entry.get("value")
+        if not raw or len(raw) < 2:
+            continue
+        try:
+            value = float(raw[1])
+        except (TypeError, ValueError):
+            continue
+        samples.append(
+            {
+                "labels": _labels(entry.get("metric", {})),
+                "value": value,
+                "timestamp": raw[0],
+            }
+        )
+
+    if not samples:
+        return _from_spec(spec, promql, status="no_data")
+
+    single = samples[0]["value"] if len(samples) == 1 else None
+    return _from_spec(spec, promql, status="ok", samples=samples, value=single)
+
+
+def parse_range_response(
+    spec: MetricSpec, payload: dict[str, Any], promql: str | None = None
+) -> SeriesResult:
+    """Turn a Prometheus range-query payload into a typed result."""
+    promql = promql if promql is not None else spec.promql
+
+    if payload.get("status") != "success":
+        detail = payload.get("error") or payload.get("errorType") or "unknown error"
+        return _from_spec(spec, promql, status="error", error=f"prometheus: {detail}")
+
+    result = payload.get("data", {}).get("result", []) or []
+    if not result:
+        return _from_spec(spec, promql, status="no_data")
+
+    samples: list[dict[str, Any]] = []
+    for entry in result:
+        points: list[tuple[Any, float]] = []
+        for raw in entry.get("values", []) or []:
+            if not raw or len(raw) < 2:
+                continue
+            try:
+                points.append((raw[0], float(raw[1])))
+            except (TypeError, ValueError):
+                continue
+        if not points:
+            continue
+        values = [v for _, v in points]
+        samples.append(
+            {
+                "labels": _labels(entry.get("metric", {})),
+                "points": len(points),
+                "min": min(values),
+                "max": max(values),
+                "first": values[0],
+                "last": values[-1],
+            }
+        )
+
+    if not samples:
+        return _from_spec(spec, promql, status="no_data")
+    return _from_spec(spec, promql, status="ok", samples=samples)
+
+
+def summarise_http_errors(error_count: float, total_count: float) -> dict[str, Any]:
+    """Pair an error percentage with the absolute counts behind it.
+
+    With no traffic there is no error rate to report. Returning `0%` there
+    would claim a healthy service on the strength of nobody having asked it
+    anything, so the percentage is `None` and the status is `no_data`.
+    """
+    if total_count <= 0:
+        return {
+            "status": "no_data",
+            "error_count": error_count,
+            "total_count": total_count,
+            "error_pct": None,
+        }
+    return {
+        "status": "ok",
+        "error_count": error_count,
+        "total_count": total_count,
+        "error_pct": 100.0 * error_count / total_count,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Transports
+# ---------------------------------------------------------------------------
+
+
+def default_fetch(url: str, headers: dict[str, str], timeout: float) -> tuple[int, bytes]:
+    """Perform one HTTP GET. Returns (status_code, body)."""
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return int(response.status), response.read()
+    except urllib.error.HTTPError as exc:  # a response, not a transport failure
+        return int(exc.code), exc.read()
+
+
+def default_runner(argv: list[str], timeout: float) -> tuple[int, str, str]:
+    """Run a command. Returns (returncode, stdout, stderr)."""
+    completed = subprocess.run(  # noqa: S603 - argv is allowlisted by assert_read_only
+        argv, capture_output=True, text=True, timeout=timeout, check=False
+    )
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def resolve_token(runner: Runner | None = None, env: dict[str, str] | None = None) -> str:
+    """Obtain a Fly API token without letting it touch the filesystem.
+
+    Prefers an existing environment token; otherwise captures `fly auth token`.
+    The value is returned for in-memory use as a header only.
+    """
+    import os
+
+    env = env if env is not None else dict(os.environ)
+    for name in ("FLY_API_TOKEN", "FLY_ACCESS_TOKEN"):
+        value = env.get(name)
+        if value:
+            return value.strip()
+
+    runner = runner or default_runner
+    code, out, err = runner(["fly", "auth", "token"], DEFAULT_TIMEOUT)
+    if code != 0 or not out.strip():
+        raise RuntimeError(
+            "could not obtain a Fly token: set FLY_API_TOKEN or run `fly auth login` "
+            f"(exit {code}: {redact(err.strip())})"
+        )
+    return out.strip()
+
+
+# ---------------------------------------------------------------------------
+# Window handling
+# ---------------------------------------------------------------------------
+
+_WINDOW_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def parse_window_seconds(window: str) -> int:
+    """Convert a PromQL-style duration such as `30m` or `6h` to seconds."""
+    match = re.fullmatch(r"(\d+)([smhd])", window.strip())
+    if not match:
+        raise ValueError(f"invalid window {window!r}: expected a form like 30m, 6h or 1d")
+    return int(match.group(1)) * _WINDOW_UNITS[match.group(2)]
+
+
+def _range_step(window_seconds: int) -> int:
+    """Pick a step that keeps a range query to roughly 100 points."""
+    return max(15, (window_seconds // 100 // 15 + 1) * 15)
+
+
+# ---------------------------------------------------------------------------
+# Collector
+# ---------------------------------------------------------------------------
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class Collector:
+    """Gathers one read-only observability snapshot for a single Fly app."""
+
+    def __init__(
+        self,
+        *,
+        app: str,
+        org: str,
+        window: str,
+        token: str,
+        fetch: Fetch | None = None,
+        runner: Runner | None = None,
+        include_logs: int = 0,
+        metrics_prefix: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        fly_binary: str = "fly",
+    ) -> None:
+        self.app = app
+        self.org = org
+        self.window = window
+        self.window_seconds = parse_window_seconds(window)
+        self._token = token
+        self.fetch = fetch or default_fetch
+        self.runner = runner or default_runner
+        self.include_logs = include_logs
+        self.metrics_prefix = metrics_prefix or app.replace("-", "_")
+        self.timeout = timeout
+        self.fly_binary = fly_binary
+
+    # -- redaction helper ------------------------------------------------
+
+    def _scrub(self, text: str) -> str:
+        return redact(text, secrets=[self._token])
+
+    # -- Prometheus ------------------------------------------------------
+
+    def _prom_url(self, path: str, params: dict[str, Any]) -> str:
+        base = f"{PROMETHEUS_BASE}/{urllib.parse.quote(self.org)}/api/v1/{path}"
+        return f"{base}?{urllib.parse.urlencode(params)}"
+
+    def _prom_get(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Query Prometheus. Raises with a scrubbed message on any failure."""
+        url = self._prom_url(path, params)
+        headers = {
+            "Authorization": f"{AUTH_SCHEME} {self._token}",
+            "Accept": "application/json",
+        }
+        try:
+            status, body = self.fetch(url, headers, self.timeout)
+        except Exception as exc:  # noqa: BLE001 - re-raised scrubbed below
+            raise RuntimeError(
+                f"{type(exc).__name__}: {self._scrub(str(exc))}"
+            ) from None
+
+        if status != 200:
+            detail = self._scrub(body.decode("utf-8", "replace"))[:300]
+            raise RuntimeError(f"HTTP {status} from Prometheus: {detail}")
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"malformed JSON from Prometheus: {exc}") from None
+
+    def _collect_one(self, spec: MetricSpec) -> SeriesResult:
+        promql = spec.render(app=self.app, window=self.window, prefix=self.metrics_prefix)
+        try:
+            if spec.kind == "range":
+                end = int(time.time())
+                payload = self._prom_get(
+                    "query_range",
+                    {
+                        "query": promql,
+                        "start": end - self.window_seconds,
+                        "end": end,
+                        "step": f"{_range_step(self.window_seconds)}s",
+                    },
+                )
+                return parse_range_response(spec, payload, promql)
+            payload = self._prom_get("query", {"query": promql})
+            return parse_instant_response(spec, payload, promql)
+        except Exception as exc:  # noqa: BLE001 - one series must not end the run
+            return _from_spec(spec, promql, status="error", error=self._scrub(str(exc)))
+
+    def collect_series(self) -> list[SeriesResult]:
+        """Collect every instant series. Never raises for a single failure."""
+        return [self._collect_one(spec) for spec in SERIES]
+
+    def collect_ranges(self) -> list[SeriesResult]:
+        """Collect every range series. Never raises for a single failure."""
+        return [self._collect_one(spec) for spec in RANGE_SERIES]
+
+    # -- flyctl ----------------------------------------------------------
+
+    def _run_fly(self, key: str, args: list[str]) -> dict[str, Any]:
+        assert_read_only(args)
+        argv = [self.fly_binary, *args]
+        entry: dict[str, Any] = {
+            "key": key,
+            "command": self._scrub(" ".join(argv)),
+            "status": "ok",
+            "data": None,
+            "error": None,
+        }
+        try:
+            code, out, err = self.runner(argv, self.timeout)
+        except Exception as exc:  # noqa: BLE001 - one command must not end the run
+            entry["status"] = "error"
+            entry["error"] = f"{type(exc).__name__}: {self._scrub(str(exc))}"
+            return entry
+
+        if code != 0:
+            entry["status"] = "error"
+            entry["error"] = self._scrub((err or out).strip())[:500] or f"exit {code}"
+            return entry
+
+        try:
+            entry["data"] = json.loads(out)
+        except json.JSONDecodeError as exc:
+            entry["status"] = "error"
+            entry["error"] = f"malformed JSON from flyctl: {exc}"
+        return entry
+
+    def collect_commands(self) -> list[dict[str, Any]]:
+        """Run the documented read-only flyctl commands.
+
+        Full payloads are reduced to selected fields — a Machine's config
+        carries its whole environment, and this report is meant to be readable
+        and shareable rather than a dump.
+        """
+        commands = [
+            self._run_fly("status", ["status", "--json", "-a", self.app]),
+            self._run_fly("checks", ["checks", "list", "--json", "-a", self.app]),
+            self._run_fly("image", ["image", "show", "--json", "-a", self.app]),
+        ]
+        for entry in commands:
+            if entry["status"] == "ok":
+                entry["data"] = _select_fields(entry["key"], entry["data"])
+        return commands
+
+    def collect_logs(self) -> dict[str, Any] | None:
+        """Collect a bounded log excerpt. Returns None unless opted in."""
+        if self.include_logs <= 0:
+            return None
+
+        args = ["logs", "--json", "--no-tail", "-a", self.app]
+        assert_read_only(args)
+        argv = [self.fly_binary, *args]
+
+        block: dict[str, Any] = {
+            "sensitive": True,
+            "requested_lines": self.include_logs,
+            "status": "ok",
+            "error": None,
+            "lines": [],
+            "command": self._scrub(" ".join(argv)),
+            "note": (
+                "Log lines are application output and may contain request detail. "
+                "Review before sharing; they are collected only on --include-logs."
+            ),
+        }
+
+        try:
+            code, out, err = self.runner(argv, self.timeout)
+        except Exception as exc:  # noqa: BLE001 - logs must not end the run
+            block["status"] = "error"
+            block["error"] = f"{type(exc).__name__}: {self._scrub(str(exc))}"
+            return block
+
+        if code != 0:
+            block["status"] = "error"
+            block["error"] = self._scrub((err or out).strip())[:500] or f"exit {code}"
+            return block
+
+        records = parse_log_stream(out)
+        if not records and out.strip():
+            block["status"] = "error"
+            block["error"] = (
+                "could not parse any JSON record from flyctl log output "
+                f"({len(out)} bytes); the --json shape may have changed"
+            )
+            return block
+
+        block["lines"] = _sanitise_log_records(records, self.include_logs, self._scrub)
+        return block
+
+    # -- the whole run ---------------------------------------------------
+
+    def run(self) -> dict[str, Any]:
+        started_at = _utc_now()
+        series = self.collect_series() + self.collect_ranges()
+        commands = self.collect_commands()
+        logs = self.collect_logs()
+        ended_at = _utc_now()
+
+        notes = [DASHBOARD_GAP_NOTE]
+        notes.extend(_interpretation_notes(series))
+
+        return build_report(
+            app=self.app,
+            org=self.org,
+            window=self.window,
+            started_at=started_at,
+            ended_at=ended_at,
+            series=series,
+            commands=commands,
+            logs=logs,
+            notes=notes,
+            metrics_prefix=self.metrics_prefix,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Field selection and sanitisation
+# ---------------------------------------------------------------------------
+
+
+def _select_fields(key: str, data: Any) -> Any:
+    """Keep the identity and health fields; drop config and environment."""
+    if key == "status" and isinstance(data, dict):
+        machines = data.get("Machines") or data.get("machines") or []
+        return {
+            "name": data.get("Name") or data.get("name"),
+            "hostname": data.get("Hostname") or data.get("hostname"),
+            "machines": [
+                {
+                    "id": m.get("id"),
+                    "state": m.get("state"),
+                    "region": m.get("region"),
+                    "image": ((m.get("config") or {}).get("image")),
+                    "created_at": m.get("created_at"),
+                    "updated_at": m.get("updated_at"),
+                }
+                for m in machines
+                if isinstance(m, dict)
+            ],
+        }
+    if key == "checks":
+        # `fly checks list --json` returns {machine_id: [check, ...]}. Older
+        # flyctl builds returned a flat list, so both shapes are accepted.
+        if isinstance(data, dict):
+            pairs = [
+                (machine, check)
+                for machine, checks in data.items()
+                if isinstance(checks, list)
+                for check in checks
+                if isinstance(check, dict)
+            ]
+        elif isinstance(data, list):
+            pairs = [(None, c) for c in data if isinstance(c, dict)]
+        else:
+            return None
+        return [
+            {
+                "machine": machine or c.get("Machine") or c.get("machine"),
+                "name": c.get("Name") or c.get("name"),
+                "status": c.get("Status") or c.get("status"),
+                "output": (c.get("Output") or c.get("output") or "")[:200],
+            }
+            for machine, c in pairs
+        ]
+    if key == "image":
+        # `fly image show --json` returns a list of image records.
+        records = data if isinstance(data, list) else [data] if isinstance(data, dict) else []
+        selected = [
+            {
+                k: record.get(k)
+                for k in ("Registry", "Repository", "Tag", "Digest", "Labels", "Version", "MachineID")
+                if k in record
+            }
+            for record in records
+            if isinstance(record, dict)
+        ]
+        return selected if isinstance(data, list) else (selected[0] if selected else None)
+    return None
+
+
+_LOG_FIELDS = ("timestamp", "level", "instance", "region", "message")
+
+
+def parse_log_stream(text: str) -> list[dict[str, Any]]:
+    """Parse `fly logs --json` output into records.
+
+    Verified against flyctl v0.4.95: the output is a stream of *pretty-printed*
+    JSON objects written one after another — not JSON-lines, and not a JSON
+    array. Splitting on newlines produces fragments such as `"URL": {`, so the
+    objects are decoded incrementally with `raw_decode` instead.
+    """
+    decoder = json.JSONDecoder()
+    records: list[dict[str, Any]] = []
+    index = 0
+    length = len(text)
+
+    while index < length:
+        while index < length and text[index] in " \t\r\n":
+            index += 1
+        if index >= length:
+            break
+        try:
+            obj, end = decoder.raw_decode(text, index)
+        except json.JSONDecodeError:
+            # Skip to the next plausible object start; a single malformed
+            # record must not discard the ones after it.
+            next_start = text.find("{", index + 1)
+            if next_start == -1:
+                break
+            index = next_start
+            continue
+        if isinstance(obj, dict):
+            records.append(obj)
+        index = end
+
+    return records
+
+
+def _sanitise_log_records(
+    records: list[Any], limit: int, scrub: Callable[[str], str]
+) -> list[dict[str, Any]]:
+    """Keep the most recent `limit` records, selected fields only, scrubbed."""
+    selected = []
+    for record in records[-limit:]:
+        if not isinstance(record, dict):
+            selected.append({"message": scrub(str(record))})
+            continue
+        selected.append(
+            {k: scrub(str(record[k])) for k in _LOG_FIELDS if k in record}
+        )
+    return selected
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+
+def _interpretation_notes(series: list[SeriesResult]) -> list[str]:
+    notes = []
+    missing = [s.key for s in series if s.status == "no_data"]
+    errored = [s.key for s in series if s.status == "error"]
+    if missing:
+        notes.append(
+            "no_data (absent series, NOT zero): " + ", ".join(sorted(missing))
+        )
+    if errored:
+        notes.append("collection errors: " + ", ".join(sorted(errored)))
+    return notes
+
+
+def build_report(
+    *,
+    app: str,
+    org: str,
+    window: str,
+    started_at: str,
+    ended_at: str,
+    series: list[SeriesResult],
+    commands: list[dict[str, Any]],
+    logs: dict[str, Any] | None,
+    notes: list[str],
+    metrics_prefix: str | None = None,
+) -> dict[str, Any]:
+    """Assemble the stable-schema report."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "target": {
+            "app": app,
+            "org": org,
+            "metrics_prefix": metrics_prefix or app.replace("-", "_"),
+        },
+        "query": {
+            "window": window,
+            "started_at": started_at,
+            "ended_at": ended_at,
+            "prometheus_base": f"{PROMETHEUS_BASE}/{org}/api/v1",
+        },
+        "series": [s.to_dict() for s in series],
+        "commands": commands,
+        "logs": logs,
+        "notes": notes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _format_value(value: float | None, unit: str) -> str:
+    if value is None:
+        return "—"
+    if unit == "bytes":
+        return f"{value:,.0f} ({value / 1024 ** 3:.2f} GiB)" if abs(value) >= 1024**2 else f"{value:,.0f}"
+    if value == int(value) and abs(value) < 1e15:
+        return f"{int(value):,}"
+    return f"{value:,.4g}"
+
+
+def _render_samples(result: SeriesResult) -> str:
+    if result.status != "ok" or not result.samples:
+        return ""
+    lines = []
+    for sample in result.samples:
+        labels = sample.get("labels", {})
+        label_text = ", ".join(f"{k}={v}" for k, v in sorted(labels.items())) or "(no labels)"
+        if result.kind == "range":
+            lines.append(
+                f"  - {label_text}: min={_format_value(sample['min'], result.unit)}, "
+                f"max={_format_value(sample['max'], result.unit)}, "
+                f"last={_format_value(sample['last'], result.unit)} "
+                f"({sample['points']} points)"
+            )
+        else:
+            lines.append(f"  - {label_text}: {_format_value(sample['value'], result.unit)}")
+    return "\n".join(lines)
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    """Render a concise interpretation of the report."""
+    target = report["target"]
+    query = report["query"]
+    out: list[str] = []
+
+    out.append(f"# Fly observability snapshot — `{target['app']}`")
+    out.append("")
+    out.append(f"- **App**: `{target['app']}` (org `{target['org']}`)")
+    out.append(f"- **Window**: `{query['window']}`")
+    out.append(f"- **Collected**: {query['started_at']} → {query['ended_at']} (UTC)")
+    out.append(f"- **Schema**: `{report['schema_version']}`")
+    out.append("")
+    out.append(
+        "`no_data` means the series has no samples — it is **not** a reading of zero. "
+        "`error` means collection failed and nothing was measured."
+    )
+    out.append("")
+
+    out.append("## Readings")
+    out.append("")
+    out.append("| Metric | Unit | Value | Status |")
+    out.append("|---|---|---|---|")
+    for entry in report["series"]:
+        status = entry["status"]
+        if status == "ok":
+            if entry["value"] is not None:
+                value = _format_value(entry["value"], entry["unit"])
+            else:
+                value = f"{len(entry['samples'])} series"
+        else:
+            value = "—"
+        title = entry["title"] + (" *(derived)*" if entry["derived"] else "")
+        out.append(f"| {title} | {entry['unit']} | {value} | `{status}` |")
+    out.append("")
+
+    # Single-sample `info` series carry everything they are worth in their
+    # labels — Machine ID, memory_mb, cpu_kind. Rendering just the value `1`
+    # would drop exactly the identity Phase D needs to record.
+    detailed = [
+        e
+        for e in report["series"]
+        if e["status"] == "ok" and (len(e["samples"]) > 1 or e["unit"] == "info")
+    ]
+    if detailed:
+        out.append("## Breakdowns")
+        out.append("")
+        for entry in detailed:
+            out.append(f"**{entry['title']}**")
+            result = SeriesResult(
+                key=entry["key"], title=entry["title"], promql=entry["promql"],
+                unit=entry["unit"], status=entry["status"], samples=entry["samples"],
+                kind=entry["kind"],
+            )
+            out.append(_render_samples(result))
+            out.append("")
+
+    problems = [e for e in report["series"] if e["status"] != "ok"]
+    if problems:
+        out.append("## Not measured")
+        out.append("")
+        out.append("| Metric | Status | Detail |")
+        out.append("|---|---|---|")
+        for entry in problems:
+            detail = entry["error"] or entry["note"] or "no samples in window"
+            out.append(f"| {entry['title']} | `{entry['status']}` | {detail} |")
+        out.append("")
+
+    out.append("## Commands")
+    out.append("")
+    for entry in report["commands"]:
+        out.append(f"- `{entry['command']}` → `{entry['status']}`"
+                   + (f" — {entry['error']}" if entry["error"] else ""))
+    out.append("")
+
+    if report["logs"] is not None:
+        logs = report["logs"]
+        out.append("## Logs")
+        out.append("")
+        out.append(
+            f"{len(logs['lines'])} line(s), requested {logs['requested_lines']}. "
+            "**Potentially sensitive** — review before sharing."
+        )
+        out.append("")
+
+    out.append("## Notes")
+    out.append("")
+    for note in report["notes"]:
+        out.append(f"- {note}")
+    out.append("")
+
+    out.append("## PromQL used")
+    out.append("")
+    for entry in report["series"]:
+        out.append(f"- **{entry['title']}** (`{entry['provenance']}`"
+                   + (", derived" if entry["derived"] else "") + ")")
+        out.append(f"  ```")
+        out.append(f"  {entry['promql']}")
+        out.append(f"  ```")
+        if entry["derivation"]:
+            out.append(f"  Derivation: {entry['derivation']}")
+    out.append("")
+
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def write_outputs(report: dict[str, Any], path: Path, force: bool = False) -> list[Path]:
+    """Write the JSON report and its Markdown rendering.
+
+    Refuses to overwrite by default: a before/after comparison is only worth
+    anything if the "before" is still there when the "after" is written.
+    """
+    json_path = Path(path)
+    md_path = json_path.with_suffix(".md")
+
+    if not force:
+        for existing in (json_path, md_path):
+            if existing.exists():
+                raise FileExistsError(
+                    f"{existing} already exists; pass --force to overwrite, or choose "
+                    "another --output so the earlier report survives"
+                )
+
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=False) + "\n")
+    md_path.write_text(render_markdown(report))
+    return [json_path, md_path]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Collect a read-only observability snapshot for a Fly.io app.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--app", required=True, help="Fly app name, e.g. property-shared")
+    parser.add_argument("--org", default="personal", help="Fly org slug (default: personal)")
+    parser.add_argument(
+        "--window", default="30m", help="Lookback window, e.g. 30m, 6h, 1d (default: 30m)"
+    )
+    parser.add_argument(
+        "--output", required=True, help="Path for the JSON report; .md is written alongside"
+    )
+    parser.add_argument(
+        "--include-logs",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Opt in to the most recent N sanitised log lines (default: 0, none)",
+    )
+    parser.add_argument(
+        "--metrics-prefix",
+        default=None,
+        help="Prefix for app-exposed metrics (default: the app name with - replaced by _)",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Overwrite an existing report at --output"
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=DEFAULT_TIMEOUT, help="Per-request timeout in seconds"
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        token = resolve_token()
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    collector = Collector(
+        app=args.app,
+        org=args.org,
+        window=args.window,
+        token=token,
+        include_logs=args.include_logs,
+        metrics_prefix=args.metrics_prefix,
+        timeout=args.timeout,
+    )
+    report = collector.run()
+    written = write_outputs(report, Path(args.output), force=args.force)
+
+    counts: dict[str, int] = {}
+    for entry in report["series"]:
+        counts[entry["status"]] = counts.get(entry["status"], 0) + 1
+    summary = ", ".join(f"{v} {k}" for k, v in sorted(counts.items()))
+    print(f"collected {len(report['series'])} series ({summary})")
+    for path in written:
+        print(f"wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fly_observability_snapshot.py
+++ b/scripts/fly_observability_snapshot.py
@@ -32,10 +32,12 @@ without them:
      an `Authorization` header, and scrubbed out of every string — including
      exception text — before anything is written or printed.
 
-What this collector does *not* measure: transient disk during a short
-operation. See `TRANSIENT_DISK_NOTE` — Fly stores one sample every 15 s, so
-these figures corroborate the verifier's own 0.2 s sampling rather than
-standing in for it.
+The report's `transient_disk` block states the free-space delta per mount as
+`baseline_free - minimum_free`, alongside the method, the resolution limit and
+the authoritative source. It is corroborating evidence only: Fly stores one
+sample every 15 s, so a short materialisation can hide almost entirely between
+samples. `/app/boot_only_verify.py`'s 0.2 s directory sampling is the real
+measurement. See `TRANSIENT_DISK_NOTE`.
 
 Usage:
     uv run python scripts/fly_observability_snapshot.py \\
@@ -70,7 +72,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
 
-SCHEMA_VERSION = "1"
+# 2: adds the top-level `transient_disk` block and `series[].no_data_reason`.
+# Nothing has consumed schema 1 — the collector has not shipped — so this is a
+# single bump rather than a compatibility shim.
+SCHEMA_VERSION = "2"
 PROMETHEUS_BASE = "https://api.fly.io/prometheus"
 REDACTION_PLACEHOLDER = "<redacted>"
 DEFAULT_TIMEOUT = 30.0
@@ -775,6 +780,55 @@ def summarise_transient_disk(
     }
 
 
+def derive_transient_disk(series: Sequence["SeriesResult"]) -> list[dict[str, Any]]:
+    """Build the corroborating free-space delta for each root-filesystem mount.
+
+    Reads the `range_rootfs_free` matrix — whose per-series `first` is the
+    free space at the start of the window and whose `min` is the low-water
+    mark — and pairs each mount with its total size purely for context.
+
+    Always returns at least one entry. An absent range series yields a
+    `no_data` entry rather than nothing, so the caveats travel with the report
+    even when there is no delta to state.
+    """
+    by_key = {result.key: result for result in series}
+
+    totals: dict[tuple[str, str], float] = {}
+    total_series = by_key.get("rootfs_total_bytes")
+    if total_series is not None and total_series.status == "ok":
+        for sample in total_series.samples:
+            labels = sample.get("labels", {})
+            key = (labels.get("instance", ""), labels.get("mount", ""))
+            totals[key] = sample["value"]
+
+    ranged = by_key.get("range_rootfs_free")
+    entries: list[dict[str, Any]] = []
+    if ranged is not None and ranged.status == "ok":
+        for sample in ranged.samples:
+            labels = sample.get("labels", {})
+            key = (labels.get("instance", ""), labels.get("mount", ""))
+            entry = summarise_transient_disk(
+                baseline_free_bytes=sample.get("first"),
+                minimum_free_bytes=sample.get("min"),
+                total_bytes=totals.get(key),
+            )
+            entry["labels"] = labels
+            entry["points"] = sample.get("points")
+            entries.append(entry)
+
+    if not entries:
+        entry = summarise_transient_disk(None, None, None)
+        entry["labels"] = {}
+        entry["points"] = 0
+        entry["detail"] = (
+            "no root-filesystem range samples in the window, so no delta could be "
+            "derived; see the range_rootfs_free series for why"
+        )
+        entries.append(entry)
+
+    return entries
+
+
 def summarise_http_errors(error_count: float, total_count: float) -> dict[str, Any]:
     """Pair an error percentage with the absolute counts behind it.
 
@@ -1271,6 +1325,7 @@ def build_report(
     notes: list[str],
     metrics_prefix: str | None = None,
     auth_scheme: str | None = None,
+    transient_disk: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Assemble the stable-schema report."""
     return {
@@ -1291,6 +1346,11 @@ def build_report(
             "scrape_interval_seconds": FLY_SCRAPE_INTERVAL_SECONDS,
         },
         "series": [s.to_dict() for s in series],
+        # Corroborating only — see TRANSIENT_DISK_NOTE and each entry's
+        # authoritative_source.
+        "transient_disk": (
+            transient_disk if transient_disk is not None else derive_transient_disk(series)
+        ),
         "commands": commands,
         "logs": logs,
         "notes": notes,
@@ -1387,6 +1447,34 @@ def render_markdown(report: dict[str, Any]) -> str:
             )
             out.append(_render_samples(result))
             out.append("")
+
+    transient = report.get("transient_disk") or []
+    if transient:
+        out.append("## Transient disk (corroborating, not authoritative)")
+        out.append("")
+        out.append("| Mount | Instance | Baseline free | Minimum free | Delta | Status |")
+        out.append("|---|---|---|---|---|---|")
+        for entry in transient:
+            labels = entry.get("labels") or {}
+            out.append(
+                "| {mount} | {instance} | {base} | {low} | {delta} | `{status}` |".format(
+                    mount=labels.get("mount", "—"),
+                    instance=labels.get("instance", "—"),
+                    base=_format_value(entry.get("baseline_free_bytes"), "bytes"),
+                    low=_format_value(entry.get("minimum_free_bytes"), "bytes"),
+                    delta=_format_value(entry.get("delta_bytes"), "bytes"),
+                    status=entry.get("status", "unknown"),
+                )
+            )
+        out.append("")
+        first = transient[0]
+        out.append(f"- Method: {first['method']}")
+        out.append(f"- Resolution: {first['resolution_caveat']}")
+        out.append(f"- Authoritative source: {first['authoritative_source']}")
+        for entry in transient:
+            if entry.get("detail"):
+                out.append(f"- {entry['detail']}")
+        out.append("")
 
     problems = [e for e in report["series"] if e["status"] != "ok"]
     if problems:

--- a/scripts/fly_observability_snapshot.py
+++ b/scripts/fly_observability_snapshot.py
@@ -22,13 +22,20 @@ without them:
   1. **`0` and "no data" are different answers.** An absent series is reported
      as `no_data` with a null value, never as zero. `fly_app_concurrency` has
      no series for this app, and a report that renders that as `0 connections`
-     is a lie about idle traffic.
+     is a lie about idle traffic. The same applies to NaN and ±Inf, which the
+     API really does return and which `float()` accepts without complaint: a
+     quantile over a histogram with no traffic is `NaN`, not a latency.
   2. **Partial failure stays partial.** One dead command or one unavailable
      series becomes a typed entry in the report; it never aborts the run and
      never silently becomes a number.
   3. **The token never lands anywhere.** It is read into memory, used only as
      an `Authorization` header, and scrubbed out of every string — including
      exception text — before anything is written or printed.
+
+What this collector does *not* measure: transient disk during a short
+operation. See `TRANSIENT_DISK_NOTE` — Fly stores one sample every 15 s, so
+these figures corroborate the verifier's own 0.2 s sampling rather than
+standing in for it.
 
 Usage:
     uv run python scripts/fly_observability_snapshot.py \\
@@ -40,12 +47,16 @@ Usage:
 
 Auth: reads `FLY_API_TOKEN` or `FLY_ACCESS_TOKEN` if set, otherwise captures
 `fly auth token` into memory. The token is never passed as a command argument.
+The `Authorization` scheme depends on the token type, so it is negotiated once
+per run and cached; `--auth-scheme` pins it. The negotiated scheme is recorded
+in the report, the token never is.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import string
 import subprocess
@@ -64,11 +75,21 @@ PROMETHEUS_BASE = "https://api.fly.io/prometheus"
 REDACTION_PLACEHOLDER = "<redacted>"
 DEFAULT_TIMEOUT = 30.0
 
-# flyctl authenticates with a macaroon. It is sent as `Authorization: FlyV1
-# <token>`; `Bearer <token>` is rejected with 401 "something went wrong
-# resolving organization", which reads like a permissions problem rather than
-# an auth-scheme one, so it is worth stating plainly here.
-AUTH_SCHEME = "FlyV1"
+# The Authorization scheme depends on the *token type*, not on the endpoint.
+# Verified 2026-09-01: a macaroon from `fly auth token` (fm2_...) is accepted
+# as `FlyV1 <token>` and rejected 401 as `Bearer <token>` — with the message
+# "something went wrong resolving organization", which reads like a
+# permissions problem rather than an auth-scheme one. Tokens minted by
+# `fly tokens create` take the other scheme. Only one token type has been
+# observed here, so the scheme is negotiated once per run and cached rather
+# than hard-coded; `--auth-scheme` overrides the negotiation.
+AUTH_SCHEMES: tuple[str, ...] = ("FlyV1", "Bearer")
+
+# Fly's stored resolution, measured on 2026-09-01 with
+# `timestamp(fly_instance_filesystem_blocks_free{...})` over a range query:
+# consecutive distinct sample timestamps are exactly 15 s apart, for both the
+# built-in instance metrics and the app's own scraped metrics.
+FLY_SCRAPE_INTERVAL_SECONDS = 15
 
 DASHBOARD_GAP_NOTE = (
     "No Grafana dashboard titled 'BOUCH MCP Fleet' is checked in anywhere under "
@@ -297,12 +318,25 @@ SERIES: tuple[MetricSpec, ...] = (
     MetricSpec(
         key="rootfs_free_bytes_min",
         title="Root filesystem free, minimum over window",
-        promql=f"min_over_time(({_FS_FREE})[$window:1m])",
+        promql=(
+            f"min_over_time(({_FS_FREE})[$window:{FLY_SCRAPE_INTERVAL_SECONDS}s])"
+        ),
         unit="bytes",
         derived=True,
         derivation=(
-            "min_over_time of (blocks_free * block_size) sampled at 1m over the window. "
-            "The low-water mark; peak transient disk use is total minus this."
+            "min_over_time of (blocks_free * block_size) on the same mount, sampled at "
+            f"{FLY_SCRAPE_INTERVAL_SECONDS}s (Fly's real stored resolution) over the "
+            "window. This is the free-space low-water mark, nothing more. The "
+            "additional space a run consumed is baseline_free - minimum_free on that "
+            "mount — see summarise_transient_disk(). It is NOT total_bytes - "
+            "minimum_free, which is total disk in use including the image and "
+            "everything already present."
+        ),
+        note=(
+            f"Corroborating only. At {FLY_SCRAPE_INTERVAL_SECONDS}s resolution a "
+            "materialisation lasting ~20 s yields one or two samples and its true peak "
+            "can fall entirely between them. The verifier's own 0.2 s directory "
+            "sampling is the authoritative transient-disk measurement."
         ),
     ),
     MetricSpec(
@@ -536,6 +570,10 @@ class SeriesResult:
     samples: list[dict[str, Any]] = field(default_factory=list)
     value: float | None = None
     error: str | None = None
+    # Why a no_data result is empty: `empty_result` (the query matched no
+    # series at all) or `non_finite` (series matched, but every value was NaN
+    # or ±Inf). The two mean different things to a reader.
+    no_data_reason: str | None = None
     kind: str = "instant"
     provenance: str = "fly_builtin"
     derived: bool = False
@@ -553,6 +591,7 @@ class SeriesResult:
             "value": self.value,
             "samples": self.samples,
             "error": self.error,
+            "no_data_reason": self.no_data_reason,
             "provenance": self.provenance,
             "derived": self.derived,
             "derivation": self.derivation,
@@ -579,6 +618,25 @@ def _labels(metric: dict[str, str]) -> dict[str, str]:
     return {k: v for k, v in metric.items() if k != "__name__"}
 
 
+def _coerce_finite(raw: Any) -> float | None:
+    """Parse a Prometheus sample value, rejecting anything non-finite.
+
+    Prometheus returns values as strings, and `float()` cheerfully accepts
+    `"NaN"`, `"+Inf"` and `"-Inf"` — all three of which the live API does emit
+    (`1/0` returns `+Inf`; a quantile over a histogram with no traffic returns
+    `NaN`). Reporting those as measurements is precisely the confusion this
+    script exists to prevent, and `json.dumps` would then write bare `NaN` /
+    `Infinity`, which is not valid JSON. `None` means "not a measurement".
+    """
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
+
+
 def parse_instant_response(
     spec: MetricSpec, payload: dict[str, Any], promql: str | None = None
 ) -> SeriesResult:
@@ -591,16 +649,15 @@ def parse_instant_response(
 
     result = payload.get("data", {}).get("result", []) or []
     if not result:
-        return _from_spec(spec, promql, status="no_data")
+        return _from_spec(spec, promql, status="no_data", no_data_reason="empty_result")
 
     samples: list[dict[str, Any]] = []
     for entry in result:
         raw = entry.get("value")
         if not raw or len(raw) < 2:
             continue
-        try:
-            value = float(raw[1])
-        except (TypeError, ValueError):
+        value = _coerce_finite(raw[1])
+        if value is None:
             continue
         samples.append(
             {
@@ -611,7 +668,9 @@ def parse_instant_response(
         )
 
     if not samples:
-        return _from_spec(spec, promql, status="no_data")
+        # The query matched series but every value was NaN, ±Inf or
+        # unparseable — a different fact from "there is no such series".
+        return _from_spec(spec, promql, status="no_data", no_data_reason="non_finite")
 
     single = samples[0]["value"] if len(samples) == 1 else None
     return _from_spec(spec, promql, status="ok", samples=samples, value=single)
@@ -629,7 +688,7 @@ def parse_range_response(
 
     result = payload.get("data", {}).get("result", []) or []
     if not result:
-        return _from_spec(spec, promql, status="no_data")
+        return _from_spec(spec, promql, status="no_data", no_data_reason="empty_result")
 
     samples: list[dict[str, Any]] = []
     for entry in result:
@@ -637,10 +696,11 @@ def parse_range_response(
         for raw in entry.get("values", []) or []:
             if not raw or len(raw) < 2:
                 continue
-            try:
-                points.append((raw[0], float(raw[1])))
-            except (TypeError, ValueError):
+            value = _coerce_finite(raw[1])
+            if value is None:
+                # A single +Inf must not become the reported maximum.
                 continue
+            points.append((raw[0], value))
         if not points:
             continue
         values = [v for _, v in points]
@@ -656,8 +716,63 @@ def parse_range_response(
         )
 
     if not samples:
-        return _from_spec(spec, promql, status="no_data")
+        return _from_spec(spec, promql, status="no_data", no_data_reason="non_finite")
     return _from_spec(spec, promql, status="ok", samples=samples)
+
+
+TRANSIENT_DISK_NOTE = (
+    "Transient disk from this collector is corroborating evidence, never the "
+    "measurement. The additional space a run consumed on a mount is "
+    "baseline_free - minimum_free on that same mount; total_bytes - minimum_free "
+    "would instead report total disk in use at the low-water mark, including the "
+    f"image and everything already present. Fly stores samples every "
+    f"{FLY_SCRAPE_INTERVAL_SECONDS}s, so a ~20 s materialisation yields one or two "
+    "samples and its true peak can fall entirely between them. "
+    "/app/boot_only_verify.py samples the verifier directory every 0.2 s and is the "
+    "authoritative transient-disk measurement."
+)
+
+
+def summarise_transient_disk(
+    baseline_free_bytes: float | None,
+    minimum_free_bytes: float | None,
+    total_bytes: float | None = None,
+) -> dict[str, Any]:
+    """Describe the free-space delta across a window, with its limits.
+
+    `total_bytes` is accepted and echoed for context only; it deliberately
+    plays no part in the delta, because subtracting the low-water mark from
+    the filesystem size measures total occupancy rather than what a particular
+    run added.
+    """
+    if baseline_free_bytes is None or minimum_free_bytes is None:
+        delta: float | None = None
+        status = "no_data"
+    else:
+        delta = baseline_free_bytes - minimum_free_bytes
+        status = "ok"
+
+    return {
+        "status": status,
+        "baseline_free_bytes": baseline_free_bytes,
+        "minimum_free_bytes": minimum_free_bytes,
+        "total_bytes": total_bytes,
+        "delta_bytes": delta,
+        "method": (
+            "delta_bytes = baseline_free - minimum_free, on one mount. Not "
+            "total_bytes - minimum_free, which measures total occupancy."
+        ),
+        "resolution_caveat": (
+            f"Fly stores one sample per {FLY_SCRAPE_INTERVAL_SECONDS}s. A "
+            "materialisation lasting ~20 s produces one or two samples, so this "
+            "delta may understate the true peak or miss it entirely."
+        ),
+        "authoritative_source": (
+            "/app/boot_only_verify.py, which samples the verifier directory every "
+            "0.2 s, is the authoritative transient-disk measurement; this delta only "
+            "corroborates it."
+        ),
+    }
 
 
 def summarise_http_errors(error_count: float, total_count: float) -> dict[str, Any]:
@@ -774,6 +889,7 @@ class Collector:
         metrics_prefix: str | None = None,
         timeout: float = DEFAULT_TIMEOUT,
         fly_binary: str = "fly",
+        auth_scheme: str | None = None,
     ) -> None:
         self.app = app
         self.org = org
@@ -786,6 +902,10 @@ class Collector:
         self.metrics_prefix = metrics_prefix or app.replace("-", "_")
         self.timeout = timeout
         self.fly_binary = fly_binary
+        # None until negotiated on the first Prometheus request, then cached
+        # for the rest of the run. An explicit scheme skips negotiation.
+        self.auth_scheme: str | None = auth_scheme
+        self._auth_failed: str | None = None
 
     # -- redaction helper ------------------------------------------------
 
@@ -798,19 +918,52 @@ class Collector:
         base = f"{PROMETHEUS_BASE}/{urllib.parse.quote(self.org)}/api/v1/{path}"
         return f"{base}?{urllib.parse.urlencode(params)}"
 
-    def _prom_get(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
-        """Query Prometheus. Raises with a scrubbed message on any failure."""
-        url = self._prom_url(path, params)
+    def _attempt(
+        self, url: str, scheme: str
+    ) -> tuple[int, bytes]:
+        """One authenticated GET. The token exists only in this header."""
         headers = {
-            "Authorization": f"{AUTH_SCHEME} {self._token}",
+            "Authorization": f"{scheme} {self._token}",
             "Accept": "application/json",
         }
         try:
-            status, body = self.fetch(url, headers, self.timeout)
+            return self.fetch(url, headers, self.timeout)
         except Exception as exc:  # noqa: BLE001 - re-raised scrubbed below
             raise RuntimeError(
                 f"{type(exc).__name__}: {self._scrub(str(exc))}"
             ) from None
+
+    def _prom_get(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Query Prometheus. Raises with a scrubbed message on any failure.
+
+        On the first request the Authorization scheme is negotiated: each
+        candidate is tried in turn until one is not rejected, and the winner
+        is cached for the rest of the run. Only an auth rejection (401/403)
+        advances to the next candidate — any other status is that request's
+        real answer and is reported as such.
+        """
+        url = self._prom_url(path, params)
+        if self._auth_failed:
+            # Every scheme was already rejected once. Re-probing per series
+            # would hammer the API with a token that cannot work.
+            raise RuntimeError(self._auth_failed)
+
+        candidates = [self.auth_scheme] if self.auth_scheme else list(AUTH_SCHEMES)
+
+        status, body = -1, b""
+        for scheme in candidates:
+            assert scheme is not None
+            status, body = self._attempt(url, scheme)
+            if status not in (401, 403):
+                self.auth_scheme = scheme
+                break
+        else:
+            detail = self._scrub(body.decode("utf-8", "replace"))[:200]
+            self._auth_failed = (
+                f"HTTP {status} from Prometheus for every Authorization scheme tried "
+                f"({', '.join(str(c) for c in candidates)}): {detail}"
+            )
+            raise RuntimeError(self._auth_failed)
 
         if status != 200:
             detail = self._scrub(body.decode("utf-8", "replace"))[:300]
@@ -951,7 +1104,7 @@ class Collector:
         logs = self.collect_logs()
         ended_at = _utc_now()
 
-        notes = [DASHBOARD_GAP_NOTE]
+        notes = [DASHBOARD_GAP_NOTE, TRANSIENT_DISK_NOTE]
         notes.extend(_interpretation_notes(series))
 
         return build_report(
@@ -965,6 +1118,7 @@ class Collector:
             logs=logs,
             notes=notes,
             metrics_prefix=self.metrics_prefix,
+            auth_scheme=self.auth_scheme,
         )
 
 
@@ -1116,6 +1270,7 @@ def build_report(
     logs: dict[str, Any] | None,
     notes: list[str],
     metrics_prefix: str | None = None,
+    auth_scheme: str | None = None,
 ) -> dict[str, Any]:
     """Assemble the stable-schema report."""
     return {
@@ -1130,6 +1285,10 @@ def build_report(
             "started_at": started_at,
             "ended_at": ended_at,
             "prometheus_base": f"{PROMETHEUS_BASE}/{org}/api/v1",
+            # Which Authorization scheme the token turned out to need. The
+            # scheme is not a secret; the token it accompanied never appears.
+            "auth_scheme": auth_scheme,
+            "scrape_interval_seconds": FLY_SCRAPE_INTERVAL_SECONDS,
         },
         "series": [s.to_dict() for s in series],
         "commands": commands,
@@ -1236,7 +1395,14 @@ def render_markdown(report: dict[str, Any]) -> str:
         out.append("| Metric | Status | Detail |")
         out.append("|---|---|---|")
         for entry in problems:
-            detail = entry["error"] or entry["note"] or "no samples in window"
+            reason = entry.get("no_data_reason")
+            if reason == "non_finite":
+                prefix = "series matched but every value was NaN or ±Inf — not a reading. "
+            elif reason == "empty_result":
+                prefix = "query matched no series. "
+            else:
+                prefix = ""
+            detail = prefix + (entry["error"] or entry["note"] or "no samples in window")
             out.append(f"| {entry['title']} | `{entry['status']}` | {detail} |")
         out.append("")
 
@@ -1300,8 +1466,14 @@ def write_outputs(report: dict[str, Any], path: Path, force: bool = False) -> li
                     "another --output so the earlier report survives"
                 )
 
+    # allow_nan=False: Python would otherwise emit bare `NaN` / `Infinity`,
+    # which no strict JSON parser accepts. A non-finite value reaching here
+    # means the parser guards were bypassed, and that must fail loudly rather
+    # than produce a report that reads fine and cannot be loaded.
+    serialised = json.dumps(report, indent=2, sort_keys=False, allow_nan=False)
+
     json_path.parent.mkdir(parents=True, exist_ok=True)
-    json_path.write_text(json.dumps(report, indent=2, sort_keys=False) + "\n")
+    json_path.write_text(serialised + "\n")
     md_path.write_text(render_markdown(report))
     return [json_path, md_path]
 
@@ -1337,6 +1509,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Prefix for app-exposed metrics (default: the app name with - replaced by _)",
     )
     parser.add_argument(
+        "--auth-scheme",
+        choices=("auto", *AUTH_SCHEMES),
+        default="auto",
+        help=(
+            "Authorization scheme for the Prometheus API. Default 'auto' tries "
+            f"{' then '.join(AUTH_SCHEMES)} and caches whichever the token accepts."
+        ),
+    )
+    parser.add_argument(
         "--force", action="store_true", help="Overwrite an existing report at --output"
     )
     parser.add_argument(
@@ -1362,6 +1543,7 @@ def main(argv: list[str] | None = None) -> int:
         include_logs=args.include_logs,
         metrics_prefix=args.metrics_prefix,
         timeout=args.timeout,
+        auth_scheme=None if args.auth_scheme == "auto" else args.auth_scheme,
     )
     report = collector.run()
     written = write_outputs(report, Path(args.output), force=args.force)

--- a/tests/test_fly_observability_snapshot.py
+++ b/tests/test_fly_observability_snapshot.py
@@ -1,0 +1,722 @@
+"""Tests for the read-only Fly observability collector.
+
+The collector is an operator script, not a package module, so it is loaded by
+path. Every test here drives it through injected transports — a fake Prometheus
+`fetch` and a fake `flyctl` runner — so the suite never touches the network,
+never shells out, and never needs a Fly token.
+
+The negative tests carry most of the weight. This script exists to produce
+evidence for a production rollout gate, so the failure modes that would quietly
+corrupt that evidence — a missing series rendering as `0`, one dead command
+erasing the rest of the report, a token reaching disk — are the ones asserted
+hardest.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "fly_observability_snapshot.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("fly_observability_snapshot", _MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fos = _load_module()
+
+FAKE_TOKEN = "fm2_lJPECAAAAAAAtesttokenvalue0000000000000xyz"
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+
+
+def _vector(*samples: tuple[dict[str, str], str]) -> dict[str, Any]:
+    return {
+        "status": "success",
+        "data": {
+            "resultType": "vector",
+            "result": [
+                {"metric": labels, "value": [1788221858, value]} for labels, value in samples
+            ],
+        },
+    }
+
+
+_EMPTY_VECTOR = {"status": "success", "data": {"resultType": "vector", "result": []}}
+
+
+class FakeFetch:
+    """Stands in for the HTTP transport. Records every call it is given."""
+
+    def __init__(self, responses: dict[str, Any] | None = None, default: Any = None) -> None:
+        self.responses = responses or {}
+        self.default = default if default is not None else _EMPTY_VECTOR
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, url: str, headers: dict[str, str], timeout: float) -> tuple[int, bytes]:
+        self.calls.append({"url": url, "headers": dict(headers), "timeout": timeout})
+        for needle, response in self.responses.items():
+            if needle in url:
+                if isinstance(response, Exception):
+                    raise response
+                status, payload = response
+                return status, json.dumps(payload).encode()
+        return 200, json.dumps(self.default).encode()
+
+
+class FakeRunner:
+    """Stands in for subprocess execution of `flyctl`."""
+
+    def __init__(self, results: dict[str, tuple[int, str, str]] | None = None) -> None:
+        self.results = results or {}
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: list[str], timeout: float) -> tuple[int, str, str]:
+        self.calls.append(list(argv))
+        for needle, result in self.results.items():
+            if needle in " ".join(argv):
+                return result
+        return 0, "{}", ""
+
+
+def _collector(fetch: Any = None, runner: Any = None, **kwargs: Any) -> Any:
+    return fos.Collector(
+        app="property-shared",
+        org="personal",
+        window="30m",
+        token=FAKE_TOKEN,
+        fetch=fetch or FakeFetch(),
+        runner=runner or FakeRunner(),
+        **kwargs,
+    )
+
+
+# --------------------------------------------------------------------------
+# Zero versus no_data — the distinction the whole report depends on
+# --------------------------------------------------------------------------
+
+
+def test_empty_prometheus_result_is_no_data_not_zero() -> None:
+    """An absent series must never be reportable as the number 0."""
+    spec = fos.MetricSpec(
+        key="app_concurrency",
+        title="App concurrency",
+        promql='fly_app_concurrency{app="property-shared"}',
+        unit="connections",
+    )
+
+    result = fos.parse_instant_response(spec, _EMPTY_VECTOR)
+
+    assert result.status == "no_data"
+    assert result.samples == []
+    assert result.value is None
+
+
+def test_zero_valued_sample_is_reported_as_a_real_zero() -> None:
+    """A genuine 0 reading is data, and must survive as 0.0 with status ok."""
+    spec = fos.MetricSpec(
+        key="load5",
+        title="Load average (5m)",
+        promql='fly_instance_load_average{app="property-shared",minutes="5"}',
+        unit="load",
+    )
+    payload = _vector(({"app": "property-shared", "minutes": "5"}, "0"))
+
+    result = fos.parse_instant_response(spec, payload)
+
+    assert result.status == "ok"
+    assert result.value == 0.0
+    assert result.samples[0]["value"] == 0.0
+
+
+def test_markdown_renders_no_data_distinctly_from_zero() -> None:
+    """The rendered report must not let a gap read as a measurement."""
+    zero = fos.SeriesResult(
+        key="load5", title="Load average (5m)", promql="q", unit="load",
+        status="ok", samples=[{"labels": {}, "value": 0.0}], value=0.0,
+    )
+    missing = fos.SeriesResult(
+        key="app_concurrency", title="App concurrency", promql="q", unit="connections",
+        status="no_data", samples=[], value=None,
+    )
+
+    rendered = fos.render_markdown(
+        fos.build_report(
+            app="property-shared", org="personal", window="30m",
+            started_at="2026-09-01T12:00:00Z", ended_at="2026-09-01T12:00:04Z",
+            series=[zero, missing], commands=[], logs=None, notes=[],
+        )
+    )
+
+    assert "no_data" in rendered
+    load_line = next(ln for ln in rendered.splitlines() if "Load average (5m)" in ln)
+    conc_line = next(ln for ln in rendered.splitlines() if "App concurrency" in ln)
+    assert "0" in load_line
+    assert "no_data" in conc_line
+    assert "0" not in conc_line.split("no_data")[0].split("|")[-1]
+
+
+# --------------------------------------------------------------------------
+# Partial failure must stay partial
+# --------------------------------------------------------------------------
+
+
+def test_http_failure_on_one_series_does_not_erase_the_others() -> None:
+    fetch = FakeFetch(
+        responses={
+            "fly_instance_memory_mem_available": (503, {"error": "upstream down"}),
+        },
+        default=_vector(({"app": "property-shared"}, "1"),),
+    )
+    collector = _collector(fetch=fetch)
+
+    results = collector.collect_series()
+    by_key = {r.key: r for r in results}
+    failed = [r for r in results if r.status == "error"]
+    succeeded = [r for r in results if r.status == "ok"]
+
+    assert failed, "expected the injected 503 to surface as a typed error entry"
+    assert succeeded, "one failed series must not erase the rest of the report"
+    assert all(r.value is None for r in failed)
+    assert any("503" in (r.error or "") for r in failed)
+    assert "memory_available" in by_key
+
+
+def test_transport_exception_becomes_a_typed_error_entry() -> None:
+    fetch = FakeFetch(
+        responses={"fly_instance_cpu": OSError("connection reset by peer")},
+        default=_EMPTY_VECTOR,
+    )
+    collector = _collector(fetch=fetch)
+
+    results = collector.collect_series()
+    errored = [r for r in results if r.status == "error"]
+
+    assert errored
+    assert any("connection reset" in (r.error or "") for r in errored)
+
+
+def test_prometheus_error_status_is_an_error_not_no_data() -> None:
+    spec = fos.MetricSpec(key="k", title="T", promql="q", unit="u")
+    payload = {"status": "error", "errorType": "bad_data", "error": "invalid expression"}
+
+    result = fos.parse_instant_response(spec, payload)
+
+    assert result.status == "error"
+    assert "invalid expression" in (result.error or "")
+    assert result.value is None
+
+
+def test_malformed_flyctl_json_is_reported_not_crashed_on() -> None:
+    runner = FakeRunner(results={"status": (0, "not json at all {{{", "")})
+    collector = _collector(runner=runner)
+
+    commands = collector.collect_commands()
+    status_entry = next(c for c in commands if c["key"] == "status")
+
+    assert status_entry["status"] == "error"
+    assert "json" in status_entry["error"].lower()
+    assert status_entry["data"] is None
+    assert any(c["status"] == "ok" for c in commands), "other commands must still run"
+
+
+def test_failing_flyctl_command_is_reported_with_its_exit_code() -> None:
+    runner = FakeRunner(results={"image show": (1, "", "Error: no access to app")})
+    collector = _collector(runner=runner)
+
+    commands = collector.collect_commands()
+    entry = next(c for c in commands if c["key"] == "image")
+
+    assert entry["status"] == "error"
+    assert "no access to app" in entry["error"]
+
+
+# --------------------------------------------------------------------------
+# Token safety
+# --------------------------------------------------------------------------
+
+
+def test_token_never_appears_in_rendered_report_or_json() -> None:
+    fetch = FakeFetch(default=_vector(({"app": "property-shared"}, "1")))
+    collector = _collector(fetch=fetch)
+
+    report = collector.run()
+    as_json = json.dumps(report)
+    as_markdown = fos.render_markdown(report)
+
+    assert FAKE_TOKEN not in as_json
+    assert FAKE_TOKEN not in as_markdown
+    assert "fm2_" not in as_json
+    assert "fm2_" not in as_markdown
+
+
+def test_token_is_never_passed_as_a_command_argument() -> None:
+    runner = FakeRunner()
+    collector = _collector(runner=runner)
+
+    collector.collect_commands()
+
+    for argv in runner.calls:
+        joined = " ".join(argv)
+        assert FAKE_TOKEN not in joined
+        assert "fm2_" not in joined
+
+
+def test_token_is_sent_only_as_an_in_memory_authorization_header() -> None:
+    fetch = FakeFetch()
+    collector = _collector(fetch=fetch)
+
+    collector.collect_series()
+
+    assert fetch.calls
+    for call in fetch.calls:
+        assert FAKE_TOKEN not in call["url"]
+        assert call["headers"]["Authorization"] == f"FlyV1 {FAKE_TOKEN}"
+
+
+def test_token_leaked_into_an_exception_is_redacted_before_it_is_stored() -> None:
+    """urllib puts the failing URL in the exception; a token must not ride along."""
+    leaky = RuntimeError(f"failed calling https://api.fly.io/x?token={FAKE_TOKEN}")
+    fetch = FakeFetch(responses={"fly_instance_cpu": leaky}, default=_EMPTY_VECTOR)
+    collector = _collector(fetch=fetch)
+
+    results = collector.collect_series()
+    blob = json.dumps([r.to_dict() for r in results])
+
+    assert FAKE_TOKEN not in blob
+    assert "fm2_" not in blob
+    assert fos.REDACTION_PLACEHOLDER in blob
+
+
+def test_redact_removes_macaroon_tokens_it_was_not_told_about() -> None:
+    other = "FlyV1 fm2_lJPECAAAAAAAsomeothertokenvalue999"
+    scrubbed = fos.redact(f"boom: {other}", secrets=[FAKE_TOKEN])
+
+    assert "fm2_" not in scrubbed
+    assert fos.REDACTION_PLACEHOLDER in scrubbed
+
+
+# --------------------------------------------------------------------------
+# Read-only enforcement
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["deploy"],
+        ["secrets", "set", "PPD_SNAPSHOT_ENABLED=1"],
+        ["machine", "update", "7849207a412608"],
+        ["scale", "count", "2"],
+        ["apps", "destroy", "property-shared"],
+        ["ssh", "console"],
+    ],
+)
+def test_mutating_fly_subcommands_are_refused(argv: list[str]) -> None:
+    with pytest.raises(fos.ReadOnlyViolation):
+        fos.assert_read_only(argv)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["status", "--json"],
+        ["checks", "list", "--json"],
+        ["image", "show", "--json"],
+        ["logs", "--json", "--no-tail"],
+    ],
+)
+def test_documented_read_only_commands_are_allowed(argv: list[str]) -> None:
+    fos.assert_read_only(argv)
+
+
+def test_every_command_the_collector_issues_is_read_only() -> None:
+    runner = FakeRunner()
+    collector = _collector(runner=runner, include_logs=25)
+
+    collector.collect_commands()
+
+    assert runner.calls
+    for argv in runner.calls:
+        fos.assert_read_only([a for a in argv if a not in ("fly", "flyctl")])
+
+
+# --------------------------------------------------------------------------
+# Error percentages, derived values, provenance
+# --------------------------------------------------------------------------
+
+
+def test_error_percentage_is_paired_with_absolute_counts() -> None:
+    responses = {
+        "5xx": (200, _vector(({"status": "500"}, "3"))),
+        "responses_total": (200, _vector(({}, "200"))),
+    }
+    summary = fos.summarise_http_errors(error_count=3.0, total_count=200.0)
+
+    assert summary["error_count"] == 3.0
+    assert summary["total_count"] == 200.0
+    assert summary["error_pct"] == pytest.approx(1.5)
+    assert responses  # fixture kept adjacent to the arithmetic it describes
+
+
+def test_error_percentage_with_no_traffic_is_no_data_not_zero_percent() -> None:
+    summary = fos.summarise_http_errors(error_count=0.0, total_count=0.0)
+
+    assert summary["error_pct"] is None
+    assert summary["status"] == "no_data"
+    assert summary["total_count"] == 0.0
+
+
+def test_derived_series_declare_their_derivation_and_promql() -> None:
+    derived = [s for s in fos.SERIES if s.derived]
+
+    assert derived, "free rootfs bytes is computed from blocks * block size"
+    for spec in derived:
+        assert spec.derivation, f"{spec.key} is derived but does not say how"
+        assert spec.promql
+
+
+def test_report_records_the_provenance_of_every_series() -> None:
+    for spec in fos.SERIES:
+        assert spec.provenance in {"fly_builtin", "app_custom"}
+
+
+def test_no_series_is_sourced_from_the_missing_fleet_dashboard() -> None:
+    """The BOUCH MCP Fleet dashboard was not found; nothing may claim it."""
+    assert all(s.provenance != "dashboard" for s in fos.SERIES)
+    assert fos.DASHBOARD_GAP_NOTE
+
+
+# --------------------------------------------------------------------------
+# Timestamps, window, schema, output
+# --------------------------------------------------------------------------
+
+
+def test_report_records_utc_query_start_and_end_and_the_window() -> None:
+    report = fos.build_report(
+        app="property-shared", org="personal", window="30m",
+        started_at="2026-09-01T12:00:00Z", ended_at="2026-09-01T12:00:04Z",
+        series=[], commands=[], logs=None, notes=[],
+    )
+
+    assert report["query"]["started_at"].endswith("Z")
+    assert report["query"]["ended_at"].endswith("Z")
+    assert report["query"]["window"] == "30m"
+    assert report["schema_version"] == fos.SCHEMA_VERSION
+
+
+def test_report_has_a_stable_top_level_schema() -> None:
+    report = fos.build_report(
+        app="a", org="o", window="30m",
+        started_at="2026-09-01T12:00:00Z", ended_at="2026-09-01T12:00:04Z",
+        series=[], commands=[], logs=None, notes=[],
+    )
+
+    assert set(report) == {
+        "schema_version", "target", "query", "series", "commands", "logs", "notes",
+    }
+
+
+def test_writing_a_report_refuses_to_overwrite_an_existing_one(tmp_path: Path) -> None:
+    """Before/after comparison is worthless if the baseline can be clobbered."""
+    out = tmp_path / "baseline.json"
+    out.write_text('{"schema_version": "1"}')
+
+    with pytest.raises(FileExistsError):
+        fos.write_outputs({"schema_version": "1"}, out, force=False)
+
+    assert out.read_text() == '{"schema_version": "1"}'
+
+
+def test_writing_a_report_creates_both_json_and_markdown(tmp_path: Path) -> None:
+    out = tmp_path / "run.json"
+    report = fos.build_report(
+        app="property-shared", org="personal", window="30m",
+        started_at="2026-09-01T12:00:00Z", ended_at="2026-09-01T12:00:04Z",
+        series=[], commands=[], logs=None, notes=[],
+    )
+
+    written = fos.write_outputs(report, out, force=False)
+
+    assert out.exists()
+    assert out.with_suffix(".md").exists()
+    assert set(written) == {out, out.with_suffix(".md")}
+
+
+# --------------------------------------------------------------------------
+# Logs are opt-in and bounded
+# --------------------------------------------------------------------------
+
+
+def test_logs_are_not_collected_by_default() -> None:
+    runner = FakeRunner()
+    collector = _collector(runner=runner)
+
+    report = collector.run()
+
+    assert report["logs"] is None
+    assert not any("logs" in " ".join(argv) for argv in runner.calls)
+
+
+def test_logs_when_requested_are_bounded_and_flagged_sensitive() -> None:
+    log_lines = "\n".join(
+        json.dumps({"timestamp": f"t{i}", "message": f"line {i}", "instance": "abc"})
+        for i in range(50)
+    )
+    runner = FakeRunner(results={"logs": (0, log_lines, "")})
+    collector = _collector(runner=runner, include_logs=10)
+
+    report = collector.run()
+
+    assert report["logs"] is not None
+    assert report["logs"]["sensitive"] is True
+    assert report["logs"]["requested_lines"] == 10
+    assert len(report["logs"]["lines"]) == 10
+
+
+# --------------------------------------------------------------------------
+# Log stream parsing
+# --------------------------------------------------------------------------
+
+# Verified against `fly logs --json --no-tail -a property-shared` on 2026-09-01:
+# the output is a stream of *pretty-printed* JSON objects, one after another —
+# neither JSON-lines nor a JSON array. Splitting on newlines yields fragments
+# like `"URL": {`, which is what an earlier revision of this collector stored.
+_REAL_LOG_STREAM = """{
+    "level": "info",
+    "instance": "7849207a412608",
+    "message": "INFO:     172.16.33.82:40526 - \\"POST /mcp HTTP/1.1\\" 202 Accepted",
+    "region": "lhr",
+    "timestamp": "2026-09-01T00:24:11.037797623Z",
+    "meta": {
+        "Instance": "7849207a412608",
+        "HTTP": {"Request": {"ID": "", "Method": ""}}
+    }
+}
+{
+    "level": "info",
+    "instance": "7849207a412608",
+    "message": "Terminating session: None",
+    "region": "lhr",
+    "timestamp": "2026-09-01T00:24:11.038296725Z",
+    "meta": {"Instance": "7849207a412608"}
+}
+"""
+
+
+def test_pretty_printed_concatenated_json_log_stream_is_parsed() -> None:
+    records = fos.parse_log_stream(_REAL_LOG_STREAM)
+
+    assert len(records) == 2
+    assert records[0]["message"].startswith("INFO:")
+    assert records[1]["message"] == "Terminating session: None"
+    assert records[0]["instance"] == "7849207a412608"
+
+
+def test_log_lines_are_whole_records_not_newline_fragments() -> None:
+    """The bug this guards: `"URL": {` stored as if it were a log message."""
+    runner = FakeRunner(results={"logs": (0, _REAL_LOG_STREAM, "")})
+    collector = _collector(runner=runner, include_logs=5)
+
+    logs = collector.collect_logs()
+
+    assert logs is not None
+    assert logs["status"] == "ok"
+    assert len(logs["lines"]) == 2
+    for line in logs["lines"]:
+        assert "message" in line
+        assert not line["message"].strip().endswith("{")
+        assert "timestamp" in line
+
+
+def test_log_records_keep_only_selected_fields() -> None:
+    """`meta` carries nested request detail that has no place in the report."""
+    runner = FakeRunner(results={"logs": (0, _REAL_LOG_STREAM, "")})
+    collector = _collector(runner=runner, include_logs=5)
+
+    logs = collector.collect_logs()
+
+    assert logs is not None
+    for line in logs["lines"]:
+        assert set(line) <= {"timestamp", "level", "instance", "region", "message"}
+    assert "meta" not in json.dumps(logs["lines"])
+
+
+def test_unparseable_log_output_is_reported_rather_than_silently_empty() -> None:
+    runner = FakeRunner(results={"logs": (0, "totally not json", "")})
+    collector = _collector(runner=runner, include_logs=5)
+
+    logs = collector.collect_logs()
+
+    assert logs is not None
+    assert logs["status"] == "error"
+    assert logs["error"]
+    assert logs["lines"] == []
+
+
+# --------------------------------------------------------------------------
+# Field selection — flyctl payloads must be reduced, not dumped
+# --------------------------------------------------------------------------
+
+
+def test_checks_payload_keyed_by_machine_id_is_field_selected() -> None:
+    """`fly checks list --json` returns {machine_id: [check, ...]}, not a list."""
+    raw = {
+        "7849207a412608": [
+            {
+                "name": "servicecheck-00-http-8080",
+                "status": "passing",
+                "output": '{"status":"ok"}',
+                "updated_at": "2026-08-31T23:08:10.528Z",
+                "unexpected_future_field": "must not be carried through",
+            }
+        ]
+    }
+
+    selected = fos._select_fields("checks", raw)
+
+    assert selected == [
+        {
+            "machine": "7849207a412608",
+            "name": "servicecheck-00-http-8080",
+            "status": "passing",
+            "output": '{"status":"ok"}',
+        }
+    ]
+
+
+def test_image_payload_as_a_list_is_field_selected() -> None:
+    """`fly image show --json` returns a list of image records."""
+    raw = [
+        {
+            "Digest": "sha256:5c1c4039",
+            "Labels": '{"GH_SHA":"176c401"}',
+            "MachineID": "7849207a412608",
+            "Registry": "registry.fly.io",
+            "Repository": "property-shared",
+            "Tag": "deployment-01M1D17A8J7WME8FKCDA8NK33W",
+            "Version": "N/A",
+            "SomeFutureSecretField": "must not be carried through",
+        }
+    ]
+
+    selected = fos._select_fields("image", raw)
+
+    assert isinstance(selected, list)
+    assert "SomeFutureSecretField" not in selected[0]
+    assert selected[0]["Digest"] == "sha256:5c1c4039"
+    assert selected[0]["MachineID"] == "7849207a412608"
+
+
+def test_machine_environment_is_never_carried_into_the_report() -> None:
+    """A Machine's config carries its whole env; the report must not."""
+    raw = {
+        "Name": "property-shared",
+        "Machines": [
+            {
+                "id": "7849207a412608",
+                "state": "started",
+                "region": "lhr",
+                "config": {
+                    "image": "registry.fly.io/property-shared:deployment-x",
+                    "env": {"PPD_SNAPSHOT_S3_SECRET_ACCESS_KEY": "super-secret-value"},
+                },
+            }
+        ],
+    }
+
+    selected = fos._select_fields("status", raw)
+
+    assert "super-secret-value" not in json.dumps(selected)
+    assert "env" not in json.dumps(selected)
+    assert selected["machines"][0]["image"] == "registry.fly.io/property-shared:deployment-x"
+
+
+def test_an_unrecognised_payload_shape_is_dropped_rather_than_dumped() -> None:
+    """Selection is enforced: an unknown shape yields nothing, not everything."""
+    selected = fos._select_fields("image", {"AnythingAtAll": "including secrets"})
+
+    assert "including secrets" not in json.dumps(selected)
+
+
+def test_single_sample_info_series_renders_its_identifying_labels() -> None:
+    """Machine identity is carried in labels; a bare `1` is useless evidence."""
+    info = fos.SeriesResult(
+        key="instance_info", title="Machine identity", promql="q", unit="info",
+        status="ok", value=1.0,
+        samples=[{
+            "labels": {
+                "app": "property-shared", "instance": "7849207a412608",
+                "memory_mb": "2048", "cpu_kind": "shared", "region": "lhr",
+            },
+            "value": 1.0,
+        }],
+    )
+
+    rendered = fos.render_markdown(
+        fos.build_report(
+            app="property-shared", org="personal", window="30m",
+            started_at="2026-09-01T12:00:00Z", ended_at="2026-09-01T12:00:04Z",
+            series=[info], commands=[], logs=None, notes=[],
+        )
+    )
+
+    assert "7849207a412608" in rendered
+    assert "memory_mb=2048" in rendered
+
+
+# --------------------------------------------------------------------------
+# Live collection — one bounded, read-only run against the real app
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.getenv("RUN_LIVE_TESTS") != "1", reason="Set RUN_LIVE_TESTS=1")
+def test_live_collection_against_property_shared(tmp_path: Path) -> None:
+    """One bounded read-only collection. Touches no secrets and no state.
+
+    Skips rather than fails when no Fly token is available, so a developer
+    without Fly access still gets a green suite.
+    """
+    try:
+        token = fos.resolve_token()
+    except RuntimeError as exc:
+        pytest.skip(f"no Fly token available: {exc}")
+
+    collector = fos.Collector(
+        app="property-shared", org="personal", window="30m", token=token
+    )
+    try:
+        report = collector.run()
+    except OSError as exc:
+        pytest.skip(f"Fly API unavailable: {exc}")
+
+    assert report["schema_version"] == fos.SCHEMA_VERSION
+    statuses = {s["key"]: s["status"] for s in report["series"]}
+
+    # Something must have been measured, or the run proved nothing.
+    assert any(v == "ok" for v in statuses.values()), statuses
+
+    # The Machine is up and its rootfs is reported: the two readings Phase D
+    # depends on. A collector that silently returned an empty report would
+    # otherwise pass every offline test in this file.
+    assert statuses["instance_up"] == "ok"
+    assert statuses["rootfs_free_bytes"] == "ok"
+
+    written = fos.write_outputs(report, tmp_path / "live.json", force=False)
+    for path in written:
+        assert "fm2_" not in path.read_text()

--- a/tests/test_fly_observability_snapshot.py
+++ b/tests/test_fly_observability_snapshot.py
@@ -18,6 +18,7 @@ import importlib.util
 import json
 import os
 import sys
+import urllib.parse
 from pathlib import Path
 from typing import Any
 
@@ -787,17 +788,27 @@ _MOUNT_LABELS = {
 
 
 class RootfsFetch:
-    """Serves a realistic rootfs matrix on query_range and totals on query."""
+    """Serves a realistic rootfs matrix on query_range and totals on query.
+
+    Matches on the *decoded* `query` parameter. Matching raw URL text silently
+    fails for anything containing PromQL punctuation: `urlencode` turns `{`
+    into `%7B`, so a needle like `fly_instance_filesystem_blocks{` can never
+    appear in the URL and its branch is dead. That is not hypothetical — this
+    fixture had exactly that bug, and the totals branch never ran while the
+    tests still passed on the fallback.
+    """
 
     def __init__(self, *, with_range: bool = True) -> None:
         self.with_range = with_range
         self.calls: list[dict[str, Any]] = []
+        self.matched_totals = 0
 
     def __call__(self, url: str, headers: dict[str, str], timeout: float) -> tuple[int, bytes]:
         self.calls.append({"url": url, "headers": dict(headers), "timeout": timeout})
-        is_range = "query_range" in url
+        is_range = "query_range" in urllib.parse.urlparse(url).path
+        promql = urllib.parse.parse_qs(urllib.parse.urlparse(url).query).get("query", [""])[0]
 
-        if is_range and "filesystem_blocks_free" in url:
+        if is_range and "fly_instance_filesystem_blocks_free{" in promql:
             if not self.with_range:
                 return 200, json.dumps(_EMPTY_VECTOR).encode()
             payload = {
@@ -821,20 +832,36 @@ class RootfsFetch:
         if is_range:
             return 200, json.dumps(_EMPTY_VECTOR).encode()
 
-        if "fly_instance_filesystem_blocks{" in url:
+        if "fly_instance_filesystem_blocks{" in promql:
+            self.matched_totals += 1
             return 200, json.dumps(_vector((dict(_MOUNT_LABELS), str(_TOTAL)))).encode()
 
         return 200, json.dumps(_vector((dict(_MOUNT_LABELS), "1"))).encode()
 
 
-def test_run_reports_a_transient_disk_summary(tmp_path: Path) -> None:
-    collector = _collector(fetch=RootfsFetch())
+def test_run_reports_a_transient_disk_summary() -> None:
+    fetch = RootfsFetch()
+    collector = _collector(fetch=fetch)
 
     report = collector.run()
 
     assert report["transient_disk"], "the collector computed no transient-disk summary"
     entry = report["transient_disk"][0]
     assert entry["status"] == "ok"
+    assert entry["delta_bytes"] == pytest.approx(_BASELINE_FREE - _MIN_FREE)
+    # Guards the fixture itself: if the totals branch stops matching, the
+    # generic fallback quietly supplies 1 and the pairing below is untested.
+    assert fetch.matched_totals == 1
+
+
+def test_transient_disk_entry_is_paired_with_the_total_for_its_mount() -> None:
+    """Total is context, not arithmetic — but it must still be the real total."""
+    collector = _collector(fetch=RootfsFetch())
+
+    entry = collector.run()["transient_disk"][0]
+
+    assert entry["total_bytes"] == pytest.approx(_TOTAL)
+    # ...and it must not have leaked into the delta.
     assert entry["delta_bytes"] == pytest.approx(_BASELINE_FREE - _MIN_FREE)
 
 

--- a/tests/test_fly_observability_snapshot.py
+++ b/tests/test_fly_observability_snapshot.py
@@ -490,6 +490,282 @@ def test_logs_when_requested_are_bounded_and_flagged_sensitive() -> None:
 
 
 # --------------------------------------------------------------------------
+# Auth scheme negotiation
+# --------------------------------------------------------------------------
+
+# Verified 2026-09-01: a macaroon from `fly auth token` (fm2_...) is accepted
+# with `FlyV1 <token>` and rejected 401 with `Bearer <token>`. That is one
+# token type. Tokens minted by `fly tokens create` are documented to take the
+# other scheme, so the scheme is negotiated rather than hard-coded.
+
+
+class SchemeAwareFetch:
+    """Accepts exactly one Authorization scheme; 401s every other."""
+
+    def __init__(self, accepts: str, payload: Any = None) -> None:
+        self.accepts = accepts
+        self.payload = payload if payload is not None else _EMPTY_VECTOR
+        self.calls: list[dict[str, Any]] = []
+
+    def schemes_tried(self) -> list[str]:
+        return [c["headers"]["Authorization"].split(" ", 1)[0] for c in self.calls]
+
+    def __call__(self, url: str, headers: dict[str, str], timeout: float) -> tuple[int, bytes]:
+        self.calls.append({"url": url, "headers": dict(headers), "timeout": timeout})
+        scheme = headers["Authorization"].split(" ", 1)[0]
+        if scheme != self.accepts:
+            return 401, b"something went wrong resolving organization"
+        return 200, json.dumps(self.payload).encode()
+
+
+def test_flyv1_scheme_is_tried_first_and_bearer_is_never_needed() -> None:
+    fetch = SchemeAwareFetch(accepts="FlyV1")
+    collector = _collector(fetch=fetch)
+
+    collector.collect_series()
+
+    assert "Bearer" not in fetch.schemes_tried()
+    assert collector.auth_scheme == "FlyV1"
+
+
+def test_bearer_token_is_negotiated_when_flyv1_is_rejected() -> None:
+    """A token type that needs Bearer must not fail the whole collection."""
+    fetch = SchemeAwareFetch(accepts="Bearer", payload=_vector(({"app": "x"}, "1")))
+    collector = _collector(fetch=fetch)
+
+    results = collector.collect_series()
+
+    assert collector.auth_scheme == "Bearer"
+    assert any(r.status == "ok" for r in results), "Bearer-only token must still collect"
+
+
+def test_negotiation_happens_once_not_per_series() -> None:
+    fetch = SchemeAwareFetch(accepts="Bearer", payload=_vector(({"app": "x"}, "1")))
+    collector = _collector(fetch=fetch)
+
+    collector.collect_series()
+
+    rejected = [c for c in fetch.calls if c["headers"]["Authorization"].startswith("FlyV1")]
+    assert len(rejected) == 1, f"negotiated per request instead of once: {len(rejected)} probes"
+
+
+def test_explicit_auth_scheme_is_honoured_without_negotiation() -> None:
+    fetch = SchemeAwareFetch(accepts="Bearer", payload=_vector(({"app": "x"}, "1")))
+    collector = _collector(fetch=fetch, auth_scheme="Bearer")
+
+    collector.collect_series()
+
+    assert set(fetch.schemes_tried()) == {"Bearer"}
+
+
+def test_report_records_the_negotiated_scheme_and_not_the_token() -> None:
+    fetch = SchemeAwareFetch(accepts="Bearer", payload=_vector(({"app": "x"}, "1")))
+    collector = _collector(fetch=fetch)
+
+    report = collector.run()
+
+    assert report["query"]["auth_scheme"] == "Bearer"
+    blob = json.dumps(report)
+    assert FAKE_TOKEN not in blob
+    assert "fm2_" not in blob
+
+
+def test_every_scheme_failing_is_a_typed_error_not_a_crash() -> None:
+    fetch = SchemeAwareFetch(accepts="NoSuchScheme")
+    collector = _collector(fetch=fetch)
+
+    results = collector.collect_series()
+
+    assert all(r.status == "error" for r in results)
+    assert any("401" in (r.error or "") for r in results)
+    assert all("fm2_" not in (r.error or "") for r in results)
+
+
+# --------------------------------------------------------------------------
+# Non-finite values must never be reported as measurements
+# --------------------------------------------------------------------------
+
+# Verified 2026-09-01 against the live API: `1/0` returns the literal "+Inf"
+# and `-1/0` returns "-Inf" as ordinary sample values. `float()` accepts
+# "NaN"/"+Inf" happily, and `json.dumps` then emits bare NaN/Infinity, which
+# is not valid JSON. A quantile with no traffic is the case that matters:
+# reporting NaN as a successful reading defeats the whole zero-vs-no_data point.
+
+
+@pytest.mark.parametrize("raw", ["NaN", "nan", "+Inf", "-Inf", "inf"])
+def test_non_finite_sample_is_no_data_not_a_measurement(raw: str) -> None:
+    spec = fos.MetricSpec(key="p95", title="p95", promql="q", unit="seconds")
+
+    result = fos.parse_instant_response(spec, _vector(({"app": "x"}, raw)))
+
+    assert result.status == "no_data"
+    assert result.value is None
+    assert result.samples == []
+    assert result.no_data_reason == "non_finite"
+
+
+def test_no_data_reason_distinguishes_an_empty_result_from_a_non_finite_one() -> None:
+    spec = fos.MetricSpec(key="k", title="T", promql="q", unit="u")
+
+    empty = fos.parse_instant_response(spec, _EMPTY_VECTOR)
+    non_finite = fos.parse_instant_response(spec, _vector(({"app": "x"}, "NaN")))
+
+    assert empty.no_data_reason == "empty_result"
+    assert non_finite.no_data_reason == "non_finite"
+
+
+def test_finite_samples_survive_alongside_discarded_non_finite_ones() -> None:
+    spec = fos.MetricSpec(key="k", title="T", promql="q", unit="u")
+    payload = _vector(
+        ({"status": "200"}, "42"),
+        ({"status": "500"}, "NaN"),
+        ({"status": "404"}, "7"),
+    )
+
+    result = fos.parse_instant_response(spec, payload)
+
+    assert result.status == "ok"
+    assert [s["labels"]["status"] for s in result.samples] == ["200", "404"]
+
+
+def test_range_series_of_only_non_finite_points_is_no_data() -> None:
+    spec = fos.MetricSpec(key="k", title="T", promql="q", unit="u", kind="range")
+    payload = {
+        "status": "success",
+        "data": {
+            "resultType": "matrix",
+            "result": [{"metric": {"app": "x"}, "values": [[1, "NaN"], [2, "+Inf"]]}],
+        },
+    }
+
+    result = fos.parse_range_response(spec, payload)
+
+    assert result.status == "no_data"
+    assert result.no_data_reason == "non_finite"
+
+
+def test_range_min_and_max_ignore_non_finite_points() -> None:
+    """A single +Inf must not become the reported maximum."""
+    spec = fos.MetricSpec(key="k", title="T", promql="q", unit="bytes", kind="range")
+    payload = {
+        "status": "success",
+        "data": {
+            "resultType": "matrix",
+            "result": [
+                {
+                    "metric": {"app": "x"},
+                    "values": [[1, "100"], [2, "+Inf"], [3, "50"], [4, "NaN"], [5, "80"]],
+                }
+            ],
+        },
+    }
+
+    result = fos.parse_range_response(spec, payload)
+
+    assert result.status == "ok"
+    sample = result.samples[0]
+    assert sample["min"] == 50.0
+    assert sample["max"] == 100.0
+    assert sample["last"] == 80.0
+    assert sample["points"] == 3
+
+
+def test_written_json_is_strict_and_would_reject_a_non_finite_value(tmp_path: Path) -> None:
+    """allow_nan=False, so a leak becomes a loud failure rather than bad JSON."""
+    report = fos.build_report(
+        app="a", org="o", window="30m",
+        started_at="2026-09-01T12:00:00Z", ended_at="2026-09-01T12:00:04Z",
+        series=[
+            fos.SeriesResult(
+                key="k", title="T", promql="q", unit="u",
+                status="ok", value=float("nan"), samples=[],
+            )
+        ],
+        commands=[], logs=None, notes=[],
+    )
+
+    with pytest.raises(ValueError) as caught:
+        fos.write_outputs(report, tmp_path / "bad.json", force=False)
+
+    # Must come from json.dumps(allow_nan=False), not incidentally from
+    # int(nan) inside the Markdown formatter.
+    assert "JSON compliant" in str(caught.value)
+
+
+def test_a_clean_report_still_writes_strict_json(tmp_path: Path) -> None:
+    report = fos.build_report(
+        app="a", org="o", window="30m",
+        started_at="2026-09-01T12:00:00Z", ended_at="2026-09-01T12:00:04Z",
+        series=[], commands=[], logs=None, notes=[],
+    )
+
+    out = tmp_path / "good.json"
+    fos.write_outputs(report, out, force=False)
+
+    text = out.read_text()
+    assert "NaN" not in text
+    assert "Infinity" not in text
+    json.loads(text)
+
+
+# --------------------------------------------------------------------------
+# Transient disk: the corroborating delta, and its limits
+# --------------------------------------------------------------------------
+
+
+def test_transient_disk_delta_is_baseline_minus_minimum() -> None:
+    """Total minus minimum would report the image and everything already there."""
+    summary = fos.summarise_transient_disk(
+        baseline_free_bytes=8_319_373_312.0,
+        minimum_free_bytes=8_040_263_440.0,
+        total_bytes=8_350_298_112.0,
+    )
+
+    assert summary["delta_bytes"] == pytest.approx(279_109_872.0)
+    # The wrong calculation would give total - minimum = 310,034,672.
+    assert summary["delta_bytes"] != pytest.approx(8_350_298_112.0 - 8_040_263_440.0)
+    assert "baseline_free" in summary["method"]
+    assert "minimum_free" in summary["method"]
+
+
+def test_transient_disk_summary_states_the_scrape_resolution_limit() -> None:
+    summary = fos.summarise_transient_disk(
+        baseline_free_bytes=100.0, minimum_free_bytes=50.0, total_bytes=200.0
+    )
+
+    assert str(fos.FLY_SCRAPE_INTERVAL_SECONDS) in summary["resolution_caveat"]
+    assert "authoritative" in summary["authoritative_source"].lower()
+    assert "boot_only_verify" in summary["authoritative_source"]
+
+
+def test_transient_disk_delta_is_none_when_an_input_is_missing() -> None:
+    summary = fos.summarise_transient_disk(
+        baseline_free_bytes=None, minimum_free_bytes=50.0, total_bytes=200.0
+    )
+
+    assert summary["delta_bytes"] is None
+    assert summary["status"] == "no_data"
+
+
+def test_rootfs_subquery_samples_at_the_real_scrape_interval() -> None:
+    """1m sampling would miss most of a ~20s materialisation."""
+    spec = next(s for s in fos.SERIES if s.key == "rootfs_free_bytes_min")
+
+    rendered = spec.render(app="property-shared", window="30m", prefix="property_shared")
+
+    assert f":{fos.FLY_SCRAPE_INTERVAL_SECONDS}s]" in rendered
+    assert ":1m]" not in rendered
+
+
+def test_no_derivation_claims_peak_disk_is_total_minus_minimum() -> None:
+    """Guard against the incorrect explanation coming back."""
+    for spec in fos.SERIES + fos.RANGE_SERIES:
+        blob = f"{spec.derivation} {spec.note}".lower()
+        assert "total minus this" not in blob
+        assert "total minus" not in blob
+
+
+# --------------------------------------------------------------------------
 # Log stream parsing
 # --------------------------------------------------------------------------
 

--- a/tests/test_fly_observability_snapshot.py
+++ b/tests/test_fly_observability_snapshot.py
@@ -429,6 +429,7 @@ def test_report_has_a_stable_top_level_schema() -> None:
 
     assert set(report) == {
         "schema_version", "target", "query", "series", "commands", "logs", "notes",
+        "transient_disk",
     }
 
 
@@ -763,6 +764,143 @@ def test_no_derivation_claims_peak_disk_is_total_minus_minimum() -> None:
         blob = f"{spec.derivation} {spec.note}".lower()
         assert "total minus this" not in blob
         assert "total minus" not in blob
+
+
+# --------------------------------------------------------------------------
+# Transient disk reaches the report, not just the helper
+# --------------------------------------------------------------------------
+
+# Regression guard: summarise_transient_disk() once existed with a correct
+# formula that no caller invoked, so the generated report carried only the raw
+# rootfs readings and no delta at all. These tests drive Collector.run()
+# end-to-end rather than calling the helper directly.
+
+_BASELINE_FREE = 8_319_373_312.0
+_MIN_FREE = 8_040_263_440.0
+_TOTAL = 8_350_298_112.0
+_MOUNT_LABELS = {
+    "app": "property-shared",
+    "instance": "7849207a412608",
+    "mount": "/.fly-upper-layer",
+    "region": "lhr",
+}
+
+
+class RootfsFetch:
+    """Serves a realistic rootfs matrix on query_range and totals on query."""
+
+    def __init__(self, *, with_range: bool = True) -> None:
+        self.with_range = with_range
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, url: str, headers: dict[str, str], timeout: float) -> tuple[int, bytes]:
+        self.calls.append({"url": url, "headers": dict(headers), "timeout": timeout})
+        is_range = "query_range" in url
+
+        if is_range and "filesystem_blocks_free" in url:
+            if not self.with_range:
+                return 200, json.dumps(_EMPTY_VECTOR).encode()
+            payload = {
+                "status": "success",
+                "data": {
+                    "resultType": "matrix",
+                    "result": [
+                        {
+                            "metric": dict(_MOUNT_LABELS),
+                            "values": [
+                                [1, str(_BASELINE_FREE)],
+                                [2, str(_MIN_FREE)],
+                                [3, "8300000000"],
+                            ],
+                        }
+                    ],
+                },
+            }
+            return 200, json.dumps(payload).encode()
+
+        if is_range:
+            return 200, json.dumps(_EMPTY_VECTOR).encode()
+
+        if "fly_instance_filesystem_blocks{" in url:
+            return 200, json.dumps(_vector((dict(_MOUNT_LABELS), str(_TOTAL)))).encode()
+
+        return 200, json.dumps(_vector((dict(_MOUNT_LABELS), "1"))).encode()
+
+
+def test_run_reports_a_transient_disk_summary(tmp_path: Path) -> None:
+    collector = _collector(fetch=RootfsFetch())
+
+    report = collector.run()
+
+    assert report["transient_disk"], "the collector computed no transient-disk summary"
+    entry = report["transient_disk"][0]
+    assert entry["status"] == "ok"
+    assert entry["delta_bytes"] == pytest.approx(_BASELINE_FREE - _MIN_FREE)
+
+
+def test_reported_delta_is_first_minus_min_not_total_minus_min() -> None:
+    collector = _collector(fetch=RootfsFetch())
+
+    entry = collector.run()["transient_disk"][0]
+
+    assert entry["delta_bytes"] == pytest.approx(279_109_872.0)
+    # total - min would be 310,034,672 — total occupancy, including the image.
+    assert entry["delta_bytes"] != pytest.approx(_TOTAL - _MIN_FREE)
+
+
+def test_transient_disk_entry_preserves_instance_and_mount_labels() -> None:
+    collector = _collector(fetch=RootfsFetch())
+
+    entry = collector.run()["transient_disk"][0]
+
+    assert entry["labels"]["mount"] == "/.fly-upper-layer"
+    assert entry["labels"]["instance"] == "7849207a412608"
+
+
+def test_transient_disk_summary_is_rendered_in_the_markdown() -> None:
+    collector = _collector(fetch=RootfsFetch())
+
+    rendered = fos.render_markdown(collector.run())
+    lines = rendered.splitlines()
+
+    # Exact heading: "Transient disk" alone also matches a heading that has
+    # dropped the crucial "not authoritative" qualifier.
+    assert "## Transient disk (corroborating, not authoritative)" in lines
+    assert "/.fly-upper-layer" in rendered
+    assert "279,109,872" in rendered
+
+    # The authoritative source must be labelled *in this section*. Asserting
+    # only that "boot_only_verify" appears somewhere is satisfied by the
+    # report-wide notes, so it would not notice this line disappearing.
+    source_lines = [ln for ln in lines if ln.startswith("- Authoritative source:")]
+    assert len(source_lines) == 1
+    assert "boot_only_verify" in source_lines[0]
+    assert any(ln.startswith("- Method:") for ln in lines)
+    assert any(ln.startswith("- Resolution:") for ln in lines)
+
+
+def test_transient_disk_is_no_data_when_the_rootfs_range_is_absent() -> None:
+    """Absent input must say so, not vanish from the report."""
+    collector = _collector(fetch=RootfsFetch(with_range=False))
+
+    report = collector.run()
+
+    assert report["transient_disk"], "an absent series must still produce an entry"
+    entry = report["transient_disk"][0]
+    assert entry["status"] == "no_data"
+    assert entry["delta_bytes"] is None
+    # The caveats are the point; they must survive the no_data path.
+    assert "boot_only_verify" in entry["authoritative_source"]
+
+
+def test_transient_disk_carries_its_caveats_through_run() -> None:
+    collector = _collector(fetch=RootfsFetch())
+
+    entry = collector.run()["transient_disk"][0]
+
+    assert "baseline_free" in entry["method"]
+    assert str(fos.FLY_SCRAPE_INTERVAL_SECONDS) in entry["resolution_caveat"]
+    assert "authoritative" in entry["authoritative_source"].lower()
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Adds `scripts/fly_observability_snapshot.py`: a read-only operator script that replaces dashboard screenshots with repeatable, timestamped evidence before/during/after the PPD snapshot rollout. Standard library only — no runtime dependency added.

**Not for merge yet.** Prepared for review per the rollout handoff. Phase D is a separate approval boundary and has not been started.

## What it does

One invocation writes a stable-schema JSON report plus a Markdown interpretation to `--output`, from two read-only sources:

- documented `flyctl` JSON commands — `status`, `checks list`, `image show`, and an opt-in bounded `logs --no-tail`;
- Fly's Prometheus-compatible API, both `/api/v1/query` and `/api/v1/query_range`.

```
uv run python scripts/fly_observability_snapshot.py \
    --app property-shared --org personal --window 30m \
    --output docs/ops/evidence/2026-09-01-baseline.json
```

`--output` refuses to overwrite by default, so a "before" report survives the "after".

## Enumeration, not recall

Every metric name and PromQL expression in `SERIES` was executed against the live API for `app="property-shared"` before being written into the file. That produced three findings, each encoded as behaviour rather than left as a comment:

| Finding | Consequence in the code |
|---|---|
| `fly_app_concurrency` has **no series** for `property-shared` or `propertydata`, while five other fleet apps report it | Renders as `no_data`, never `0` |
| `property_shared_tool_calls_total` has **no live series** despite its duration histogram existing | Reported as stale, not as zero traffic |
| Fly's Prometheus wants `Authorization: FlyV1 <token>`; `Bearer <token>` returns 401 `something went wrong resolving organization` | Documented at the constant, since the error misreads as a permissions problem |

## The fleet dashboard gap

The handoff asked for the custom-metric queries from the checked-in **"BOUCH MCP Fleet"** Grafana dashboard. **That dashboard is not checked in anywhere in the workspace.** The only one that is — `monitoring/grafana-dashboard.json`, titled "Property Shared API" — targets metric names that **do not exist** in Fly's Prometheus (`http_request_duration_seconds_*`, `http_requests_inprogress`, `http_response_size_bytes_*`, `external_request_duration_seconds_*`). It is written for a `prometheus_fastapi_instrumentator` naming scheme the deployed app does not use, so it appears to be stale relative to `app/core/metrics.py`.

No series here is sourced from it. The `app_custom` series come from the live Fly label index and from the checked-in definitions in `app/core/metrics.py`. The gap is recorded in `DASHBOARD_GAP_NOTE` and reproduced in the notes of every report, so no reader mistakes these for dashboard-derived queries. **Worth a separate look:** that dashboard is probably showing `No Data` in Grafana today.

## Guarantees, and the tests that prove them

Three properties the evidence is worthless without. Each was confirmed to be genuinely load-bearing by removing it and watching the suite go red:

| Guarantee | Mutation | Tests that failed |
|---|---|---|
| `0` and "no data" are different answers | absent series returns `0.0` | 1 |
| Token never reaches disk, logs, or exception text | redaction disabled | 2 |
| One failure stays partial | series error re-raised | 3 |
| Strictly read-only | allowlist accepts everything | 6 |
| Baseline cannot be clobbered | overwrite guard removed | 1 |
| Error % paired with absolute counts | no-traffic renders `0%` | 1 |
| Malformed flyctl JSON is reported | handler removed | 2 |
| Logs are opt-in | default changed | 1 |

Read-only is enforced by an allowlist, not a denylist, so a new mutating flyctl verb is refused by default.

## Two defects found by running it, not by reasoning about it

1. `fly checks list --json` returns `{machine_id: [...]}` and `fly image show --json` returns a list — my field selection expected the opposite shapes for both and silently fell through to a raw dump. Selection is now enforced: an unrecognised shape yields nothing rather than everything.
2. `fly logs --json` emits **concatenated pretty-printed JSON objects**, not JSON-lines. Splitting on newlines stored fragments such as `"URL": {` as log messages. Now decoded incrementally with `raw_decode`.

Both are regression-tested against captured real output.

## Sample output (live, redacted)

```
collected 35 series (3 no_data, 32 ok)
```

| Metric | Unit | Value | Status |
|---|---|---|---|
| App concurrency | connections | — | `no_data` |
| Load average (5m) | load | 0 | `ok` |
| Machine memory available | bytes | 1,791,877,120 (1.67 GiB) | `ok` |
| Root filesystem free *(derived)* | bytes | 8,319,373,312 (7.75 GiB) | `ok` |
| Process RSS | bytes | 108,908,544 (0.10 GiB) | `ok` |
| MCP tool calls by tool and status *(derived)* | calls | — | `no_data` |
| OOM exits | count | — | `no_data` |

The run independently corroborates the deployed identity already recorded in the rollout log: Machine `7849207a412608`, digest `sha256:5c1c4039…f335`, label `GH_SHA=176c401ce…`, health check `passing`.

Root filesystem free space is reported on mount `/.fly-upper-layer` — the ephemeral rootfs, which is the filesystem the §4.7 `bundle_bytes * 2.5` preflight is measured against.

## Packaging

`.gitignore` carries `scripts/*` with an explicit allowlist, so the new script is un-ignored alongside the others. Without that line the branch would have contained only the test and CI would have failed on the missing module. `scripts/` is not in the published wheel (`[tool.hatch.build.targets.wheel] packages`), so nothing ships to PyPI.

## Validation

`./scripts/validate.sh` from a fresh worktree at `origin/main` (`6c9f3f0`): **1706 passed, 27 skipped**. That is the 1661 baseline plus 44 new unit tests and 1 gated live test.

The 44 unit tests use injected fake transports — no network, no subprocess, no token. The single live test is gated on `RUN_LIVE_TESTS=1`, skips gracefully without a token or when the API is unavailable, and performs one bounded read-only collection against `property-shared`. It was run and passes.

## What this does not do

No deploy, restart, secret, scale, Machine update, tag or release. No credentials were staged or applied, and the verifier was not invoked. Phase D remains unstarted and needs its own authorisation.
