### PR TITLE
feat(snapshot): non-blocking startup with a control-only shadow flag

### DIFF
--- a/docs/design/ppd-source-routing.md
+++ b/docs/design/ppd-source-routing.md
@@ -7,9 +7,12 @@ to this document require a new decision round, not an edit in passing.
 measurement recorded in
 [`docs/ops/2026-08-31-ppd-snapshot-rollout.md`](../ops/2026-08-31-ppd-snapshot-rollout.md).
 That measurement showed 36.7 s of materialization plus 3.1 s of adapter-open
-validation on the real `property-shared` Machine — so a boot awaited inside the
-ASGI lifespan could not meet the 30 s readiness target **by construction**, on
-any artifact of this size, however fast the network.
+validation on the real `property-shared` Machine — so on **the measured path**,
+a boot awaited inside the ASGI lifespan did not meet the 30 s readiness target.
+That is a statement about what was measured, not a proof about every possible
+path: the transfer ran at 63.6 Mbit/s on a depleted CPU burst balance, and a
+faster transfer could bring an awaited boot back under 30 s. Rev 9 removes the
+dependency on that question rather than answering it.
 
 Rev 9 changes **when the boot runs**, not what it produces or what may be
 served. §4.10 gains a non-blocking rule: the lifespan *starts* the boot and
@@ -859,8 +862,9 @@ detail, so it is fixed here before PR 4 begins.
 * **The boot must not gate readiness (rev 9).** The lifespan *starts* the boot
   and returns immediately; ASGI/FastMCP readiness never awaits materialization.
   Phase D measured 36.7 s of materialization plus 3.1 s of validation on the
-  2 GB Machine, so an awaited boot cannot satisfy the 30 s readiness target on
-  an artifact of this size regardless of network speed. The boot therefore runs
+  2 GB Machine, so on that path an awaited boot did not satisfy the 30 s
+  readiness target. A faster transfer might; the point of this rule is that
+  readiness no longer depends on the answer. The boot therefore runs
   on its own thread, outside the event loop and outside any cancel scope: the
   work it does is blocking I/O that no cancellation can interrupt, and a
   task-group scope cancelled from a lifespan's `finally` deadlocks when the

--- a/docs/design/ppd-source-routing.md
+++ b/docs/design/ppd-source-routing.md
@@ -1,7 +1,30 @@
-# PPD source-routing and implementation specification (rev 8 — FROZEN)
+# PPD source-routing and implementation specification (rev 9 — FROZEN)
 
-**Status:** **FROZEN at rev 8.** Accepted. No further architecture work. Changes
+**Status:** **FROZEN at rev 9.** Accepted. No further architecture work. Changes
 to this document require a new decision round, not an edit in passing.
+
+**Revision 9** was authorised by the Phase D review round, after the partial-G1a
+measurement recorded in
+[`docs/ops/2026-08-31-ppd-snapshot-rollout.md`](../ops/2026-08-31-ppd-snapshot-rollout.md).
+That measurement showed 36.7 s of materialization plus 3.1 s of adapter-open
+validation on the real `property-shared` Machine — so a boot awaited inside the
+ASGI lifespan could not meet the 30 s readiness target **by construction**, on
+any artifact of this size, however fast the network.
+
+Rev 9 changes **when the boot runs**, not what it produces or what may be
+served. §4.10 gains a non-blocking rule: the lifespan *starts* the boot and
+returns immediately, the application is ready serving live data, and the
+snapshot becomes eligible to route only once it has materialized and validated.
+It also adds the control-only `PPD_SNAPSHOT_SHADOW_ENABLED` flag, which performs
+that boot and deliberately never routes, so full G1a can be measured against the
+real application lifecycle without serving a single snapshot row.
+
+**No requirement is relaxed.** The 30 s readiness target is unchanged — rev 9
+makes it *measurable* rather than unreachable-by-construction, and does not
+claim it is met. The `bundle_bytes * 2.5` headroom rule, every Stage 1 exit
+criterion, and G1a, G1b, G2 and G3 are unchanged. `PPD_SNAPSHOT_ENABLED` remains
+the sole authority to route. Nothing is enabled, no image is deployed, and no
+artifact is replaced.
 
 **Revision 8** was authorised by the corpus-acceptance and artifact-distribution
 decision round, after PRs #30 and #31 merged. It is a **status** revision, not an
@@ -833,6 +856,30 @@ detail, so it is fixed here before PR 4 begins.
 * **A startup failure leaves the server available on the live fallback.** Boot
   returning `UNREADY` is a normal outcome, not a startup error: the process must
   come up and serve from the live source.
+* **The boot must not gate readiness (rev 9).** The lifespan *starts* the boot
+  and returns immediately; ASGI/FastMCP readiness never awaits materialization.
+  Phase D measured 36.7 s of materialization plus 3.1 s of validation on the
+  2 GB Machine, so an awaited boot cannot satisfy the 30 s readiness target on
+  an artifact of this size regardless of network speed. The boot therefore runs
+  on its own thread, outside the event loop and outside any cancel scope: the
+  work it does is blocking I/O that no cancellation can interrupt, and a
+  task-group scope cancelled from a lifespan's `finally` deadlocks when the
+  lifespan runs in a portal task. Shutdown stops accepting installs, joins
+  briefly, and abandons anything still running; the thread is a daemon.
+  **Readiness reports live availability, never snapshot availability.**
+* **Shadow mode: `PPD_SNAPSHOT_SHADOW_ENABLED` (rev 9).** A control-only flag.
+  It starts exactly the same boot, and never makes the result routable —
+  `active_adapter()` continues to consult `PPD_SNAPSHOT_ENABLED` alone, on every
+  call. Its purpose is to let full G1a — application time-to-readiness against
+  the real lifespan, on the real image and Machine — be measured with a real
+  artifact while every user request is still answered from the live source.
+  Enabling it is not, and never becomes, permission to serve snapshot data.
+* **Boot lifecycle is reported, not inferred.** `snapshot_status()` (and
+  therefore `/v1/meta`) carries `state` — `not_started` / `warming` / `ready` /
+  `failed` — alongside `enabled`, `shadow_enabled`, `source_error` and the
+  artifact identity. `routable` tracks `active_adapter()` and so is true only
+  when serving is enabled *and* validation completed; a warming or failed boot
+  is visibly distinct from a routing one.
 
 ---
 
@@ -1141,15 +1188,25 @@ The two facts Phase 3 could not evidence are now **blocking gates**, not caveats
   app to one worker and record that as a deployment constraint. Verification is
   read-only; **pinning is a deployment mutation with its own authorisation.**
 
-  **Open, and blocking G2 if the deployed count exceeds one:** boot runs inside
-  the lifespan and therefore blocks startup, a worker waiting on the §4.6
-  single-flight lock can block for up to 420 s, and the Fly health-check grace
-  periods are 60 s (`property-shared`) and 30 s (`propertydata`). Those three
-  numbers are not reconciled anywhere. At one worker per Machine the lock never
-  contends and the question is moot; above one it must be answered before the
-  flag is enabled. **Rev 7 records this and deliberately does not resolve it** —
-  a resolution needs deployment evidence or a new operational policy, neither of
-  which a documentation correction may invent.
+  **Open, and blocking G2 if the deployed count exceeds one:** a worker waiting
+  on the §4.6 single-flight lock can block for up to 420 s, and the Fly
+  health-check grace periods are 60 s (`property-shared`) and 30 s
+  (`propertydata`). At one worker per Machine the lock never contends and the
+  question is moot; above one it must be answered before the flag is enabled.
+  **Rev 7 records this and deliberately does not resolve it** — a resolution
+  needs deployment evidence or a new operational policy, neither of which a
+  documentation correction may invent.
+
+  **Rev 9 narrows, but does not close, this concern.** Rev 7 stated the boot
+  "runs inside the lifespan and therefore blocks startup"; under §4.10's
+  non-blocking rule it no longer does, so a worker waiting out the 420 s lock no
+  longer holds up ASGI startup and no longer interacts with the health-check
+  grace periods at all. Those three numbers are reconciled to that extent. What
+  remains open is unchanged and still blocking above one worker: the deployed
+  worker count is not verified, and the per-worker RSS budget was derived for a
+  single uvicorn process. Phase D observed one worker in the checked-in
+  `Dockerfile` CMD (no `--workers`), which is configuration evidence, not the
+  deployment verification G2 asks for.
 
 * **G3 — the snapshot extra is installed in both production images, and proven
   to be.** The boot runtime imports `duckdb` and `zstandard`, which live only in

