### PR TITLE
fix(snapshot): match the root mount for paths beneath it in _filesystem_type

### DIFF
--- a/tests/snapshot/test_boot_only_verify.py
+++ b/tests/snapshot/test_boot_only_verify.py
@@ -114,6 +114,48 @@ def test_disk_backed_assertion_refuses_when_nothing_matches(tmp_path):
         assert_disk_backed(tmp_path, "none /completely/unrelated ext4 rw 0 0\n")
 
 
+def test_disk_backed_assertion_matches_the_root_mount_for_a_path_beneath_it(tmp_path):
+    """A path whose only enclosing mount is `/` must resolve to the root filesystem.
+
+    Regression, observed on the deployed `property-shared` Machine on
+    2026-09-01: the prefix test was `resolved.startswith(stripped + "/")`, and
+    for the root mount `stripped` is `"/"`, so the prefix became `"//"` --
+    which no absolute path ever starts with. The root filesystem therefore
+    matched only the exact path `/` and nothing beneath it.
+
+    A Fly Machine has no dedicated `/tmp` mount (`/tmp` falls under `/`, an
+    overlay whose upper layer is ext4 on `/dev/vdb`), so this refused every
+    run with "no mount entry matches /tmp" -- including the invocation in this
+    module's own docstring. Every existing test here synthesised a mount entry
+    for the exact parent directory, so none of them exercised this path.
+    """
+    assert assert_disk_backed(tmp_path, "none / overlay rw 0 0\n") == "overlay"
+
+
+def test_a_closer_mount_still_wins_over_the_root_mount(tmp_path):
+    """Longest-match must survive the fix; the root entry must not shadow it."""
+    mounts = f"none / overlay rw 0 0\nnone {tmp_path} ext4 rw 0 0\n"
+
+    assert assert_disk_backed(tmp_path, mounts) == "ext4"
+
+
+def test_a_tmpfs_root_is_still_refused_for_a_path_beneath_it(tmp_path):
+    """The guard this check exists for must not be weakened by matching root.
+
+    Making the root mount match everything beneath it is only safe if a
+    tmpfs-backed root still refuses -- otherwise the fix would turn a false
+    negative into a false positive, which is the more dangerous direction.
+
+    Matched on the filesystem-type wording rather than the bare word "tmpfs":
+    pytest names `tmp_path` after the test, so this test's own directory
+    contains "tmpfs", and the *wrong* refusal ("no mount entry matches
+    /tmp/.../test_a_tmpfs_root...") satisfies a bare match. Asserting the
+    reason, not a substring that the path supplies for free.
+    """
+    with pytest.raises(VerificationRefused, match=r"backed by 'tmpfs', not disk"):
+        assert_disk_backed(tmp_path, "none / tmpfs rw 0 0\n")
+
+
 # -- verification-directory preparation --------------------------------------
 
 def test_verification_directory_must_not_nest_inside_the_app_cache(tmp_path):

--- a/tools/ppd_snapshot/boot_only_verify.py
+++ b/tools/ppd_snapshot/boot_only_verify.py
@@ -82,7 +82,14 @@ def _filesystem_type(path: Path, mounts_text: Optional[str] = None) -> str:
             continue
         mount_point, fs_type = parts[1], parts[2]
         stripped = mount_point.rstrip("/") or "/"
-        if resolved == stripped or resolved.startswith(stripped + "/"):
+        # The prefix must not be built as `stripped + "/"`: for the root mount
+        # `stripped` is "/", so that yields "//", which no absolute path starts
+        # with, and the root filesystem then matches only the exact path "/".
+        # A Fly Machine has no dedicated /tmp mount, so every path under / was
+        # refused as "no mount entry" -- including this module's own documented
+        # invocation.
+        prefix = stripped if stripped.endswith("/") else stripped + "/"
+        if resolved == stripped or resolved.startswith(prefix):
             if len(stripped) >= len(best_match):
                 best_match, best_type = stripped, fs_type
     if not best_type:


### PR DESCRIPTION
Narrow fix for a defect in `_filesystem_type()` found while running Phase D against the deployed `property-shared` Machine on 2026-09-01.

**Draft — do not merge, release or redeploy without separate approval.** Reaching the Machine requires a release, which is a separate authorisation.

## The defect

The disk-backed precondition refused every path whose only enclosing mount is `/`:

```python
stripped = mount_point.rstrip("/") or "/"
if resolved == stripped or resolved.startswith(stripped + "/"):
```

For the root mount `stripped` is `"/"`, so the prefix became `"//"` — which no absolute path starts with. The root filesystem therefore matched only the exact path `/`, never anything beneath it.

A Fly Machine has **no dedicated `/tmp` mount** — `/tmp` falls under `/`, an overlay whose upper layer is ext4 on `/dev/vdb`. So the verifier refused:

```json
{"evidence_scope": "partial_g1a", "g1a_complete": false,
 "stage_1_evidence": false, "refused": "no mount entry matches /tmp"}
```

…including the invocation printed in the module's own docstring (`--verify-dir /tmp/ppd-verify-$(date +%s)`).

Nothing was materialised: the check runs before the verification directory is created and before the `try/finally`, so the refusal was inert — no download, no directory, no cleanup pending, production untouched. But Phase D could not proceed.

## The fix

Build the prefix as `stripped if stripped.endswith("/") else stripped + "/"`. Longest-match is unchanged — a closer mount still wins.

Replayed against the Machine's real `/proc/mounts`:

| path | before | after |
|---|---|---|
| `/tmp` | **REFUSED** | `overlay` |
| `/` | `overlay` | `overlay` |
| `/.fly-upper-layer` | `ext4` | `ext4` |
| `/dev/shm` | `tmpfs` | `tmpfs` |

## Tests

Three regression tests:

1. **The reported case** — a path beneath the root mount when no closer mount exists.
2. **Longest-match** — the root entry must not shadow a closer mount.
3. **The guard the check exists for** — a tmpfs root must still refuse. Making root match everything beneath it is only safe if this holds; otherwise the fix would convert a false negative into a false positive, which is the more dangerous direction.

**Why the existing suite missed this:** every case synthesised a mount entry for the *exact* parent directory (`_ext4_mounts_for(verify_dir.parent)`), so the "no closer mount than `/`" path was never exercised.

**One test needed tightening before it was trustworthy.** Test 3 initially asserted `match="tmpfs"` and passed against the *unfixed* code — pytest names `tmp_path` after the test, so its own directory contains `tmpfs`, and the wrong message (`no mount entry matches /tmp/.../test_a_tmpfs_root...`) satisfied the match. It now asserts `backed by 'tmpfs', not disk`, which only the correct refusal produces.

## Scope

Verifier behaviour is otherwise untouched: no change to `EXPECTED_BUNDLE_BYTES`, cold-run validation, cleanup, nesting rules, or the `partial_g1a` / `g1a_complete: false` / `stage_1_evidence: false` labelling.

`./scripts/validate.sh`: **1738 passed, 27 skipped**.

## Phase D status

Not unblocked by this alone. After working around the refusal with a root-parent verify directory, the run reached materialisation and then failed on `HTTP 403 for 'current.json'` from Tigris — `bytes_downloaded: 0`, `cold_run_valid: false`, `cleanup_ok: true`. That is a separate credential/object-permission question, reported separately and not addressed here.