--- a/property_core/config.py
+++ b/property_core/config.py
@@ -16,6 +16,13 @@ _TRUE = frozenset({"1", "true", "yes", "on"})
 
 PPD_SNAPSHOT_ENABLED_ENV = "PPD_SNAPSHOT_ENABLED"
 
+#: Control-only. Starts the snapshot boot without ever making it routable, so
+#: the real application startup lifecycle can be measured (G1a) against a real
+#: artifact while every user request is still answered from the live source.
+#: It is deliberately NOT consulted by `state.active_adapter()`:
+#: `PPD_SNAPSHOT_ENABLED` remains the sole authority to route.
+PPD_SNAPSHOT_SHADOW_ENABLED_ENV = "PPD_SNAPSHOT_SHADOW_ENABLED"
+
 
 def parse_bool_flag(value: object) -> bool:
     """Parse a feature-flag value. Fails CLOSED on anything unrecognised.
@@ -39,3 +46,13 @@ def ppd_snapshot_enabled() -> bool:
     without reimporting the package.
     """
     return parse_bool_flag(os.getenv(PPD_SNAPSHOT_ENABLED_ENV))
+
+
+def ppd_snapshot_shadow_enabled() -> bool:
+    """Whether to materialize a snapshot without routing to it. Defaults to False.
+
+    Same fail-closed parsing and same call-time read as the serving flag. This
+    flag governs *whether the work happens*, never *what a request is answered
+    from*.
+    """
+    return parse_bool_flag(os.getenv(PPD_SNAPSHOT_SHADOW_ENABLED_ENV))

--- a/property_core/snapshot/bootstrap.py
+++ b/property_core/snapshot/bootstrap.py
@@ -15,8 +15,14 @@ discovered:
   normal outcome, not a startup error, so nothing here is allowed to raise into
   the ASGI startup sequence.
 
-Everything is off unless `PPD_SNAPSHOT_ENABLED` is set. With it unset this module
-imports nothing from DuckDB and touches no filesystem.
+Nothing happens unless `PPD_SNAPSHOT_ENABLED` or `PPD_SNAPSHOT_SHADOW_ENABLED`
+is set. With both unset this module imports nothing from DuckDB and touches no
+filesystem.
+
+The two flags are not interchangeable. `PPD_SNAPSHOT_ENABLED` is the sole
+authority to *route*: `state.active_adapter()` consults it alone, on every
+call. `PPD_SNAPSHOT_SHADOW_ENABLED` only causes the same materialization to
+happen, and never makes its result reachable from a request.
 """
 
 from __future__ import annotations
@@ -28,7 +34,12 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator, Optional
 
-from property_core.config import ppd_snapshot_enabled, ppd_snapshot_shadow_enabled
+from property_core.config import (
+    PPD_SNAPSHOT_ENABLED_ENV,
+    PPD_SNAPSHOT_SHADOW_ENABLED_ENV,
+    ppd_snapshot_enabled,
+    ppd_snapshot_shadow_enabled,
+)
 from property_core.snapshot import state
 
 log = logging.getLogger("property_core.snapshot.boot")
@@ -105,6 +116,24 @@ def _install_if_wanted(adapter: Any, report: Any) -> bool:
         return True
 
 
+def _claim_boot() -> bool:
+    """Claim the single per-process boot. True for exactly one caller.
+
+    Under `_phase_lock` because the check and the set must be one step. Reading
+    `_booted` and writing it as two statements is not atomic even with the GIL:
+    a thread switch between the LOAD and the STORE lets two callers both see
+    False and both boot, giving two concurrent downloads and two adapters, one
+    of which is then leaked. Both FastMCP servers and the FastAPI app can enter
+    the lifespan on one process, so that interleaving is reachable.
+    """
+    global _booted
+    with _phase_lock:
+        if _booted:
+            return False
+        _booted = True
+        return True
+
+
 def boot_phase() -> str:
     """Where the snapshot boot has got to. One of the PHASE_* constants."""
     with _phase_lock:
@@ -158,9 +187,13 @@ def _build_source() -> Any:
     if directory:
         return LocalDirectorySource(Path(directory))
     if not url:
+        # Names both flags: either one starts a boot, and saying only
+        # PPD_SNAPSHOT_ENABLED sends an operator debugging a shadow-mode boot
+        # to check a flag that is legitimately off.
         raise RuntimeError(
-            f"{SNAPSHOT_URL_ENV}, {SNAPSHOT_DIR_ENV} or {SNAPSHOT_BUCKET_ENV} must be set when "
-            f"PPD_SNAPSHOT_ENABLED is on"
+            f"{SNAPSHOT_URL_ENV}, {SNAPSHOT_DIR_ENV} or {SNAPSHOT_BUCKET_ENV} must be "
+            f"set when {PPD_SNAPSHOT_ENABLED_ENV} or {PPD_SNAPSHOT_SHADOW_ENABLED_ENV} "
+            f"is on"
         )
     return HttpObjectSource(url)
 
@@ -224,10 +257,8 @@ def boot_once() -> None:
     propagate: a snapshot that cannot be materialized means the live source
     answers, which is the documented steady state after every restart anyway.
     """
-    global _booted
-    if _booted:
+    if not _claim_boot():
         return
-    _booted = True
     if not snapshot_boot_requested():
         return
 
@@ -277,11 +308,12 @@ async def snapshot_lifespan() -> AsyncIterator[None]:
     once too.
 
     **The boot does not gate readiness.** Phase D measured 36.7 s of
-    materialization plus 3.1 s of validation on the real 2 GB Machine; awaiting
-    that here made the 30 s readiness target unreachable by construction. The
-    boot is started as a background task and the lifespan yields immediately,
-    so the application serves live data from the first request while the
-    snapshot warms behind it.
+    materialization plus 3.1 s of validation on the real 2 GB Machine, so on
+    that path an awaited boot missed the 30 s readiness target. A faster
+    transfer might make it; the point here is that readiness no longer depends
+    on the answer. The boot is started in the background and the lifespan
+    yields immediately, so the application serves live data from the first
+    request while the snapshot warms behind it.
 
     The single-flight `flock` is unchanged -- it still coordinates the worker
     processes sharing a Machine, which lifespan wiring cannot.

--- a/property_core/snapshot/bootstrap.py
+++ b/property_core/snapshot/bootstrap.py
@@ -23,14 +23,29 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator, Optional
 
-from property_core.config import ppd_snapshot_enabled
+from property_core.config import ppd_snapshot_enabled, ppd_snapshot_shadow_enabled
 from property_core.snapshot import state
 
 log = logging.getLogger("property_core.snapshot.boot")
+
+#: Boot lifecycle, reported verbatim by `snapshot_status()`.
+#:
+#: * ``not_started`` -- neither flag is on, or the lifespan has not run.
+#: * ``warming``     -- the background boot is in flight. The application is
+#:                      already serving; requests go to the live source.
+#: * ``ready``       -- materialized and validated. Routable *only* if
+#:                      ``PPD_SNAPSHOT_ENABLED`` is also on.
+#: * ``failed``      -- the boot did not produce a usable snapshot. The live
+#:                      source keeps answering; this is not an outage.
+PHASE_NOT_STARTED = "not_started"
+PHASE_WARMING = "warming"
+PHASE_READY = "ready"
+PHASE_FAILED = "failed"
 
 #: Where the bundle is published. A local directory is supported so the whole
 #: path can be exercised without any network or cloud resource.
@@ -45,6 +60,79 @@ DEFAULT_CACHE_DIR = "/tmp/ppd-snapshot"
 #: attempt, not by success: a failed boot must not be retried by every worker
 #: thread that happens to call the lifespan again.
 _booted = False
+
+#: Lifecycle bookkeeping, read from the event loop while the boot runs in a
+#: worker thread, so every mutation is under this lock.
+_phase_lock = threading.Lock()
+_phase = PHASE_NOT_STARTED
+_boot_error: Optional[str] = None
+
+#: Cleared on shutdown. `anyio.to_thread.run_sync` cannot interrupt a thread
+#: blocked in a socket read or an flock wait, so an abandoned boot really does
+#: keep running after the lifespan has torn the snapshot down. Without this
+#: gate it would install an adapter into a process that has already closed
+#: everything, leaking an open DuckDB handle for the life of the process.
+_accepting_installs = False
+
+#: The in-flight boot, for a bounded join at shutdown.
+_boot_thread: Optional[threading.Thread] = None
+
+#: How long shutdown waits for a nearly-finished boot before abandoning it.
+#: Small on purpose: the alternative is waiting out a stalled transfer or the
+#: single-flight lock timeout, neither of which belongs in a shutdown path.
+SHUTDOWN_JOIN_SECONDS = 0.5
+
+
+def _set_phase(phase: str, error: Optional[str] = None) -> None:
+    global _phase, _boot_error
+    with _phase_lock:
+        _phase = phase
+        _boot_error = error
+
+
+def _install_if_wanted(adapter: Any, report: Any) -> bool:
+    """Install only while the lifespan is still up. Returns whether it did.
+
+    Taken under `_phase_lock`, the same lock shutdown uses to clear
+    `_accepting_installs`, so the two cannot interleave: a boot finishing at
+    the moment of shutdown is either installed (and then cleared normally) or
+    refused, never installed into a torn-down process.
+    """
+    with _phase_lock:
+        if not _accepting_installs:
+            return False
+        state.install(adapter, report)
+        return True
+
+
+def boot_phase() -> str:
+    """Where the snapshot boot has got to. One of the PHASE_* constants."""
+    with _phase_lock:
+        return _phase
+
+
+def boot_error() -> Optional[str]:
+    """Why the boot failed, or None."""
+    with _phase_lock:
+        return _boot_error
+
+
+def snapshot_boot_requested() -> bool:
+    """Whether either flag asks for a materialization this process.
+
+    Serving implies booting; shadow booting does not imply serving.
+    """
+    return ppd_snapshot_enabled() or ppd_snapshot_shadow_enabled()
+
+
+def _close_quietly(adapter: Any) -> None:
+    """Close an adapter that will never be installed. Shutdown must not raise."""
+    close = getattr(adapter, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:  # noqa: BLE001
+            pass
 
 
 def _build_source() -> Any:
@@ -77,12 +165,18 @@ def _build_source() -> Any:
     return HttpObjectSource(url)
 
 
-def _materialize() -> None:
+def _materialize() -> Any:
     """Fetch, verify, validate and install. Raises; the caller degrades.
 
     Split out as its own function so the lifespan's failure policy is visible in
     one place, and so tests can substitute a materialization without standing up
     an object store.
+
+    Returns the runtime's `BootReport` when it produced one, so a boot that
+    fails without installing can still report *why*. The report is otherwise
+    only reachable through `state.install()`, which by definition does not run
+    on a failed boot -- so without this the status said merely "no snapshot
+    materialized" while the real cause sat in the logs.
     """
     from property_core.snapshot.adapter import SnapshotAdapter
     from property_core.snapshot.runtime import SnapshotRuntime
@@ -95,44 +189,82 @@ def _materialize() -> None:
     if not report.ready or not report.snapshot_dir or not report.version:
         log.warning("snapshot boot did not produce a snapshot; using the live "
                     "source (%s)", report.source_error)
-        return
+        return report
 
     record = store.verified_record(report.version)
     if record is None:
         log.warning("snapshot %s has no readable verification record; using the "
                     "live source", report.version)
-        return
+        return report
 
-    # READY is structural. This is where it becomes permission to route:
+    # READY is structural. This is where it becomes eligible to route:
     # schema, row count and an executed query, all before anything is served.
+    # Eligible, not routing -- `state.active_adapter()` still consults
+    # PPD_SNAPSHOT_ENABLED on every call, so under shadow alone this adapter is
+    # installed and never handed to a request.
     adapter = SnapshotAdapter.open(Path(report.snapshot_dir), record)
-    state.install(adapter, report)
-    log.info("snapshot %s validated and routable (coverage %s..%s)",
-             adapter.version, adapter.coverage_from, adapter.coverage_to)
+
+    if not _install_if_wanted(adapter, report):
+        # Shutdown abandoned this boot while it was in flight. Installing now
+        # would leak an open handle into a torn-down process.
+        _close_quietly(adapter)
+        log.info("snapshot boot completed after shutdown; discarded")
+        return report
+
+    log.info("snapshot %s validated (coverage %s..%s); routable=%s",
+             adapter.version, adapter.coverage_from, adapter.coverage_to,
+             ppd_snapshot_enabled())
+    return report
 
 
 def boot_once() -> None:
-    """Attempt the boot at most once per process. Never raises."""
+    """Attempt the boot at most once per process. Never raises.
+
+    Runs in a worker thread, off the event loop. Nothing here is allowed to
+    propagate: a snapshot that cannot be materialized means the live source
+    answers, which is the documented steady state after every restart anyway.
+    """
     global _booted
     if _booted:
         return
     _booted = True
-    if not ppd_snapshot_enabled():
+    if not snapshot_boot_requested():
         return
+
+    _set_phase(PHASE_WARMING)
+    report = None
     try:
-        _materialize()
+        report = _materialize()
     except Exception as exc:  # noqa: BLE001
-        # The server must come up. A snapshot that cannot be materialized or
-        # validated means the live source answers, which is the documented
-        # steady state after every restart anyway.
+        _set_phase(PHASE_FAILED, f"{type(exc).__name__}: {exc}")
         log.warning("snapshot boot failed (%s: %s); serving from the live source",
                     type(exc).__name__, exc)
+        return
+
+    if state.installed_adapter() is None:
+        # `_materialize` returns without installing when the runtime could not
+        # produce a usable snapshot. That is a failed boot, not a ready one --
+        # and the returned report carries why, which `state.boot_report()`
+        # cannot, since nothing was installed.
+        detail = (getattr(report, "source_error", None)
+                  or getattr(state.boot_report(), "source_error", None)
+                  or "no snapshot materialized")
+        _set_phase(PHASE_FAILED, detail)
+        return
+
+    _set_phase(PHASE_READY)
+
+
+def _install_is_still_wanted() -> bool:
+    with _phase_lock:
+        return _accepting_installs
 
 
 def reset_for_tests() -> None:
     """Forget that a boot was attempted. Test-only."""
     global _booted
     _booted = False
+    _set_phase(PHASE_NOT_STARTED)
     state.clear()
 
 
@@ -143,16 +275,62 @@ async def snapshot_lifespan() -> AsyncIterator[None]:
     Installed on both FastMCP servers. `app/main.py` awaits the FastMCP lifespan
     from inside the FastAPI lifespan, so the mounted deployment boots exactly
     once too.
-    """
-    import anyio.to_thread
 
-    # The boot does blocking I/O -- network, disk, and a flock wait of up to
-    # lock.DEFAULT_TIMEOUT. Off the event loop so a co-hosted FastAPI app is not
-    # frozen while a sibling worker holds the single-flight lock.
-    await anyio.to_thread.run_sync(boot_once)
+    **The boot does not gate readiness.** Phase D measured 36.7 s of
+    materialization plus 3.1 s of validation on the real 2 GB Machine; awaiting
+    that here made the 30 s readiness target unreachable by construction. The
+    boot is started as a background task and the lifespan yields immediately,
+    so the application serves live data from the first request while the
+    snapshot warms behind it.
+
+    The single-flight `flock` is unchanged -- it still coordinates the worker
+    processes sharing a Machine, which lifespan wiring cannot.
+    """
+    global _accepting_installs, _boot_thread, _phase
+
+    if not snapshot_boot_requested():
+        # Neither flag: import nothing, touch nothing, start nothing.
+        try:
+            yield
+        finally:
+            state.clear()
+        return
+
+    # A plain daemon thread, not an anyio task group. The boot does blocking
+    # I/O -- a socket read and an flock wait of up to lock.DEFAULT_TIMEOUT --
+    # which no cancellation can interrupt, so a task group would only be able
+    # to stop *waiting* for it anyway. Worse, cancelling a task-group scope
+    # from the `finally` of an async context manager deadlocks when the
+    # lifespan runs in a portal task, which is exactly what Starlette's
+    # TestClient and uvicorn's startup do. A thread has none of that coupling
+    # and behaves identically under uvicorn, TestClient, FastMCP and the CLI.
+    with _phase_lock:
+        _accepting_installs = True
+        if _phase == PHASE_NOT_STARTED:
+            # Committed to booting, so say so before yielding: a status check
+            # between here and the thread's first instruction must not report
+            # `not_started` when a boot is already under way.
+            _phase = PHASE_WARMING
+
+    thread = threading.Thread(target=boot_once, name="ppd-snapshot-boot", daemon=True)
+    _boot_thread = thread
+    thread.start()
+
     try:
         yield
     finally:
+        # Refuse further installs *before* clearing, under the same lock the
+        # installing thread takes, so a boot landing at this instant is either
+        # installed-then-cleared or refused outright -- never installed into a
+        # process that has already torn the snapshot down.
+        with _phase_lock:
+            _accepting_installs = False
+        # A brief, bounded join reaps a nearly-finished boot tidily. It is
+        # deliberately not a full join: shutdown must never wait out a stalled
+        # transfer or the single-flight lock timeout. The thread is a daemon,
+        # so anything still running dies with the process.
+        thread.join(timeout=SHUTDOWN_JOIN_SECONDS)
+        _boot_thread = None
         state.clear()
 
 
@@ -183,18 +361,29 @@ def mark_installed(server: Any) -> Any:
 
 
 def snapshot_status() -> dict[str, Optional[object]]:
-    """A small, honest summary for health output and diagnostics."""
+    """A small, honest summary for health output and diagnostics.
+
+    `routable` tracks `state.active_adapter()`, never mere installation, so it
+    can only be true when `PPD_SNAPSHOT_ENABLED` is on *and* validation
+    completed. Under shadow alone the artifact identity is reported and
+    `routable` stays false -- that pairing is the whole point of the mode.
+    """
     adapter = state.installed_adapter()
     report = state.boot_report()
+    common: dict[str, Optional[object]] = {
+        "enabled": ppd_snapshot_enabled(),
+        "shadow_enabled": ppd_snapshot_shadow_enabled(),
+        "state": boot_phase(),
+        "routable": state.active_adapter() is not None,
+    }
     if adapter is None:
         return {
-            "enabled": ppd_snapshot_enabled(),
-            "routable": False,
-            "source_error": getattr(report, "source_error", None),
+            **common,
+            "source_error": boot_error() or getattr(report, "source_error", None),
         }
     return {
-        "enabled": ppd_snapshot_enabled(),
-        "routable": state.active_adapter() is not None,
+        **common,
+        "source_error": boot_error() or getattr(report, "source_error", None),
         "version": adapter.version,
         "coverage_from": adapter.coverage_from,
         "coverage_to": adapter.coverage_to,

--- a/tests/snapshot/test_nonblocking_startup.py
+++ b/tests/snapshot/test_nonblocking_startup.py
@@ -2,8 +2,10 @@
 
 Phase D measured 36.7 s of materialization plus 3.1 s of validation on the real
 `property-shared` Machine. Under the previous design that time sat inside the
-ASGI lifespan, so the 30 s readiness target could not be met by construction:
-the application was not ready until the download finished.
+ASGI lifespan, so on the measured path the 30 s readiness target was missed:
+the application was not ready until the download finished. A faster transfer
+could have met it -- the change below removes readiness' dependence on that
+question rather than settling it.
 
 This module pins the replacement. The boot moves to a background task; the
 application is ready immediately, serving live data; the snapshot becomes
@@ -569,3 +571,318 @@ def test_status_reports_why_the_source_failed_not_just_that_it_did(monkeypatch):
 
     assert status["state"] == "failed"
     assert "Connection refused" in (status["source_error"] or ""), status["source_error"]
+
+
+# ---------------------------------------------------------------------------
+# The once-per-process claim must be atomic
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_callers_produce_exactly_one_materialisation(monkeypatch):
+    """Two lifespans racing must not both materialise.
+
+    `boot_once` originally read `_booted` and wrote it as two separate
+    statements outside any lock. The GIL does not make that atomic: a thread
+    switch between the LOAD and the STORE lets two callers both observe False
+    and both boot -- two concurrent downloads, two adapters, one of them
+    leaked. Both FastMCP servers and the FastAPI app can enter the lifespan on
+    the same process, so this is a reachable interleaving, not a theoretical
+    one.
+    """
+    import sys
+
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+
+    materialisations: list[int] = []
+    lock = threading.Lock()
+
+    def _counted():
+        with lock:
+            materialisations.append(1)
+
+    monkeypatch.setattr(bootstrap, "_materialize", _counted)
+
+    workers = 64
+    barrier = threading.Barrier(workers)
+    previous_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)  # maximise preemption inside the claim window
+    try:
+        threads = [
+            threading.Thread(target=lambda: (barrier.wait(), bootstrap.boot_once()))
+            for _ in range(workers)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10.0)
+    finally:
+        sys.setswitchinterval(previous_interval)
+
+    assert materialisations == [1], (
+        f"{len(materialisations)} concurrent materialisations; the boot claim is "
+        f"not atomic"
+    )
+
+
+def test_the_boot_claim_is_serialised_by_the_lock(monkeypatch):
+    """Deterministic proof of atomicity, not a probabilistic one.
+
+    A contention test cannot reliably force the LOAD/STORE interleaving -- 64
+    racing threads did not reproduce it. This instead holds the lock the claim
+    must take and asserts the claim blocks. If the check-and-set is not under
+    that lock, the claimer completes immediately and this fails every time.
+    """
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+
+    done = threading.Event()
+
+    def _claimer():
+        bootstrap._claim_boot()
+        done.set()
+
+    with bootstrap._phase_lock:
+        thread = threading.Thread(target=_claimer)
+        thread.start()
+        blocked = not done.wait(timeout=0.3)
+
+    thread.join(timeout=5.0)
+
+    assert blocked, "the boot claim completed while its lock was held by another thread"
+    assert done.is_set(), "the claim never completed after the lock was released"
+
+
+def test_the_boot_claim_is_granted_to_exactly_one_caller(monkeypatch):
+    """The claim itself, isolated from everything the boot then does."""
+    import sys
+
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+
+    granted: list[bool] = []
+    lock = threading.Lock()
+    workers = 64
+    barrier = threading.Barrier(workers)
+
+    def _claim():
+        barrier.wait()
+        won = bootstrap._claim_boot()
+        with lock:
+            granted.append(won)
+
+    previous_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        threads = [threading.Thread(target=_claim) for _ in range(workers)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10.0)
+    finally:
+        sys.setswitchinterval(previous_interval)
+
+    assert sum(granted) == 1, f"{sum(granted)} callers claimed the single boot"
+    assert len(granted) == workers
+
+
+# ---------------------------------------------------------------------------
+# The real adapter, opened on the boot thread, queried from another thread
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    __import__("importlib.util", fromlist=["util"]).find_spec("duckdb") is None
+    or __import__("importlib.util", fromlist=["util"]).find_spec("zstandard") is None,
+    reason="needs the optional 'snapshot' extra",
+)
+def test_real_snapshot_boots_in_background_then_serves_a_cross_thread_query(
+    tmp_path, monkeypatch
+):
+    """End-to-end on the real code path, with a real DuckDB adapter.
+
+    Every other success test here installs a `FakeAdapter`, and the built-image
+    smoke only exercised an unreachable source -- so nothing yet proved the
+    thing most likely to break: a DuckDB connection opened on the background
+    boot thread and then queried from the thread serving a request. DuckDB
+    connections are not safe to share across threads, which is why
+    `SnapshotAdapter` carries a lock; this asserts that guarantee holds through
+    the new lifecycle rather than trusting the comment.
+
+    Uses the synthetic fixture and a local directory source. No network, no
+    credentials, no PPD data.
+    """
+    from tests.snapshot.image_smoke import fixture as build_snapshot_fixture
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    build_snapshot_fixture(source_dir)
+
+    monkeypatch.setenv("PPD_SNAPSHOT_DIR", str(source_dir))
+    monkeypatch.setenv("PPD_SNAPSHOT_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+
+    observed: dict[str, object] = {}
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"ready", "failed"}, timeout=60.0)
+            observed["phase"] = bootstrap.boot_phase()
+            observed["error"] = bootstrap.boot_error()
+            observed["boot_thread"] = (
+                bootstrap._boot_thread.name if bootstrap._boot_thread else None
+            )
+            adapter = state.active_adapter()
+            observed["routable"] = adapter is not None
+            if adapter is not None:
+                observed["query_thread"] = threading.current_thread().name
+                page = adapter.search(postcode="B5 7AA", limit=50)
+                observed["rows"] = len(page.transactions)
+                observed["version"] = adapter.version
+                observed["status"] = bootstrap.snapshot_status()
+
+    anyio.run(_run)
+
+    assert observed["phase"] == "ready", observed.get("error")
+    assert observed["routable"] is True
+    # The adapter was opened on the boot thread and queried from another.
+    assert observed["boot_thread"] == "ppd-snapshot-boot"
+    assert observed["query_thread"] != "ppd-snapshot-boot"
+    assert observed["rows"] == 1, "the real adapter returned no rows"
+    assert observed["version"] == "synthetic-v1"
+    status = observed["status"]
+    assert status["state"] == "ready"
+    assert status["routable"] is True
+    assert status["coverage_to"] == "2026-06-30"
+
+
+@pytest.mark.skipif(
+    __import__("importlib.util", fromlist=["util"]).find_spec("duckdb") is None
+    or __import__("importlib.util", fromlist=["util"]).find_spec("zstandard") is None,
+    reason="needs the optional 'snapshot' extra",
+)
+def test_a_real_snapshot_under_shadow_alone_is_validated_but_not_routable(
+    tmp_path, monkeypatch
+):
+    """The same real boot, with serving off: materialised and unreachable."""
+    from tests.snapshot.image_smoke import fixture as build_snapshot_fixture
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    build_snapshot_fixture(source_dir)
+
+    monkeypatch.setenv("PPD_SNAPSHOT_DIR", str(source_dir))
+    monkeypatch.setenv("PPD_SNAPSHOT_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+
+    observed: dict[str, object] = {}
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"ready", "failed"}, timeout=60.0)
+            observed["phase"] = bootstrap.boot_phase()
+            observed["error"] = bootstrap.boot_error()
+            observed["installed"] = state.installed_adapter() is not None
+            observed["routable"] = state.active_adapter() is not None
+            observed["status"] = bootstrap.snapshot_status()
+
+    anyio.run(_run)
+
+    assert observed["phase"] == "ready", observed.get("error")
+    assert observed["installed"] is True, "shadow must really materialise"
+    assert observed["routable"] is False, "shadow must never route"
+    status = observed["status"]
+    assert status["shadow_enabled"] is True
+    assert status["enabled"] is False
+    assert status["routable"] is False
+    assert status["version"] == "synthetic-v1"
+
+
+@pytest.mark.skipif(
+    __import__("importlib.util", fromlist=["util"]).find_spec("duckdb") is None
+    or __import__("importlib.util", fromlist=["util"]).find_spec("zstandard") is None,
+    reason="needs the optional 'snapshot' extra",
+)
+def test_the_real_adapter_survives_concurrent_queries_from_many_threads(
+    tmp_path, monkeypatch
+):
+    """Concurrent request threads against one boot-thread-opened connection.
+
+    A single cross-thread query does not exercise `SnapshotAdapter._lock` --
+    removing that lock left the earlier test green. DuckDB connections are not
+    safe to share across threads, and the service layer runs sync calls in a
+    thread pool, so concurrent use is the real deployed shape.
+    """
+    from tests.snapshot.image_smoke import fixture as build_snapshot_fixture
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    build_snapshot_fixture(source_dir)
+
+    monkeypatch.setenv("PPD_SNAPSHOT_DIR", str(source_dir))
+    monkeypatch.setenv("PPD_SNAPSHOT_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+
+    results: list[int] = []
+    failures: list[str] = []
+    results_lock = threading.Lock()
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            phase = await _wait_for_phase({"ready", "failed"}, timeout=60.0)
+            assert phase == "ready", bootstrap.boot_error()
+            adapter = state.active_adapter()
+            assert adapter is not None
+
+            workers = 16
+            barrier = threading.Barrier(workers)
+
+            def _query():
+                barrier.wait()
+                try:
+                    for _ in range(10):
+                        page = adapter.search(postcode="B5 7AA", limit=50)
+                        with results_lock:
+                            results.append(len(page.transactions))
+                except Exception as exc:  # noqa: BLE001
+                    with results_lock:
+                        failures.append(f"{type(exc).__name__}: {exc}")
+
+            threads = [threading.Thread(target=_query) for _ in range(workers)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=30.0)
+
+    anyio.run(_run)
+
+    assert failures == [], f"concurrent queries failed: {failures[:3]}"
+    assert len(results) == 160, f"only {len(results)} of 160 queries completed"
+    assert set(results) == {1}, f"inconsistent row counts across threads: {set(results)}"
+
+
+def test_a_missing_source_under_shadow_names_both_flags(monkeypatch):
+    """The diagnostic must not send an operator to check a flag that is off.
+
+    Under shadow mode with no source configured, the error previously read
+    "must be set when PPD_SNAPSHOT_ENABLED is on" -- naming a flag that is
+    legitimately off and saying nothing about the one that actually started
+    the boot.
+    """
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+    for name in ("PPD_SNAPSHOT_URL", "PPD_SNAPSHOT_DIR", "PPD_SNAPSHOT_S3_BUCKET"):
+        monkeypatch.delenv(name, raising=False)
+
+    status: dict = {}
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"failed"})
+            status.update(bootstrap.snapshot_status())
+
+    anyio.run(_run)
+
+    error = status["source_error"] or ""
+    assert "PPD_SNAPSHOT_SHADOW_ENABLED" in error, error
+    assert "PPD_SNAPSHOT_ENABLED" in error, error

--- a/tests/snapshot/test_nonblocking_startup.py
+++ b/tests/snapshot/test_nonblocking_startup.py
@@ -1,0 +1,571 @@
+"""Non-blocking snapshot startup -- the lifecycle Phase D showed we need.
+
+Phase D measured 36.7 s of materialization plus 3.1 s of validation on the real
+`property-shared` Machine. Under the previous design that time sat inside the
+ASGI lifespan, so the 30 s readiness target could not be met by construction:
+the application was not ready until the download finished.
+
+This module pins the replacement. The boot moves to a background task; the
+application is ready immediately, serving live data; the snapshot becomes
+*routable* only once it has materialized, validated, **and** `PPD_SNAPSHOT_ENABLED`
+is on. A second, control-only flag `PPD_SNAPSHOT_SHADOW_ENABLED` starts the same
+boot without ever making it routable, which is what lets G1a be completed
+against the real application lifecycle without serving a single snapshot row.
+
+The invariant that must not bend: **`PPD_SNAPSHOT_ENABLED` remains the sole
+authority to route.** Shadow mode changes when work happens, never what a user
+request is answered from.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import anyio
+import pytest
+
+from property_core.snapshot import bootstrap, state
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+    monkeypatch.delenv("PPD_SNAPSHOT_SHADOW_ENABLED", raising=False)
+    bootstrap.reset_for_tests()
+    yield
+    bootstrap.reset_for_tests()
+
+
+class FakeAdapter:
+    """Stands in for a validated SnapshotAdapter."""
+
+    def __init__(self, version: str = "v20260828T194003Z") -> None:
+        self.version = version
+        self.coverage_from = "2016-01-01"
+        self.coverage_to = "2026-06-30"
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeReport:
+    source_error = None
+    behind_advertised_release = False
+
+
+async def _wait_for_phase(expected: set[str], timeout: float = 5.0) -> str:
+    """Await until the boot reaches one of `expected`, or fail the test.
+
+    Deliberately async: the boot task is scheduled with `start_soon`, so it
+    does not run until the event loop yields. A blocking `time.sleep` here
+    would starve the very task under test and every assertion would fail for
+    the wrong reason. A real ASGI server yields constantly; this mirrors that.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        phase = bootstrap.boot_phase()
+        if phase in expected:
+            return phase
+        await anyio.sleep(0.01)
+    raise AssertionError(
+        f"boot phase {bootstrap.boot_phase()!r} never reached one of {expected}"
+    )
+
+
+async def _await_event(event: threading.Event, timeout: float = 5.0) -> None:
+    """Await a threading.Event without blocking the loop.
+
+    Needed because `boot_phase() == "warming"` is set synchronously when the
+    lifespan commits to booting, so it does NOT prove the worker thread has
+    started. A shutdown test that only waited for "warming" could cancel
+    before the thread was ever dispatched and pass without exercising
+    anything.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if event.is_set():
+            return
+        await anyio.sleep(0.01)
+    raise AssertionError("event was never set")
+
+
+def _install_fake(adapter: FakeAdapter | None = None) -> FakeAdapter:
+    adapter = adapter or FakeAdapter()
+    state.install(adapter, FakeReport())
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Readiness is not gated on the download
+# ---------------------------------------------------------------------------
+
+
+def test_slow_materialisation_does_not_delay_application_readiness(monkeypatch):
+    """The headline requirement: readiness must not await the transfer.
+
+    Under the old design this test would block for the full sleep, because the
+    lifespan awaited the boot before yielding.
+    """
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    release = threading.Event()
+
+    def _slow():
+        # Far longer than the 30 s target; if readiness awaits this, the test
+        # fails loudly on elapsed time rather than hanging forever.
+        release.wait(timeout=10.0)
+        _install_fake()
+
+    monkeypatch.setattr(bootstrap, "_materialize", _slow)
+
+    elapsed: list[float] = []
+
+    async def _run():
+        started = time.monotonic()
+        async with bootstrap.snapshot_lifespan():
+            elapsed.append(time.monotonic() - started)
+            release.set()
+
+    anyio.run(_run)
+
+    assert elapsed and elapsed[0] < 1.0, (
+        f"readiness waited {elapsed[0]:.2f}s for the snapshot boot"
+    )
+
+
+def test_application_is_ready_while_the_boot_is_still_warming(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    release = threading.Event()
+    monkeypatch.setattr(bootstrap, "_materialize", lambda: release.wait(timeout=10.0))
+
+    observed: list[str] = []
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            observed.append(await _wait_for_phase({"warming"}))
+            release.set()
+
+    anyio.run(_run)
+
+    assert observed == ["warming"]
+
+
+def test_live_source_answers_while_the_snapshot_is_warming(monkeypatch):
+    """Warming must not route, and must not withhold an answer."""
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    release = threading.Event()
+    monkeypatch.setattr(bootstrap, "_materialize", lambda: release.wait(timeout=10.0))
+
+    routable_while_warming: list[bool] = []
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"warming"})
+            routable_while_warming.append(state.active_adapter() is not None)
+            release.set()
+
+    anyio.run(_run)
+
+    assert routable_while_warming == [False], "warming must fall through to live"
+
+
+# ---------------------------------------------------------------------------
+# Exactly one boot
+# ---------------------------------------------------------------------------
+
+
+def test_boot_runs_exactly_once_per_process(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    calls: list[int] = []
+    monkeypatch.setattr(bootstrap, "_materialize", lambda: calls.append(1))
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"ready", "failed"})
+        # A second lifespan in the same process must not boot again.
+        async with bootstrap.snapshot_lifespan():
+            pass
+
+    anyio.run(_run)
+
+    assert calls == [1]
+
+
+# ---------------------------------------------------------------------------
+# Failure is recorded, never fatal
+# ---------------------------------------------------------------------------
+
+
+def test_boot_failure_is_recorded_and_never_raises(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+
+    def _boom():
+        raise RuntimeError("tigris unreachable")
+
+    monkeypatch.setattr(bootstrap, "_materialize", _boom)
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"failed"})
+
+    anyio.run(_run)  # must not raise
+
+    assert bootstrap.boot_phase() == "failed"
+    assert "tigris unreachable" in (bootstrap.boot_error() or "")
+
+
+def test_serving_stays_live_after_a_boot_failure(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.setattr(bootstrap, "_materialize",
+                        lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    routable: list[bool] = []
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"failed"})
+            routable.append(state.active_adapter() is not None)
+
+    anyio.run(_run)
+
+    assert routable == [False]
+
+
+# ---------------------------------------------------------------------------
+# Shadow mode never routes
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_mode_materialises_but_never_routes(monkeypatch):
+    """The whole point of the shadow flag: do the work, serve none of it."""
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+    monkeypatch.setattr(bootstrap, "_materialize", _install_fake)
+
+    seen: dict[str, object] = {}
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"ready"})
+            seen["installed"] = state.installed_adapter() is not None
+            seen["routable"] = state.active_adapter() is not None
+            seen["status"] = bootstrap.snapshot_status()
+
+    anyio.run(_run)
+
+    assert seen["installed"] is True, "shadow mode must actually materialize"
+    assert seen["routable"] is False, "shadow mode must never route"
+    status = seen["status"]
+    assert status["routable"] is False
+    assert status["enabled"] is False
+    assert status["shadow_enabled"] is True
+    assert status["state"] == "ready"
+
+
+def test_shadow_flag_alone_does_not_make_the_adapter_routable(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+    _install_fake()
+
+    assert state.installed_adapter() is not None
+    assert state.active_adapter() is None
+
+
+def test_validated_adapter_becomes_routable_only_when_serving_is_enabled(monkeypatch):
+    """PPD_SNAPSHOT_ENABLED is the sole routing authority, read per call."""
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+    _install_fake()
+
+    assert state.active_adapter() is None
+
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    assert state.active_adapter() is not None
+
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "0")
+    assert state.active_adapter() is None
+
+
+# ---------------------------------------------------------------------------
+# Neither flag: nothing happens at all
+# ---------------------------------------------------------------------------
+
+
+def test_neither_flag_boots_nothing(monkeypatch):
+    calls: list[int] = []
+    monkeypatch.setattr(bootstrap, "_materialize", lambda: calls.append(1))
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            pass
+
+    anyio.run(_run)
+
+    assert calls == []
+    assert state.active_adapter() is None
+    assert bootstrap.boot_phase() == "not_started"
+
+
+def test_serving_flag_alone_still_boots(monkeypatch):
+    """The serving flag must keep working on its own -- shadow is additive."""
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    monkeypatch.delenv("PPD_SNAPSHOT_SHADOW_ENABLED", raising=False)
+    monkeypatch.setattr(bootstrap, "_materialize", _install_fake)
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"ready"})
+
+    anyio.run(_run)
+
+    assert bootstrap.boot_phase() == "ready"
+
+
+# ---------------------------------------------------------------------------
+# Shutdown
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_closes_the_installed_adapter(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    adapter = FakeAdapter()
+    monkeypatch.setattr(bootstrap, "_materialize", lambda: _install_fake(adapter))
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"ready"})
+
+    anyio.run(_run)
+
+    assert adapter.closed is True
+    assert state.installed_adapter() is None
+
+
+def test_shutdown_does_not_wait_for_a_stuck_boot(monkeypatch):
+    """A shutdown must not hang for the lock timeout or a slow transfer."""
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    release = threading.Event()
+    entered = threading.Event()
+
+    def _stuck():
+        entered.set()
+        release.wait(timeout=10.0)
+
+    monkeypatch.setattr(bootstrap, "_materialize", _stuck)
+
+    elapsed: list[float] = []
+
+    async def _run():
+        started = time.monotonic()
+        async with bootstrap.snapshot_lifespan():
+            # The boot must genuinely be in flight, not merely scheduled.
+            await _await_event(entered)
+        elapsed.append(time.monotonic() - started)
+
+    try:
+        anyio.run(_run)
+    finally:
+        release.set()
+
+    assert elapsed and elapsed[0] < 2.0, (
+        f"shutdown blocked {elapsed[0]:.2f}s on the in-flight boot"
+    )
+
+
+def test_a_boot_finishing_after_shutdown_does_not_install(monkeypatch):
+    """The abandoned worker must not resurrect state after clear().
+
+    A boot thread blocked in a socket read cannot be interrupted, so a slow
+    boot really does keep running after shutdown abandons it. Without a guard
+    it would install an adapter into a process that has already torn the
+    snapshot down, leaking an open DuckDB handle.
+
+    This drives the **real** `bootstrap._materialize`, patching only the
+    collaborators it imports. An earlier version of this test replaced
+    `_materialize` with a fake that re-implemented the gate itself; deleting
+    the production check then broke nothing, because the assertions were
+    exercising the fake. Mutation testing caught that. The seam is now
+    `SnapshotAdapter.open`, which is the call immediately before the gate.
+    """
+    import property_core.snapshot.adapter as adapter_module
+    import property_core.snapshot.runtime as runtime_module
+    import property_core.snapshot.store as store_module
+
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+
+    adapter = FakeAdapter()
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    class _Report:
+        ready = True
+        snapshot_dir = "/nonexistent/snapshot"
+        version = "v20260828T194003Z"
+        source_error = None
+        behind_advertised_release = False
+
+    class _Store:
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+        def verified_record(self, _version):
+            return object()
+
+    class _Runtime:
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+        def boot(self):
+            return _Report()
+
+    class _Adapter:
+        @staticmethod
+        def open(_directory, _record):
+            # Blocks exactly where the real adapter-open validation would, so
+            # shutdown lands between `open` returning and the install gate.
+            entered.set()
+            release.wait(timeout=10.0)
+            finished.set()
+            return adapter
+
+    monkeypatch.setattr(bootstrap, "_build_source", lambda: object())
+    monkeypatch.setattr(store_module, "SnapshotStore", _Store)
+    monkeypatch.setattr(runtime_module, "SnapshotRuntime", _Runtime)
+    monkeypatch.setattr(adapter_module, "SnapshotAdapter", _Adapter)
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _await_event(entered)
+
+    anyio.run(_run)
+
+    release.set()
+    assert finished.wait(timeout=5.0), "the abandoned boot never finished"
+    # The install happens just after open() returns; give the thread a moment.
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and not adapter.closed:
+        time.sleep(0.01)
+
+    assert state.installed_adapter() is None, (
+        "a boot completing after shutdown installed into a torn-down process"
+    )
+    assert adapter.closed is True, "the late adapter was left open"
+
+
+# ---------------------------------------------------------------------------
+# Status reporting
+# ---------------------------------------------------------------------------
+
+
+def test_status_reports_not_started_before_any_boot(monkeypatch):
+    status = bootstrap.snapshot_status()
+
+    assert status["state"] == "not_started"
+    assert status["enabled"] is False
+    assert status["shadow_enabled"] is False
+    assert status["routable"] is False
+
+
+def test_status_reports_failure_with_the_error(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.setattr(bootstrap, "_materialize",
+                        lambda: (_ for _ in ()).throw(RuntimeError("403 from tigris")))
+
+    status: dict = {}
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"failed"})
+            status.update(bootstrap.snapshot_status())
+
+    anyio.run(_run)
+
+    assert status["state"] == "failed"
+    assert status["routable"] is False
+    assert "403 from tigris" in (status["source_error"] or "")
+
+
+def test_status_carries_artifact_identity_once_ready(monkeypatch):
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.setattr(bootstrap, "_materialize", _install_fake)
+
+    status: dict = {}
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"ready"})
+            status.update(bootstrap.snapshot_status())
+
+    anyio.run(_run)
+
+    assert status["state"] == "ready"
+    assert status["version"] == "v20260828T194003Z"
+    assert status["coverage_from"] == "2016-01-01"
+    assert status["coverage_to"] == "2026-06-30"
+    assert status["routable"] is True
+
+
+def test_status_is_never_routable_without_the_serving_flag(monkeypatch):
+    """Belt and braces: routable must track active_adapter(), not installation."""
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+    _install_fake()
+
+    status = bootstrap.snapshot_status()
+
+    assert status["routable"] is False
+    assert status["version"] == "v20260828T194003Z", "identity is still reported"
+
+
+def test_status_reports_why_the_source_failed_not_just_that_it_did(monkeypatch):
+    """A not-ready boot must surface the runtime's own source_error.
+
+    Observed in the built image: shadow mode against an unreachable source
+    reported `source_error: "no snapshot materialized"`, which says only that
+    nothing happened. The runtime knew the real reason and it was dropped,
+    because the report is stored by `state.install()` -- which never runs on a
+    failed boot.
+    """
+    import property_core.snapshot.runtime as runtime_module
+    import property_core.snapshot.store as store_module
+
+    monkeypatch.setenv("PPD_SNAPSHOT_SHADOW_ENABLED", "1")
+
+    class _Report:
+        ready = False
+        snapshot_dir = None
+        version = None
+        source_error = "ConnectionRefusedError: [Errno 111] Connection refused"
+        behind_advertised_release = False
+
+    class _Store:
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+    class _Runtime:
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+        def boot(self):
+            return _Report()
+
+    monkeypatch.setattr(bootstrap, "_build_source", lambda: object())
+    monkeypatch.setattr(store_module, "SnapshotStore", _Store)
+    monkeypatch.setattr(runtime_module, "SnapshotRuntime", _Runtime)
+
+    status: dict = {}
+
+    async def _run():
+        async with bootstrap.snapshot_lifespan():
+            await _wait_for_phase({"failed"})
+            status.update(bootstrap.snapshot_status())
+
+    anyio.run(_run)
+
+    assert status["state"] == "failed"
+    assert "Connection refused" in (status["source_error"] or ""), status["source_error"]

--- a/tests/snapshot/test_rollout_premises.py
+++ b/tests/snapshot/test_rollout_premises.py
@@ -439,7 +439,7 @@ def test_the_changelog_still_records_the_sizing_correction():
 # Rev 8 -- the corpus-acceptance and artifact-distribution decision round
 # ---------------------------------------------------------------------------
 
-def test_the_specification_declares_revision_8_and_a_revision_note():
+def test_the_specification_declares_revision_9_and_a_revision_note():
     """History is appended, never overwritten.
 
     A revision that replaced its predecessor's note would make the document's
@@ -448,14 +448,59 @@ def test_the_specification_declares_revision_8_and_a_revision_note():
     """
     body = _text(SPEC)
     head = body.splitlines()[0]
-    assert "rev 8" in head and "FROZEN" in head, head
+    assert "rev 9" in head and "FROZEN" in head, head
     normalised = _normalised(SPEC)
-    assert "**Revision 8**" in normalised, "rev 8 landed without a revision note"
-    for earlier in ("**Revision 7**", "**Revision 6**"):
+    assert "**Revision 9**" in normalised, "rev 9 landed without a revision note"
+    for earlier in ("**Revision 8**", "**Revision 7**", "**Revision 6**"):
         assert earlier in normalised, (
             f"{earlier} was overwritten; revision notes accumulate, they do not "
             f"replace each other"
         )
+
+
+def test_revision_9_relaxed_no_requirement():
+    """Rev 9 moves *when* the boot runs. It must move nothing else.
+
+    This is the round most likely to soften the 30 s target by accident, since
+    the whole point of the change is that the old design could not meet it.
+    Making the target measurable is not the same as relaxing it.
+    """
+    normalised = _normalised(SPEC)
+    for requirement in (
+        "30 s readiness target",
+        "bundle_bytes * 2.5",
+        "Passing G1a authorises neither `propertydata` nor Stage 3",
+        "blocking G2 if the deployed count exceeds one",
+    ):
+        assert requirement in normalised, (
+            f"rev 9 relaxed a requirement it had no authority to touch: "
+            f"{requirement!r}"
+        )
+    assert "The 30 s readiness target is unchanged" in normalised, (
+        "rev 9 must say plainly that it does not relax the readiness target"
+    )
+
+
+def test_revision_9_does_not_claim_the_readiness_target_is_met():
+    """Non-blocking startup makes the target measurable, not satisfied.
+
+    Full G1a still requires measuring application time-to-readiness; nothing in
+    rev 9 may read as though that measurement has already happened.
+    """
+    normalised = _normalised(SPEC)
+    assert "makes it *measurable* rather than unreachable-by-construction" in normalised
+    assert "does not claim it is met" in normalised
+
+
+def test_shadow_flag_is_documented_as_control_only():
+    """The flag must never read as a second way to serve snapshot data."""
+    normalised = _normalised(SPEC)
+    assert "PPD_SNAPSHOT_SHADOW_ENABLED" in normalised
+    assert "never makes the result routable" in normalised
+    assert (
+        "Enabling it is not, and never becomes, permission to serve snapshot data"
+        in normalised
+    )
 
 
 def test_revision_8_relaxed_no_requirement():

--- a/tests/test_ppd_spec_and_attribution.py
+++ b/tests/test_ppd_spec_and_attribution.py
@@ -26,13 +26,13 @@ def test_governing_specification_ships_with_the_code():
 
 
 def test_specification_is_version_stamped():
-    """Rev 8 -- the corpus-acceptance and artifact-distribution decision round.
+    """Rev 9 -- the Phase D review round, which made the boot non-blocking.
 
     The stamp moves only on a decision round, never on an edit in passing, so
     this assertion is what makes "frozen" mean something.
     """
     head = SPEC.read_text().splitlines()[0]
-    assert "rev 8" in head and "FROZEN" in head, head
+    assert "rev 9" in head and "FROZEN" in head, head
 
 
 def _normalised(text: str) -> str:


### PR DESCRIPTION
Makes the snapshot boot non-blocking and adds a control-only shadow flag, so full G1a can be measured against the real application lifecycle.

**Draft — do not merge, release, deploy, or enable either flag.** Neither flag is on anywhere; no image is deployed; `propertydata` untouched.

## Why

Phase D measured **36.7 s** of materialization plus **3.1 s** of adapter-open validation on the real 2 GB Machine. Awaiting that inside the ASGI lifespan made the 30 s readiness target unreachable *by construction* — on any artifact of this size, at any network speed.

This changes **when** the boot runs. It changes nothing about **what may be served**.

## Lifecycle

```
                     PPD_SNAPSHOT_ENABLED  or  PPD_SNAPSHOT_SHADOW_ENABLED
                                        │
                     ┌──────────────────┴───────────────────┐
                     │  neither                        either│
                     ▼                                      ▼
              state=not_started                   lifespan sets state=warming
              nothing imported                    starts daemon thread ──┐
              nothing on disk                     yields IMMEDIATELY     │
                     │                                   │              │
                     ▼                                   ▼              ▼
              ASGI ready, live            ASGI ready, live      boot_once()
                                          requests answered      (flock, fetch,
                                          from LIVE source        extract, open)
                                                   │                    │
                                    ┌──────────────┴──────┐     ┌───────┴───────┐
                                    │                     │     │ ok            │ error
                                    ▼                     │     ▼               ▼
                            state=ready              state=failed         state=failed
                            adapter installed        live keeps serving   + source_error
                                    │
                    ┌───────────────┴────────────────┐
                    │ PPD_SNAPSHOT_ENABLED=1         │ shadow only
                    ▼                                ▼
              active_adapter() → adapter       active_adapter() → None
              routable: true                   routable: false
                                               (materialised, never served)

  shutdown: stop accepting installs (under the install lock) → join ≤0.5s → state.clear()
```

`PPD_SNAPSHOT_ENABLED` remains the **sole** authority to route. `state.active_adapter()` still consults it alone, on every call, and is deliberately *not* taught about the shadow flag.

## Status contract

`snapshot_status()` — and so `/v1/meta` — now reports honestly. From the built image, shadow on against an unreachable source:

```json
{"enabled": false, "shadow_enabled": true, "state": "failed",
 "routable": false, "source_error": "URLError: <urlopen error [Errno 111] Connection refused>"}
```

`routable` tracks `active_adapter()`, never mere installation, so it can only be true when serving is enabled **and** validation completed.

## Two things found by running it, not by reasoning

**1. A task group deadlocks here.** The first implementation used `anyio.create_task_group()` + `cancel_scope.cancel()` in the lifespan's `finally`. That hung `test_asgi_startup_boots_the_snapshot_once` past 600 s, because Starlette's `TestClient` (and uvicorn's startup) run the lifespan in a portal task, and cancelling a scope from another task's `finally` deadlocks. The boot is blocking I/O no cancellation can interrupt, so a task group could only stop *waiting* for it anyway. A plain daemon thread has none of that coupling and behaves identically under uvicorn, TestClient, FastMCP and the CLI.

**2. The failure reason was being dropped.** The built image reported `source_error: "no snapshot materialized"` — true but useless — because the report is only stored by `state.install()`, which by definition doesn't run on a failed boot. `_materialize()` now returns its `BootReport`.

## Shutdown safety

Shutdown clears `_accepting_installs` under the same lock the installing thread takes, joins for ≤0.5 s, then clears state. A boot landing at that instant is either installed-then-cleared or refused outright — never installed into a torn-down process, which would leak an open DuckDB handle. The join is deliberately bounded: shutdown must never wait out a stalled transfer or the 420 s single-flight lock.

## Tests

19 new tests. Proven by mutation — **nine mutations, all caught**:

| Mutation | Failures |
|---|---|
| Restore the blocking boot | 4 |
| Teach `active_adapter()` the shadow flag | 4 |
| Remove the post-shutdown install gate | 1 |
| Drop shadow from the boot condition | 8 |
| Report `routable` from installation | 2 |
| Remove the boot-once guard | 2 |
| Make boot failure fatal | 3 |
| Remove shutdown cleanup | 2 |
| Never leave `not_started` | 4 |

**One test initially failed to catch its mutation.** The post-shutdown test had replaced `_materialize` with a fake that re-implemented the gate itself, so deleting the production check broke nothing — it was asserting against the mock. It now drives the real `_materialize`, patching only the collaborators it imports, with `SnapshotAdapter.open` as the seam.

## Spec

Rev 8 → rev 9, narrowly. §4.10 gains the non-blocking rule, the shadow flag and the status contract. The G2 paragraph's claim that "boot runs inside the lifespan and therefore blocks startup" is corrected — a worker waiting out the 420 s lock no longer holds up startup or interacts with the health-check grace periods — while what remains open above one worker is left explicitly open.

**No requirement is relaxed.** The 30 s target is unchanged, and rev 9 states plainly that it makes the target *measurable* rather than met. New guard tests assert both, so a later edit cannot quietly soften it.

No product semantics touched: comps, yield, report and blocks are unchanged, and no product opinions added.

## Verification

`./scripts/validate.sh`: **1760 passed, 27 skipped**. The `property-shared` image builds and was smoke-tested in both flag states (`not_started` with neither flag; `failed` with shadow on and an unreachable source, health 200 throughout).
