### PR TITLE
DO NOT MERGE/DEPLOY — Stage 1 shadow comparator (out of band, default off) + spec rev 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,19 @@ COPY property_core ./property_core
 # CMD; the app never imports it. One file only -- not tools/ or property_cli/.
 COPY tools/ppd_snapshot/boot_only_verify.py ./boot_only_verify.py
 
+# Stage 1 shadow comparison (docs/ops/ppd-stage1-shadow-runbook.md). Same
+# out-of-band contract as the verifier above: never imported by the app, never
+# wired into CMD, and refusing to do anything unless PPD_SHADOW_COMPARE_ENABLED
+# is explicitly set for the invocation.
+#
+# Three named files, not `tools/`. The comparator needs the frozen corpus
+# definition, and the definition is shared with the local rehearsal so that the
+# two tools cannot drift apart -- copying one without the other would ship a
+# comparator that cannot import its own corpus. Nothing else from `tools/`
+# (the build, packaging and release pipeline) belongs in a serving image.
+COPY tools/ppd_snapshot/__init__.py tools/ppd_snapshot/corpus.py \
+     tools/ppd_snapshot/stage1_shadow.py ./tools/ppd_snapshot/
+
 EXPOSE 8080
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/docs/design/ppd-shadow-corpus.md
+++ b/docs/design/ppd-shadow-corpus.md
@@ -142,6 +142,18 @@ because that boundary is a definitional choice rather than an artifact property,
 though an Instance must still qualify them and may substitute with recorded
 justification.
 
+**On S1's rule.** "Comparable or greater volume" is qualitative, and it stays
+qualitative: tooling checks it literally and, where an artifact falls below it,
+**refers the judgement rather than deciding it**. A threshold weaker than the
+words — an implementation quietly reading "comparable" as, say, a tenth — would
+be a downward revision of a frozen qualification rule made inside code, and is
+forbidden. The two ways to settle a below-threshold artifact are the ones this
+section already gives: accept it for that artifact with the decision recorded,
+or substitute with recorded justification. Substitution moves `B5`, `B50` and
+`B5 4` **together**: S3 and S9 are a sector inside S1's district and S2 is its
+neighbouring outcode, so moving one alone leaves the containment relation the
+baselines establish silently false.
+
 | # | Request shape | Intent | Instance qualifies by verifying |
 |---|---|---|---|
 | S1 | `postcode=B5`, `search_level=district` | contamination boundary | the longer neighbouring outcode holds comparable or greater volume |
@@ -407,7 +419,17 @@ and the Stage 1 run it governs.
   S13 and S14 use geographies with confirmed activity and an empty *filter*.
 * **Rows with no geography** — a small share of PPD rows carry no postcode, and
   so can never be returned by a geography-filtered query while still counting
-  toward snapshot totals. Whether any case should assert this is undecided.
+  toward snapshot totals. **Decided before Stage 1 began:** a row *returned* by
+  a geography-filtered query while carrying no usable postcode is a
+  **containment failure**, on whichever arm produced it, and blocks exit. This
+  is about what a query returns, not about rows sitting un-returnable in the
+  artifact — the limit above is unchanged.
+
+  Leaving it open in the implementation would have settled it in the weakest
+  direction: skipping such rows means a source could return arbitrary rows with
+  the postcode blanked and every containment check would still pass. Only the
+  count reaches a report (`rows_without_postcode`); the row is by definition the
+  one whose geography cannot be stated, so there is nothing else safe to record.
 * **All shape expectations are snapshot-side.** Live counts are unknown by
   construction; establishing them would require live queries, which are
   separately authorised.

--- a/docs/design/ppd-shadow-corpus.md
+++ b/docs/design/ppd-shadow-corpus.md
@@ -284,8 +284,9 @@ in whichever source produced it.
 
 ## 8. Stage 1 exit criteria
 
-Carried forward from rev 7 §7.2 unchanged, and unchanged again by rev 8. All
-must hold. **No percentage threshold.**
+Carried forward from rev 7 §7.2, unchanged by rev 8, and changed by **rev 10 in
+exactly one criterion — p95 — before Stage 1 started**. All must hold. **No
+percentage threshold.**
 
 * **Zero unexplained false empties** — no case where the snapshot returns empty
   and live returns rows within coverage without a classified explanation.
@@ -296,7 +297,18 @@ must hold. **No percentage threshold.**
   blocks exit.
 * **Zero snapshot errors** in the agreed corpus — no unhandled exception, no
   typed error where the request was in-coverage and well-formed.
-* **p95 < 1 second** on real traffic.
+* **p95 < 1 second on the deployed production Machine and selected artifact,
+  measured across the frozen corpus request mix** (rev 10). The governing
+  §7.2 carries the reasoning; in short, organic `comps` traffic here is sparse
+  and uncontrolled, so a percentile over it measures the callers rather than the
+  adapter, while this corpus is risk-shaped, repeatable and attributable.
+  **The request mix is chosen, not observed** — a corpus run is never to be
+  described as organic traffic.
+
+  Latency recorded by any run that is **not** on the deployed Machine and the
+  selected artifact — a local rehearsal above all — is `controlled_synthetic`
+  and is excluded from this percentile. The two are separate fields in a report
+  and no code path merges them.
 
 ---
 
@@ -366,8 +378,9 @@ expected shape — before any production shadow.
    dropping an adapter the caller had installed, would leave that process
    quietly different afterwards.
 
-**A rehearsal produces no real-traffic sample.** It can satisfy neither the p95
-criterion nor any divergence criterion — there is no live arm to diverge from.
+**A rehearsal is neither a production-Machine measurement nor a comparison.** It
+runs on a workstation against a local artifact, so it satisfies no p95 criterion,
+and it has no live arm, so it satisfies no divergence criterion.
 Its output is labelled a rehearsal result and is **never filed as Stage 1
 evidence**.
 

--- a/docs/design/ppd-source-routing.md
+++ b/docs/design/ppd-source-routing.md
@@ -1,7 +1,32 @@
-# PPD source-routing and implementation specification (rev 9 — FROZEN)
+# PPD source-routing and implementation specification (rev 10 — FROZEN)
 
-**Status:** **FROZEN at rev 9.** Accepted. No further architecture work. Changes
+**Status:** **FROZEN at rev 10.** Accepted. No further architecture work. Changes
 to this document require a new decision round, not an edit in passing.
+
+**Revision 10** was authorised by the Stage 1 mechanism decision round, before
+Stage 1 started and before any Stage 1 evidence existed. It changes **one exit
+criterion and nothing else**: §7.2's "p95 < 1 second **on real traffic**" becomes
+"**p95 < 1 second on the deployed production Machine and selected artifact,
+measured across the frozen corpus request mix**".
+
+The reasoning is stated in full at §7.2 and is summarised here: organic `comps`
+traffic on `property-shared` is sparse and uncontrolled, so a percentile over it
+measures the callers rather than the adapter, and could not be reproduced or
+attributed; the frozen thirteen-case corpus is deliberately risk-shaped, is
+identical between runs, and is harder than organic traffic. The revision also
+avoids adding permanent request-path machinery — a queue, a worker thread,
+sampling configuration and a telemetry stream inside the serving application —
+that would exist solely to produce rollout evidence and would outlive the gate.
+
+**What is given up is stated rather than hidden: the request mix is chosen, not
+observed.** This is a gate revision made *before* Stage 1, not a claim that a
+corpus run is organic traffic, and not a licence to relabel one as the other.
+
+**No other requirement is relaxed.** The 30 s readiness target, the
+`bundle_bytes * 2.5` headroom rule, the other five Stage 1 exit criteria, the
+`comps`-only corpus scope, and G1a, G1b, G2 and G3 are unchanged.
+`PPD_SNAPSHOT_ENABLED` remains the sole authority to route and remains absent.
+Nothing is enabled, no image is deployed, and no artifact is replaced.
 
 **Revision 9** was authorised by the Phase D review round, after the partial-G1a
 measurement recorded in
@@ -1141,15 +1166,56 @@ explanation, not a similarity score.
   ordering differences. An unclassified divergence blocks exit.
 * **Zero snapshot errors in the agreed corpus** — no unhandled exception, no
   typed error where the request was in-coverage and well-formed.
-* **p95 < 1 second** on real traffic.
+* **p95 < 1 second on the deployed production Machine and selected artifact,
+  measured across the frozen corpus request mix.** *(Revised at rev 10, before
+  Stage 1 began — see below.)*
 
 The corpus is agreed before Stage 1 begins and is fixed for the duration.
 
-**A local rehearsal is not Stage 1.** Exercising the fixed corpus against an
-already-verified local artifact validates routing, coverage handling and
-divergence classification. It produces no real-traffic sample, so it **cannot
-satisfy** the p95 criterion or the divergence exit criteria, and must never be
-recorded as a Stage 1 result. Consistent with the rule above, live SPARQL is
+**Rev 10 revision of the p95 criterion — made before Stage 1 started, and not a
+claim that synthetic traffic is organic traffic.** Rev 9 and earlier wrote this
+criterion as "p95 < 1 second **on real traffic**", which presumed a
+traffic-sampling shadow: a fraction of arriving `comps` requests would be
+compared and timed in the request path.
+
+That is deliberately no longer the mechanism, for two reasons.
+
+* **Organic `comps` traffic on `property-shared` is sparse and uncontrolled.**
+  A percentile over whatever requests happen to arrive is dominated by whatever
+  geography and window a caller happened to choose, and by how few of them there
+  were. It measures the callers, not the adapter. Reaching a defensible sample
+  size would take weeks, and the resulting mix would still be unknown and
+  unrepeatable — a number nobody could reproduce or attribute.
+* **The frozen corpus is risk-shaped on purpose.** Its thirteen cases were
+  chosen to span the contamination boundary, the thin and dense extremes,
+  truncation at `limit`, the widest 120-month window, type and category
+  filtering, and the expected-empty cases. That mix is *harder* than organic
+  traffic, is identical between runs, and is attributable case by case. A p95
+  over it is a statement about the adapter.
+
+The measurement therefore moves to the frozen corpus, executed **on the deployed
+production Machine, against the selected artifact** — which is what makes it a
+production measurement rather than a workstation one. What is given up is stated
+plainly rather than papered over: **the request mix is chosen, not observed.**
+This is a gate revision, made before any Stage 1 evidence existed, and it must
+never be read as a claim that a corpus run is organic traffic. Nothing else in
+the exit criteria is relaxed.
+
+**It also removes permanent production machinery introduced solely for rollout
+evidence.** Traffic sampling would have required a background queue, a worker
+thread, sampling configuration and a telemetry stream inside the serving
+application — code that exists only to measure a rollout, in the request path of
+a live service, outliving the gate it was built for. An out-of-band comparator
+on the same Machine has none of that: it is not in any request path, so "shadow
+comparison never makes a live request fail" holds by construction rather than by
+careful coding.
+
+**A local rehearsal is still not Stage 1.** Exercising the fixed corpus against
+an already-verified local artifact validates routing, coverage handling and
+divergence classification. It runs on a workstation with no live arm, so it is
+neither a production-Machine measurement nor a divergence comparison, and it
+**cannot satisfy** the p95 criterion or the divergence exit criteria. It must
+never be recorded as a Stage 1 result. Consistent with the rule above, live SPARQL is
 diagnostic, not the numerical gold standard; any new live SPARQL call is a
 separately authorised action.
 
@@ -1360,8 +1426,9 @@ Then, each separately authorised:
    separate design, and every mutation remains separately authorised.**
 6. **Fixed shadow corpus** — *merged (PR #30), and frozen.* Agreed before Stage 1
    and frozen for its duration. Its **local rehearsal** — *merged (PR #31)* — is
-   a correctness exercise only: it **cannot satisfy** Stage 1's real-traffic p95
-   or divergence exit criteria. The artifact-bound corpus **Instance** is written
+   a correctness exercise only: it runs on a workstation with no live arm, so
+   it **cannot satisfy** Stage 1's production-Machine p95 or divergence exit
+   criteria. The artifact-bound corpus **Instance** is written
    when the Stage 1 artifact is selected, and has not been.
 7. **Rollout gates** — G1a (`property-shared`, 2 GB), G1b (`propertydata`,
    512 MB), G2 (verified worker count, or one worker pinned) and G3

--- a/docs/ops/ppd-stage1-shadow-runbook.md
+++ b/docs/ops/ppd-stage1-shadow-runbook.md
@@ -194,22 +194,70 @@ fly ssh sftp get /tmp/stage1-candidate-instance.json
 
 ### Substituting a definitional geography
 
-§4 permits replacing `B5` / `B50` / `B5 4` **with recorded justification**. The
-Instance carries an optional `substitutions` block, and all three move together
-— S3 is a sector inside S1's district and S2 is its neighbouring outcode, so
-substituting one alone would leave the containment relation the baselines exist
-to establish silently false:
+§4 permits replacing `B5` / `B50` / `B5 4` **with recorded justification**.
 
-```json
-"substitutions": {
+**A substitution is a re-qualification, not an annotation.** Adding a
+`substitutions` block to an Instance qualified over `B5`/`B50`/`B5 4` produces a
+document where every required key is present and every rule is stated, and whose
+baselines and measurements describe geographies the run will never touch. The
+comparator refuses that: each definitional qualification entry names the
+geography it was measured over, and all three must match the Instance's
+effective geographies.
+
+The supported route is to **re-run `qualify` against the substitution**, so
+every count is taken over the geographies that will actually execute:
+
+```bash
+cat > /tmp/subs.json <<'JSON'
+{"substitutions": {
   "S1_district":           {"geography": "M3",   "justification": "..."},
   "S2_neighbour_district": {"geography": "M30",  "justification": "..."},
   "S3_sector":             {"geography": "M3 7", "justification": "..."}
-}
+}}
+JSON
+
+PPD_SHADOW_COMPARE_ENABLED=1 python -m tools.ppd_snapshot.stage1_shadow \
+    qualify --substitutions /tmp/subs.json \
+            --out /tmp/stage1-candidate-instance.json
 ```
+
+The three move together, and their **geometry is validated**: substituting is
+permitted, substituting into a shape that tests nothing is not.
+
+| Rule | Why |
+|---|---|
+| S1 and S2 are outward codes; S3 is a sector | a `search_level` and a geography that disagree describe a query the corpus never specified |
+| S2 **extends** S1 and is longer (`B5` → `B50`) | that *is* the contamination boundary — a district search for the shorter outcode wrongly prefix-matching the longer one. Two unrelated outcodes are merely two districts and test nothing |
+| S3 lies **inside** S1's district | S3's count is qualified as a strict subset of S1's and S9's as exceeding S3's on identical geography; a sector outside the district makes both relations meaningless while the baselines still look like numbers |
 
 A substitution with no justification is refused: the Definition permits the
 route only *with* one.
+
+### When the neighbour falls short of the literal rule
+
+`qualify` refers this judgement rather than settling it, and **the Instance must
+answer the referral**. An Instance whose `S1_district` entry records
+`comparable_or_greater: false` and nothing else is refused — a pending judgement
+is not a qualification. Record the owner's decision in that entry:
+
+```json
+"S1_district": {
+  "rule": "the longer neighbouring outcode holds comparable or greater volume",
+  "geography": "B5",
+  "measured_neighbour_ratio": 0.31,
+  "comparable_or_greater": false,
+  "owner_decision": {
+    "decision": "accepted",
+    "justification": "B50 is a small rural outcode; 31% still returns hundreds
+                      of rows, enough for contamination to show. Reviewed <date>."
+  }
+}
+```
+
+Only `"accepted"` qualifies the case, and only with a non-empty justification:
+an accepted shortfall with no stated reason is a decision nobody can review, and
+anything other than acceptance leaves the Definition's other route —
+substitute — untaken.
 
 `staleness_bound_days` is **enforced at load, not merely recorded**: the
 comparator refuses an Instance older than its own bound. The artifact is fixed,
@@ -263,6 +311,12 @@ bound survives a code change rather than resting on the shape of the loop.
 The run stops, and still writes its report, on any of: **the first error on
 either arm**, a failed `/v1/health`, a Machine `MemAvailable` below the floor,
 the deadline, an unclassified divergence, or a midnight crossing.
+
+**This applies to the latency pass too.** A snapshot error there stops the run
+rather than skipping the repetition: continuing would leave that case short of
+its thirty observations, and the gate would then report `insufficient_evidence`
+for a reason buried in an error list rather than the snapshot error that
+actually caused it.
 
 **A snapshot-arm failure stops the run before that case makes its live call.**
 Once the snapshot arm has failed, `zero_snapshot_errors` is unreachable, so

--- a/docs/ops/ppd-stage1-shadow-runbook.md
+++ b/docs/ops/ppd-stage1-shadow-runbook.md
@@ -1,0 +1,203 @@
+# Stage 1 shadow comparison — runbook
+
+**Nothing in this runbook has been executed.** It describes the sequence for the
+Stage 1 gate; every step is separately authorised. `PPD_SNAPSHOT_ENABLED` is
+absent from both applications and stays absent throughout — Stage 1 never routes
+a single request to the snapshot.
+
+Governed by [`docs/design/ppd-source-routing.md`](../design/ppd-source-routing.md)
+§7.2 (rev 10) and the frozen
+[`docs/design/ppd-shadow-corpus.md`](../design/ppd-shadow-corpus.md).
+
+---
+
+## What Stage 1 is here
+
+A **controlled production-Machine corpus run**. The thirteen frozen `comps`
+cases are executed on the deployed `property-shared` Machine, against the
+selected artifact `v20260828T194003Z` (coverage `2016-01-01..2026-06-30`), which
+that Machine has already materialized under `PPD_SNAPSHOT_SHADOW_ENABLED`.
+
+It is **not** a traffic sampler. Rev 10 revised the p95 criterion to say so
+explicitly, before Stage 1 began, and records what that gives up: the request
+mix is chosen, not observed. Read §7.2 before reading a report.
+
+**Why out of band.** The comparator is a separate process invoked over
+`fly ssh console`. It is in no request path, so *"shadow comparison never makes
+a live request fail"* holds by construction. Nothing permanent is added to the
+serving application: no queue, no worker thread, no sampling configuration and
+no telemetry stream that would outlive the gate it was built for.
+
+## Preconditions
+
+| | |
+|---|---|
+| G1a, G2, G3 | complete — [2026-08-31-ppd-snapshot-rollout.md](2026-08-31-ppd-snapshot-rollout.md) Phase E |
+| Artifact | `v20260828T194003Z` materialized and `state: ready` on the Machine |
+| `PPD_SNAPSHOT_ENABLED` | **absent** on both apps, and stays absent |
+| `PPD_SNAPSHOT_SHADOW_ENABLED` | set on `property-shared` only |
+| `propertydata` / G1b | out of scope, untouched |
+
+Confirm the artifact before anything else:
+
+```bash
+curl -s https://property-shared.fly.dev/v1/meta | jq .snapshot
+# expect: enabled false, shadow_enabled true, state "ready", routable false,
+#         version "v20260828T194003Z", coverage 2016-01-01..2026-06-30
+```
+
+`routable: false` while `state: ready` is the whole point of shadow mode: the
+artifact is validated on the Machine and reachable by no request.
+
+## Step 0 — baseline the Machine
+
+```bash
+uv run python scripts/fly_observability_snapshot.py \
+    --app property-shared --org personal --window 30m \
+    --output docs/ops/evidence/<date>-stage1-before.json
+```
+
+Existing tooling, reused deliberately. No new observability platform is
+introduced for this gate.
+
+## Step 1 — deploy (separately authorised)
+
+The comparator reaches the Machine through the ordinary image. This is a
+dependency-and-tooling change only: no flag, no routing, no behaviour change.
+
+```bash
+fly deploy --ha=false            # property-shared only
+```
+
+A deploy restarts the Machine, so the ephemeral rootfs is wiped and the snapshot
+re-materializes. Wait for `state: ready` again before continuing (Phase E
+measured ~44 s after readiness).
+
+## Step 2 — qualify the artifact
+
+Read-only. No download, no live call, nothing written into the snapshot.
+
+```bash
+fly ssh console -a property-shared
+cd /app
+PPD_SHADOW_COMPARE_ENABLED=1 python -m tools.ppd_snapshot.stage1_shadow \
+    qualify --out /tmp/stage1-candidate-instance.json
+cat /tmp/stage1-candidate-instance.json
+```
+
+It emits a **candidate** Instance: the full bundle digest and version, the seven
+selected geographies with the rule and measurement each satisfied, and the
+`S1_full` / `S3_full` / `S9_full` aggregate baselines.
+
+Check two fields before going further:
+
+* `unqualified_placeholders` — must be empty. A placeholder the artifact could
+  not qualify has no geography, and the corpus cannot run without one.
+* `baselines_satisfy_their_relations` — must be `true`. If it is `false`,
+  `baselines_refusal` says which relation failed; the Definition's remedy is a
+  substituted geography with recorded justification, which is an authoring
+  decision, not one this tool may make.
+
+## Step 3 — review and commit the Instance
+
+Retrieve the candidate, review it, and commit it as **its own small
+evidence/configuration change**:
+
+```bash
+fly ssh sftp get /tmp/stage1-candidate-instance.json
+```
+
+Set `governs_run` to the Stage 1 run it governs. Nothing artifact-specific is
+hard-coded in the tool, and the Instance is never read as runtime configuration.
+
+**A new artifact creates a new Instance and restarts Stage 1.** It never
+silently mutates the corpus.
+
+## Step 4 — run the comparison
+
+```bash
+fly ssh sftp shell            # put the reviewed instance at /tmp/stage1-instance.json
+fly ssh console -a property-shared
+cd /app
+PPD_SHADOW_COMPARE_ENABLED=1 python -m tools.ppd_snapshot.stage1_shadow \
+    compare \
+    --instance /tmp/stage1-instance.json \
+    --report   /tmp/stage1-report.json \
+    --latency-repeats 30 \
+    --max-live-per-case 1 \
+    --live-delay-seconds 2.0 \
+    --deadline-seconds 3600
+```
+
+Two passes:
+
+* **correctness** — every case once through each arm. **One rate-limited live
+  observation per case**: thirteen calls to HM Land Registry in total. A retry
+  beyond that needs separate authorisation.
+* **latency** — the snapshot arm alone, 13 cases × 30 repetitions = **390
+  observations**, with **no further live calls at all**.
+
+The run stops, and still writes its report, on any of: a failed `/v1/health`, a
+Machine `MemAvailable` below the floor, a snapshot error, the deadline, or an
+unclassified divergence.
+
+## Step 5 — close the evidence
+
+```bash
+fly ssh sftp get /tmp/stage1-report.json
+uv run python scripts/fly_observability_snapshot.py \
+    --app property-shared --org personal --window 30m \
+    --output docs/ops/evidence/<date>-stage1-after.json
+```
+
+Write `docs/ops/<date>-ppd-stage1-shadow.md` with the classification, the
+verdict against each exit criterion, and anything the run could not decide.
+
+## Reading the report
+
+`exit_criteria` carries one block per criterion. Three deserve care:
+
+**`field_equality_on_shared_ids`** — check `vacuous_comparison_shapes` before
+believing a pass. A shape listed there shared **no** transaction id while both
+arms returned rows. "100% equality on shared ids" is trivially true over an
+empty intersection, which is exactly what a systematic difference in id spelling
+between the two sources would produce. The tool reports that as a failure.
+
+**`every_divergence_classified`** — `unclassified` must be `0`.
+`operator_confirmation_required` counts proposed **later A/C/D revisions**,
+which cannot be evidenced from these two sources: confirming one needs the
+monthly change records published after the build. They are proposed, never
+asserted.
+
+**`p95_under_one_second`** — measured over the 390 snapshot-arm observations by
+nearest rank (sorted ascending, 1-based rank `ceil(p/100 × N)`; for N=390 and
+p=95 that is rank 371). An observed value, never an interpolation. `p50`, `p99`
+and `max` are reported for context; **only p95 < 1 s is the gate.**
+
+## Hygiene
+
+Transaction ids and the values of compared fields exist in memory for the length
+of one comparison and are then discarded. The report carries counts, month
+histograms, field-mismatch tallies, geography results, warning classes, source
+evidence, latency, classification and artifact identity. **No id, address, price
+or row reaches a report** — the same rule the local rehearsal already follows.
+
+## Rollback
+
+There is nothing to roll back. The comparator routes nothing, installs nothing
+into the serving process, downloads no artifact and writes nothing into the
+snapshot. Stopping means not running it; `PPD_SHADOW_COMPARE_ENABLED` is never
+persisted anywhere.
+
+## What Stage 1 will not prove
+
+* **Later A/C/D revision cannot be machine-evidenced.** It is proposed with
+  `operator_confirmation_required`, and because ids are deliberately not
+  persisted, chasing a specific row against HM Land Registry is not possible
+  from the report alone. An unclassified divergence blocks exit; what further
+  evidence to authorise is a decision at that point.
+* **False empties and geography contamination are proved for the corpus
+  geographies**, which is what the criteria ask — not for the whole artifact.
+* **The p95 is over a chosen request mix**, on the deployed Machine and the
+  selected artifact. It is not organic traffic and must never be described as
+  such.

--- a/docs/ops/ppd-stage1-shadow-runbook.md
+++ b/docs/ops/ppd-stage1-shadow-runbook.md
@@ -98,6 +98,9 @@ Check two fields before going further:
   substituted geography with recorded justification, which is an authoring
   decision, not one this tool may make.
 
+**`qualify` exits non-zero on either of those**, so a scripted invocation cannot
+mistake an unusable candidate for success.
+
 ## Step 3 — review and commit the Instance
 
 Retrieve the candidate, review it, and commit it as **its own small
@@ -107,8 +110,11 @@ evidence/configuration change**:
 fly ssh sftp get /tmp/stage1-candidate-instance.json
 ```
 
-Set `governs_run` to the Stage 1 run it governs. Nothing artifact-specific is
-hard-coded in the tool, and the Instance is never read as runtime configuration.
+Set `governs_run` to the Stage 1 run it governs. The comparator **refuses** an
+Instance whose `governs_run` is blank or still carries the placeholder `qualify`
+wrote: unfilled, that field ties the Instance to nothing, and its whole purpose
+is to record that this review happened. Nothing artifact-specific is hard-coded
+in the tool, and the Instance is never read as runtime configuration.
 
 **A new artifact creates a new Instance and restarts Stage 1.** It never
 silently mutates the corpus.
@@ -137,9 +143,32 @@ Two passes:
 * **latency** — the snapshot arm alone, 13 cases × 30 repetitions = **390
   observations**, with **no further live calls at all**.
 
+`--latency-repeats` is deliberately not a way to lower the bar: the gate is
+defined at 30 repetitions per case, and a run producing fewer reports
+`insufficient_evidence`, never a pass.
+
 The run stops, and still writes its report, on any of: a failed `/v1/health`, a
-Machine `MemAvailable` below the floor, a snapshot error, the deadline, or an
-unclassified divergence.
+Machine `MemAvailable` below the floor, the deadline, an unclassified
+divergence, or a midnight crossing. A health, memory and deadline check also
+runs **after the final observation**, so a run cannot finish on a Machine that
+went bad during its last case and report a pass measured under conditions
+nobody checked.
+
+### Midnight
+
+`comps` derives its window from `date.today()`, so an observation straddling
+midnight describes a different window from the one recorded. Such an observation
+is **never skipped** — skipping it would leave a report claiming thirteen cases
+while holding twelve, and a latency sample short of its declared size, with the
+totals concealing both.
+
+The snapshot arm retries up to three times, because a local retry costs nothing.
+The live arm does not: a retry there is another request to HM Land Registry and
+the correctness pass is budgeted at one per case. A crossing that survives its
+retries **aborts the run and writes a failed report**. The two arms of a pair
+must also share a calendar date; if they do not, the pair compares two different
+windows and the run aborts — nothing downstream could detect that, since both
+arms look internally consistent on their own.
 
 ## Step 5 — close the evidence
 
@@ -155,7 +184,16 @@ verdict against each exit criterion, and anything the run could not decide.
 
 ## Reading the report
 
-`exit_criteria` carries one block per criterion. Three deserve care:
+`exit_criteria` carries one block per criterion, and **every one of them can
+only move the verdict towards failure**. There is no path by which a missing
+observation, an absent arm, a short sample or an unconfirmed classification
+produces a pass: absence is never evidence of compliance.
+
+`all_thirteen_cases_compared` is a precondition for most of the others. A report
+covering fewer than thirteen cases with two successful arms each is not a
+smaller Stage 1 result — it is not a Stage 1 result.
+
+Four blocks deserve particular care:
 
 **`field_equality_on_shared_ids`** — check `vacuous_comparison_shapes` before
 believing a pass. A shape listed there shared **no** transaction id while both
@@ -163,16 +201,49 @@ arms returned rows. "100% equality on shared ids" is trivially true over an
 empty intersection, which is exactly what a systematic difference in id spelling
 between the two sources would produce. The tool reports that as a failure.
 
-**`every_divergence_classified`** — `unclassified` must be `0`.
+**`every_divergence_classified`** — `unclassified` must be `0`. Note that
+**live truncation or ordering is classified only from captured live transport
+evidence** (`raw_bindings_returned` against `fetch_limit`). Page saturation on
+either side is recorded under `context_not_evidence` and classifies nothing: a
+live page at `limit` says our own presentation limit was reached, not that the
+upstream window was, and a saturated snapshot page says nothing about live at
+all. With no transport evidence a divergence stays unclassified and blocks exit,
+which is the fail-closed direction.
+
+**`no_unconfirmed_classifications`** — **blocking, not advisory.**
 `operator_confirmation_required` counts proposed **later A/C/D revisions**,
 which cannot be evidenced from these two sources: confirming one needs the
-monthly change records published after the build. They are proposed, never
-asserted.
+monthly change records published after the build. While any remain proposed,
+Stage 1 cannot exit on this report alone. Obtaining that external confirmation
+is a separately authorised step.
 
-**`p95_under_one_second`** — measured over the 390 snapshot-arm observations by
-nearest rank (sorted ascending, 1-based rank `ceil(p/100 × N)`; for N=390 and
-p=95 that is rank 371). An observed value, never an interpolation. `p50`, `p99`
-and `max` are reported for context; **only p95 < 1 s is the gate.**
+**`p95_under_one_second`** — carries a `verdict` of `pass`, `fail` or
+`insufficient_evidence`. It requires **exactly 390 observations and exactly 30
+for every case**; anything less is `insufficient_evidence`, never a pass, and
+`cases_short_of_the_required_repeats` names the shortfall. A total that happens
+to come out right while one case was measured 29 times and another 31 is also
+`insufficient_evidence` — the percentile would be weighted towards the
+over-sampled shapes, which is a different measurement from the one the gate is
+defined over. Computed by nearest rank (sorted ascending, 1-based rank
+`ceil(p/100 × N)`; for N=390 and p=95 that is rank 371) — an observed value,
+never an interpolation. `p50`, `p99` and `max` are reported for context;
+**only p95 < 1 s is the gate.**
+
+## Corpus invariants
+
+`corpus_invariants_hold` asserts Definition §3's universal invariants on the
+snapshot arm of every case — the coverage-clamp warning present,
+`sample_complete` false, `completeness_basis` null, `recent_period_provisional`
+true, answered by the snapshot — plus each shape's own intent: S1's geography
+isolation, S4's thin-market flag, S5 and S12 truncated at `limit`, S11 empty
+while still flagged provisional, S13 and S14 empty. These are structural, not
+situational: a case reporting `sample_complete: true` is a **defect**, not a
+divergence.
+
+The same assertions are used by the local rehearsal, from the one shared
+Definition module, so the two tools cannot check different things. Each arm also
+records `returned_date_from` / `returned_date_to` (Definition §9) — the bounds
+that show a window was honoured. Two dates are not a transaction.
 
 ## Hygiene
 

--- a/docs/ops/ppd-stage1-shadow-runbook.md
+++ b/docs/ops/ppd-stage1-shadow-runbook.md
@@ -89,8 +89,9 @@ scope — `Dockerfile.app` is untouched by this work, `propertydata` carries no
 carry the comparator, and G1b is neither attempted nor affected. "Untouched"
 means untouched in configuration and scope, not that no deploy reaches it.
 
-After the release completes, confirm what is actually running — from the app,
-never from git:
+### Post-release checks — `property-shared`
+
+Confirm what is actually running, from the app and never from git:
 
 ```bash
 fly image show -a property-shared
@@ -101,6 +102,34 @@ A deploy restarts the Machine, so the ephemeral rootfs is wiped and the snapshot
 re-materializes. Wait for `state: ready` again before continuing (Phase E
 measured ~44 s after readiness). Confirm `enabled: false` and `routable: false`
 have not changed.
+
+### Post-release checks — `propertydata`
+
+**This app is redeployed by the same release and must be checked, not assumed.**
+It is out of Stage 1 scope, which is a statement about what changes — not a
+reason to skip verifying that nothing did. Its `/health` carries no snapshot
+block, so the checks are external:
+
+```bash
+# 1. It is serving.
+curl -s -o /dev/null -w '%{http_code}\n' https://propertydata.fly.dev/health   # 200
+fly status -a propertydata                                                     # machine started, checks passing
+
+# 2. No snapshot configuration reached it. Expect NO PPD_SNAPSHOT_* entries.
+fly secrets list -a propertydata
+
+# 3. It did not gain the comparator or the boot verifier.
+fly ssh console -a propertydata -C "ls /app/tools/ppd_snapshot/stage1_shadow.py"  # expect: no such file
+fly ssh console -a propertydata -C "ls /app/boot_only_verify.py"                  # expect: no such file
+
+# 4. The MCP surface still answers.
+fly image show -a propertydata
+```
+
+If any of these differ from the expectation, **stop**: `propertydata` has
+changed in a way this work did not intend, and that is a finding in its own
+right rather than something to note and continue past. G1b remains unattempted
+either way — passing G1a authorises neither `propertydata` nor Stage 3.
 
 ## Step 2 — qualify the artifact
 
@@ -133,14 +162,23 @@ Check two fields before going further:
   frozen parameters, and S1 needs a neighbour carrying enough volume for
   B50-in-B5 contamination to be visible at all. Against a near-empty `B50`, a
   clean S1 result proves nothing — the contamination boundary becomes a test
-  that cannot fail. Unlike the seven placeholders these cannot be substituted:
-  `B5`/`B50` *is* the boundary the corpus is built around.
+  that cannot fail.
+* `requires_owner_adjudication` — must be empty **before Stage 1 runs**, and it
+  is not a failure. §4 states S1's rule qualitatively: *the longer neighbouring
+  outcode holds comparable or greater volume*. The tool checks that literally
+  (`NEIGHBOUR_COMPARABLE_RATIO = 1.0`) and, where the artifact falls below it,
+  **neither passes nor fails the case** — it records the measured ratio and
+  refers the judgement. "Is 0.6 comparable for this artifact?" is a decision
+  about the corpus, and §4 already gives the two ways to settle it:
 
-  The Definition states S1's rule qualitatively ("comparable or greater
-  volume"). A tool needs a number, so the threshold is named in
-  `MIN_NEIGHBOUR_VOLUME_RATIO` and the **measured ratio is recorded beside it**
-  under `threshold_is_an_operationalisation` — judge the operationalisation
-  rather than trust it.
+  1. **accept it** for this artifact, recording that decision; or
+  2. **substitute** the definitional geographies with recorded justification.
+
+  An earlier revision of this tool auto-qualified at a 10% ratio. That was
+  wrong twice over — a tenth is not "comparable or greater", and redefining a
+  frozen qualification rule downwards is not something an implementation may
+  do. It is recorded here so the mistake is not repeated by someone who thinks
+  a threshold is missing.
 
 **`qualify` exits non-zero on any of those**, so a scripted invocation cannot
 mistake an unusable candidate for success.
@@ -153,6 +191,25 @@ evidence/configuration change**:
 ```bash
 fly ssh sftp get /tmp/stage1-candidate-instance.json
 ```
+
+### Substituting a definitional geography
+
+§4 permits replacing `B5` / `B50` / `B5 4` **with recorded justification**. The
+Instance carries an optional `substitutions` block, and all three move together
+— S3 is a sector inside S1's district and S2 is its neighbouring outcode, so
+substituting one alone would leave the containment relation the baselines exist
+to establish silently false:
+
+```json
+"substitutions": {
+  "S1_district":           {"geography": "M3",   "justification": "..."},
+  "S2_neighbour_district": {"geography": "M30",  "justification": "..."},
+  "S3_sector":             {"geography": "M3 7", "justification": "..."}
+}
+```
+
+A substitution with no justification is refused: the Definition permits the
+route only *with* one.
 
 `staleness_bound_days` is **enforced at load, not merely recorded**: the
 comparator refuses an Instance older than its own bound. The artifact is fixed,
@@ -203,9 +260,16 @@ they have a control they do not have. The live budget
 (`max_live_per_case x 13`) is checked before every live call, so the declared
 bound survives a code change rather than resting on the shape of the loop.
 
-The run stops, and still writes its report, on any of: a failed `/v1/health`, a
-Machine `MemAvailable` below the floor, the deadline, an unclassified
-divergence, or a midnight crossing. A health, memory and deadline check also
+The run stops, and still writes its report, on any of: **the first error on
+either arm**, a failed `/v1/health`, a Machine `MemAvailable` below the floor,
+the deadline, an unclassified divergence, or a midnight crossing.
+
+**A snapshot-arm failure stops the run before that case makes its live call.**
+Once the snapshot arm has failed, `zero_snapshot_errors` is unreachable, so
+every later case is work whose result cannot change the verdict — and the live
+call would be a request to HM Land Registry for a comparison that can no longer
+take place. A live-arm failure stops the run for the same reason:
+`all_thirteen_cases_compared` is already lost. A health, memory and deadline check also
 runs **after the final observation**, so a run cannot finish on a Machine that
 went bad during its last case and report a pass measured under conditions
 nobody checked.
@@ -296,6 +360,14 @@ neither arm is assumed clean because the other is:
 | `district` | its outcode differs (`B50` in a `B5` result) |
 | `sector` | its outcode differs, **or its sector does** (`B5 6` in a `B5 4` result) |
 | `postcode` | either of the above, **or it is a different unit in the same sector** |
+
+A returned row carrying **no usable postcode** is a containment failure at every
+level, on either arm. §11 lists such rows as a known limit and leaves the
+question open; skipping them would settle it in the weakest possible direction,
+since a source could then return arbitrary rows with the postcode blanked and
+every containment check would pass. Only `rows_without_postcode: N` is
+persisted — the row is by definition the one whose geography cannot be stated,
+so there is nothing else safe to record about it.
 
 An outcode-only test passes a sector case handed a neighbouring sector in the
 same outcode — which is the sector-isolation trap the Definition names in its

--- a/docs/ops/ppd-stage1-shadow-runbook.md
+++ b/docs/ops/ppd-stage1-shadow-runbook.md
@@ -36,7 +36,7 @@ no telemetry stream that would outlive the gate it was built for.
 | Artifact | `v20260828T194003Z` materialized and `state: ready` on the Machine |
 | `PPD_SNAPSHOT_ENABLED` | **absent** on both apps, and stays absent |
 | `PPD_SNAPSHOT_SHADOW_ENABLED` | set on `property-shared` only |
-| `propertydata` / G1b | out of scope, untouched |
+| `propertydata` / G1b | out of scope; redeployed by the shared release workflow, but unchanged in configuration and scope |
 
 Confirm the artifact before anything else:
 
@@ -60,18 +60,47 @@ uv run python scripts/fly_observability_snapshot.py \
 Existing tooling, reused deliberately. No new observability platform is
 introduced for this gate.
 
-## Step 1 — deploy (separately authorised)
+## Step 1 — release and deploy (separately authorised)
 
-The comparator reaches the Machine through the ordinary image. This is a
-dependency-and-tooling change only: no flag, no routing, no behaviour change.
+**Use the established release workflow, not a manual `fly deploy`.** Publishing
+a GitHub release runs `.github/workflows/release.yml`, which validates the
+released revision, publishes to PyPI, and deploys **both** Fly apps from that
+commit.
+
+```
+merge PR -> publish a GitHub release -> release.yml:
+    validate (_validate.yml)
+      -> publish to PyPI
+        -> flyctl deploy --remote-only --ha=false                 (property-shared)
+        -> flyctl deploy --config fly.app.toml --remote-only ...  (propertydata)
+```
+
+A local `fly deploy` ships **the working directory, not a commit**. Stage 1
+evidence has to be attributable to a revision — a measurement taken against an
+image built from whatever happened to be on a laptop cannot be tied to anything,
+and "which code produced this p95?" becomes unanswerable. That is the whole
+reason the release path exists; use it.
+
+**This redeploys `propertydata` too.** Say so plainly rather than claiming
+otherwise: `release.yml` deploys both apps on every release, so `propertydata`
+receives the new image. What does **not** change is its configuration or its
+scope — `Dockerfile.app` is untouched by this work, `propertydata` carries no
+`PPD_SNAPSHOT_*` secret, its snapshot state stays `not_started`, it does not
+carry the comparator, and G1b is neither attempted nor affected. "Untouched"
+means untouched in configuration and scope, not that no deploy reaches it.
+
+After the release completes, confirm what is actually running — from the app,
+never from git:
 
 ```bash
-fly deploy --ha=false            # property-shared only
+fly image show -a property-shared
+curl -s https://property-shared.fly.dev/v1/meta | jq .snapshot
 ```
 
 A deploy restarts the Machine, so the ephemeral rootfs is wiped and the snapshot
 re-materializes. Wait for `state: ready` again before continuing (Phase E
-measured ~44 s after readiness).
+measured ~44 s after readiness). Confirm `enabled: false` and `routable: false`
+have not changed.
 
 ## Step 2 — qualify the artifact
 
@@ -98,7 +127,22 @@ Check two fields before going further:
   substituted geography with recorded justification, which is an authoring
   decision, not one this tool may make.
 
-**`qualify` exits non-zero on either of those**, so a scripted invocation cannot
+* `unqualified_definitional_cases` — must be empty. `B5` and `B50` are named in
+  the Definition because the boundary is a definitional choice, but §4 is
+  explicit that an Instance must still qualify them: S2 must be non-empty under
+  frozen parameters, and S1 needs a neighbour carrying enough volume for
+  B50-in-B5 contamination to be visible at all. Against a near-empty `B50`, a
+  clean S1 result proves nothing — the contamination boundary becomes a test
+  that cannot fail. Unlike the seven placeholders these cannot be substituted:
+  `B5`/`B50` *is* the boundary the corpus is built around.
+
+  The Definition states S1's rule qualitatively ("comparable or greater
+  volume"). A tool needs a number, so the threshold is named in
+  `MIN_NEIGHBOUR_VOLUME_RATIO` and the **measured ratio is recorded beside it**
+  under `threshold_is_an_operationalisation` — judge the operationalisation
+  rather than trust it.
+
+**`qualify` exits non-zero on any of those**, so a scripted invocation cannot
 mistake an unusable candidate for success.
 
 ## Step 3 — review and commit the Instance
@@ -109,6 +153,13 @@ evidence/configuration change**:
 ```bash
 fly ssh sftp get /tmp/stage1-candidate-instance.json
 ```
+
+`staleness_bound_days` is **enforced at load, not merely recorded**: the
+comparator refuses an Instance older than its own bound. The artifact is fixed,
+but the frozen window moves forward every day, so counts qualified months ago
+describe a query nobody now runs. Re-run `qualify` rather than reusing them.
+`qualified_at` must be a canonical `YYYY-MM-DD` string and may not be in the
+future.
 
 Set `governs_run` to the Stage 1 run it governs. The comparator **refuses** an
 Instance whose `governs_run` is blank or still carries the placeholder `qualify`
@@ -145,7 +196,12 @@ Two passes:
 
 `--latency-repeats` is deliberately not a way to lower the bar: the gate is
 defined at 30 repetitions per case, and a run producing fewer reports
-`insufficient_evidence`, never a pass.
+`insufficient_evidence`, never a pass. `--max-live-per-case` below 1 and
+`--latency-repeats` below 1 are **refused before any work happens** — an option
+that silently does nothing is worse than no option, because it tells an operator
+they have a control they do not have. The live budget
+(`max_live_per_case x 13`) is checked before every live call, so the declared
+bound survives a code change rather than resting on the shape of the loop.
 
 The run stops, and still writes its report, on any of: a failed `/v1/health`, a
 Machine `MemAvailable` below the floor, the deadline, an unclassified
@@ -228,6 +284,28 @@ defined over. Computed by nearest rank (sorted ascending, 1-based rank
 `ceil(p/100 × N)`; for N=390 and p=95 that is rank 371) — an observed value,
 never an interpolation. `p50`, `p99` and `max` are reported for context;
 **only p95 < 1 s is the gate.**
+
+## Geography containment
+
+`zero_geography_contamination` is checked **at the level each case asked at**,
+on **both** arms — contamination is a defect in whichever source produced it, so
+neither arm is assumed clean because the other is:
+
+| `search_level` | a row is out of area when |
+|---|---|
+| `district` | its outcode differs (`B50` in a `B5` result) |
+| `sector` | its outcode differs, **or its sector does** (`B5 6` in a `B5 4` result) |
+| `postcode` | either of the above, **or it is a different unit in the same sector** |
+
+An outcode-only test passes a sector case handed a neighbouring sector in the
+same outcode — which is the sector-isolation trap the Definition names in its
+own right (`M3 7` returns only `M3 7`).
+
+Findings are reported at **sector and outcode granularity only**, the hygiene
+rule the local rehearsal already follows. A unit-level violation inside the
+requested sector is recorded as `same_sector_unit_violations: N` and the
+offending postcode is never named: the count is what proves the contamination,
+and the unit would be the most identifying value in the report.
 
 ## Corpus invariants
 

--- a/docs/ops/ppd-stage1-shadow-runbook.md
+++ b/docs/ops/ppd-stage1-shadow-runbook.md
@@ -221,6 +221,13 @@ PPD_SHADOW_COMPARE_ENABLED=1 python -m tools.ppd_snapshot.stage1_shadow \
             --out /tmp/stage1-candidate-instance.json
 ```
 
+The candidate this writes carries the **complete substitution block,
+justifications included** — take it as written. A reviewer fills in
+`governs_run`, and an owner decision where one is required, and nothing else:
+every measurement, geography and derived field is already bound to the
+substituted run, and hand-reconstructing any of it is a place for the evidence
+and the run to drift apart.
+
 The three move together, and their **geometry is validated**: substituting is
 permitted, substituting into a shape that tests nothing is not.
 
@@ -265,6 +272,18 @@ but the frozen window moves forward every day, so counts qualified months ago
 describe a query nobody now runs. Re-run `qualify` rather than reusing them.
 `qualified_at` must be a canonical `YYYY-MM-DD` string and may not be in the
 future.
+
+**The Instance's numbers must agree with each other.** The loader cross-checks
+every recorded definitional measurement and derived field against the aggregate
+baselines and the effective geographies, and refuses any mismatch:
+`S1_district.measured_rows` against `S1_full`, `S3_sector.measured_rows` and
+`measured_rows_category_all` against `S3_full` and `S9_full`, the neighbour
+count against itself in both places it appears, `measured_neighbour_ratio`
+recomputed from the counts, `comparable_or_greater` recomputed from the ratio,
+and `neighbour_geography` / `inside_s1_district` against the effective
+geographies. A ratio edited to clear the literal rule while the counts stay put
+is the single most consequential edit anyone could make to an Instance, and it
+is refused.
 
 Set `governs_run` to the Stage 1 run it governs. The comparator **refuses** an
 Instance whose `governs_run` is blank or still carries the placeholder `qualify`

--- a/tests/snapshot/image_smoke.py
+++ b/tests/snapshot/image_smoke.py
@@ -47,6 +47,56 @@ def fixture(root):
     (root / "current.json").write_text(json.dumps({"current_manifest": "manifest.json"}))
 
 
+def stage1(target):
+    """Invoke the Stage 1 comparator inside the built image, flag off.
+
+    Reading the Dockerfile proves nothing about whether the files landed, the
+    package imports on this platform, or the CLI wires up -- and the one thing
+    that must hold on a serving image is that the comparator does NOTHING
+    unless it is deliberately enabled. So this actually runs it.
+
+    Only the API image carries the comparator; `propertydata` is out of Stage 1
+    scope and must not have gained it.
+    """
+    root = Path(os.getcwd())
+    present = (root / "tools" / "ppd_snapshot" / "stage1_shadow.py").is_file()
+    if target != "api":
+        assert not present, (
+            "the propertydata image carries the Stage 1 comparator; Stage 1 is "
+            "property-shared only and propertydata must stay untouched")
+        print(json.dumps({"image": target, "mode": "stage1", "passed": True,
+                          "comparator_present": False}))
+        return
+    assert present, "the API image does not carry tools/ppd_snapshot/stage1_shadow.py"
+
+    helped = subprocess.run(
+        [sys.executable, "-m", "tools.ppd_snapshot.stage1_shadow", "--help"],
+        capture_output=True, text=True, cwd=root)
+    assert helped.returncode == 0, helped.stderr
+    assert "qualify" in helped.stdout and "compare" in helped.stdout, helped.stdout
+
+    # Default off: with the flag absent it must refuse, exit 2, and never reach
+    # an adapter -- even though this image has DuckDB installed and the app on
+    # this Machine may well have a snapshot materialized.
+    environment = {k: v for k, v in os.environ.items()
+                   if k != "PPD_SHADOW_COMPARE_ENABLED"}
+    for argv in (["qualify", "--out", "/tmp/should-not-exist.json"],
+                 ["compare", "--instance", "/tmp/nope.json",
+                  "--report", "/tmp/should-not-exist.json"]):
+        refused = subprocess.run(
+            [sys.executable, "-m", "tools.ppd_snapshot.stage1_shadow", *argv],
+            capture_output=True, text=True, cwd=root, env=environment)
+        assert refused.returncode == 2, (argv, refused.returncode, refused.stdout,
+                                         refused.stderr)
+        assert "refused" in refused.stdout, refused.stdout
+        assert "PPD_SHADOW_COMPARE_ENABLED" in refused.stdout, refused.stdout
+    assert not Path("/tmp/should-not-exist.json").exists(), (
+        "a refused invocation still wrote its output file")
+
+    print(json.dumps({"image": target, "mode": "stage1", "passed": True,
+                      "comparator_present": True, "default_off_exit_code": 2}))
+
+
 def child(root, mode, target):
     blocked = mode if mode in {"duckdb", "zstandard", "botocore"} else None
     if blocked:
@@ -145,6 +195,8 @@ def child(root, mode, target):
 if __name__ == "__main__":
     if sys.argv[1] == "child":
         child(Path(sys.argv[2]), sys.argv[3], sys.argv[4])
+    elif sys.argv[1] == "stage1":
+        stage1(sys.argv[2])
     else:
         import duckdb, zstandard, botocore
         print(json.dumps({"python": sys.version.split()[0], "duckdb": duckdb.__version__,

--- a/tests/snapshot/test_rollout_premises.py
+++ b/tests/snapshot/test_rollout_premises.py
@@ -360,7 +360,7 @@ def test_nothing_in_the_correction_relaxed_a_requirement():
 
 def test_a_local_rehearsal_is_not_recorded_as_a_stage_1_result():
     normalised = _normalised(SPEC)
-    assert "A local rehearsal is not Stage 1" in normalised
+    assert "A local rehearsal is still not Stage 1" in normalised
     assert "cannot satisfy" in normalised and "p95" in normalised
 
 
@@ -439,7 +439,7 @@ def test_the_changelog_still_records_the_sizing_correction():
 # Rev 8 -- the corpus-acceptance and artifact-distribution decision round
 # ---------------------------------------------------------------------------
 
-def test_the_specification_declares_revision_9_and_a_revision_note():
+def test_the_specification_declares_revision_10_and_a_revision_note():
     """History is appended, never overwritten.
 
     A revision that replaced its predecessor's note would make the document's
@@ -448,10 +448,11 @@ def test_the_specification_declares_revision_9_and_a_revision_note():
     """
     body = _text(SPEC)
     head = body.splitlines()[0]
-    assert "rev 9" in head and "FROZEN" in head, head
+    assert "rev 10" in head and "FROZEN" in head, head
     normalised = _normalised(SPEC)
-    assert "**Revision 9**" in normalised, "rev 9 landed without a revision note"
-    for earlier in ("**Revision 8**", "**Revision 7**", "**Revision 6**"):
+    assert "**Revision 10**" in normalised, "rev 10 landed without a revision note"
+    for earlier in ("**Revision 9**", "**Revision 8**", "**Revision 7**",
+                    "**Revision 6**"):
         assert earlier in normalised, (
             f"{earlier} was overwritten; revision notes accumulate, they do not "
             f"replace each other"
@@ -719,3 +720,80 @@ def test_the_lock_wait_versus_grace_period_question_is_recorded_not_resolved():
     assert "deliberately does not resolve it" in normalised
     for number in ("420 s", "60 s (`property-shared`)", "30 s (`propertydata`)"):
         assert number in normalised, f"G2's open question no longer cites {number}"
+
+
+# ---------------------------------------------------------------------------
+# Rev 10 -- the Stage 1 mechanism decision round
+# ---------------------------------------------------------------------------
+
+def test_revision_10_relaxed_no_requirement_but_the_one_it_names():
+    """Rev 10 moves *where* p95 is measured. It must move nothing else.
+
+    A round whose whole purpose is to change an exit criterion is exactly where
+    a second one gets softened in passing, because the diff already touches the
+    criteria list and one more line there looks like part of the same edit.
+    """
+    normalised = _normalised(SPEC)
+    for requirement in (
+        "30 s readiness target",
+        "bundle_bytes * 2.5",
+        "Zero unexplained false empties",
+        "Zero geography contamination",
+        "100% field equality on shared transaction IDs",
+        "Every divergence classified",
+        "Zero snapshot errors",
+        "p95 < 1 second",
+        "Passing G1a authorises neither `propertydata` nor Stage 3",
+        "blocking G2 if the deployed count exceeds one",
+    ):
+        assert requirement in normalised, (
+            f"rev 10 relaxed a requirement it had no authority to touch: "
+            f"{requirement!r}"
+        )
+
+
+def test_the_p95_criterion_names_the_machine_and_the_artifact():
+    """The revised criterion is only meaningful if it says where it was measured.
+
+    "p95 < 1 second" on its own is satisfiable by a workstation run against a
+    local artifact, which is precisely the reading the rehearsal paragraph
+    exists to forbid. The qualification is the criterion.
+    """
+    normalised = _normalised(SPEC)
+    assert ("p95 < 1 second on the deployed production Machine and selected "
+            "artifact, measured across the frozen corpus request mix") in normalised, (
+        "the p95 criterion no longer names the Machine, the artifact and the "
+        "request mix it is measured over"
+    )
+
+
+def test_the_revision_does_not_claim_a_corpus_run_is_organic_traffic():
+    """The honest half of the revision, and the half most likely to be dropped.
+
+    A later editor tidying this section could remove the concession and leave a
+    criterion that reads as though it were measured on real users. The whole
+    justification for the change is that it says out loud what it gave up.
+    """
+    normalised = _normalised(SPEC)
+    assert "the request mix is chosen, not observed" in normalised.lower(), (
+        "the specification no longer concedes that the corpus mix is chosen "
+        "rather than observed"
+    )
+    assert "not a claim that synthetic traffic is organic traffic" in normalised, (
+        "the specification no longer states that this is a gate revision rather "
+        "than a relabelling of synthetic traffic as organic"
+    )
+
+
+def test_the_revision_records_that_it_was_made_before_stage_1():
+    """A gate revision made *after* seeing evidence is a different act entirely.
+
+    Rev 10 is defensible only because no Stage 1 evidence existed when it was
+    written. If that ordering stops being recorded, the revision stops being
+    distinguishable from moving the goalposts.
+    """
+    normalised = _normalised(SPEC)
+    assert ("before Stage 1 started and before any Stage 1 evidence existed"
+            in normalised), (
+        "the specification no longer records that rev 10 preceded Stage 1"
+    )

--- a/tests/snapshot/test_shadow_corpus_definition.py
+++ b/tests/snapshot/test_shadow_corpus_definition.py
@@ -283,3 +283,31 @@ def test_the_freeze_does_not_claim_an_instance():
             f"the freeze describes the absent Instance as incomplete work "
             f"({overreach!r}); it is deferred by design, not missing"
         )
+
+
+def test_the_definition_carries_the_rev_10_p95_qualification():
+    """§8 must not keep the pre-rev-10 wording while §7.2 has moved on.
+
+    The Definition says its criteria are carried forward from the governing
+    spec. Two documents stating the same criterion differently is the failure
+    mode that makes "which one governs?" an open question mid-run.
+    """
+    body = _normalised(DEFINITION)
+    assert ("p95 < 1 second on the deployed production Machine and selected "
+            "artifact, measured across the frozen corpus request mix") in body
+    assert "on real traffic" not in body, (
+        "the Definition still carries the pre-rev-10 'on real traffic' wording"
+    )
+
+
+def test_the_definition_excludes_non_machine_latency_from_the_percentile():
+    """A rehearsal's latency must not be able to reach the gate percentile.
+
+    Both tools record per-case latency in the same shape. Without an explicit
+    exclusion rule, the cheap mistake is to pool them -- and a workstation run
+    against a local artifact is faster than the Machine, so pooling would
+    flatter the gate.
+    """
+    body = _normalised(DEFINITION)
+    assert "controlled_synthetic" in body
+    assert "excluded from this percentile" in body

--- a/tests/snapshot/test_shadow_corpus_definition.py
+++ b/tests/snapshot/test_shadow_corpus_definition.py
@@ -311,3 +311,31 @@ def test_the_definition_excludes_non_machine_latency_from_the_percentile():
     body = _normalised(DEFINITION)
     assert "controlled_synthetic" in body
     assert "excluded from this percentile" in body
+
+
+def test_the_definition_decides_the_postcode_less_row_question():
+    """§11 left it undecided; leaving it so in code would settle it silently.
+
+    Skipping a returned row that carries no postcode means a source could
+    return arbitrary rows with the geography blanked and every containment
+    check would pass. The decision is recorded here, before Stage 1, rather
+    than living only in an implementation.
+    """
+    body = _normalised(DEFINITION)
+    assert "Decided before Stage 1 began" in body
+    assert "containment failure" in body
+    assert "rows_without_postcode" in body
+
+
+def test_the_definition_forbids_weakening_the_neighbour_volume_rule():
+    """The rule stays qualitative, and tooling refers rather than redefines."""
+    body = _normalised(DEFINITION)
+    assert "refers the judgement rather than deciding it" in body
+    assert "is forbidden" in body
+    assert "substitute with recorded justification" in body
+
+
+def test_the_definition_keeps_the_substitution_route_and_links_the_three():
+    body = _normalised(DEFINITION)
+    assert "may substitute with recorded justification" in body
+    assert "silently false" in body

--- a/tests/snapshot/test_stage1_shadow.py
+++ b/tests/snapshot/test_stage1_shadow.py
@@ -913,6 +913,7 @@ def test_the_report_labels_its_latency_as_the_corpus_mix_not_organic_traffic(
 # ---------------------------------------------------------------------------
 
 def _write(tmp_path, materialized, **overrides):
+    """An Instance file with the given fields overridden."""
     raw = _instance_dict(materialized)
     raw.update(overrides)
     path = tmp_path / "instance.json"
@@ -3032,3 +3033,187 @@ def test_the_runbook_documents_the_measurement_cross_checks():
     assert "must agree with each other" in body
     assert "recomputed from the counts" in body
     assert "most consequential edit" in body
+
+
+# ---------------------------------------------------------------------------
+# The rounding boundary
+# ---------------------------------------------------------------------------
+
+def test_comparability_is_decided_on_the_exact_ratio_not_the_rounded_one(
+        materialized, tmp_path):
+    """20,000 against 20,001: the regression this boundary exists to catch.
+
+    The exact ratio is 0.99995 -- the neighbour is smaller, so it is NOT
+    "comparable or greater" -- and it rounds to 1.0 at four decimals. Deciding
+    from the rounded value put a rounding boundary inside a deployment gate:
+    the loader would compute `True` while `qualify` recorded `False`, refusing
+    a correct candidate, and would equally accept a hand-edited `True` that
+    skips the owner decision altogether.
+
+    Mutation: derive `expected_comparable` from the rounded ratio again and
+    this fails in both directions below.
+    """
+    block = _qualification_block()
+    block["S1_district"]["measured_rows"] = 20_001
+    block["S1_district"]["measured_neighbour_rows"] = 20_000
+    block["S1_district"]["measured_neighbour_ratio"] = round(20_000 / 20_001, 4)
+    block["S1_district"]["comparable_or_greater"] = False
+    block["S2_district"]["measured_rows"] = 20_000
+    baselines = {**BASELINES, "S1_full": 20_001}
+
+    # The recorded display field really does round to 1.0 -- the case is only
+    # interesting because those two values differ.
+    assert block["S1_district"]["measured_neighbour_ratio"] == 1.0
+    assert (20_000 / 20_001) < s1.NEIGHBOUR_COMPARABLE_RATIO
+
+    # `false` is correct here, and must load. Because the neighbour falls
+    # short, the Instance must also answer the referral.
+    block["S1_district"]["owner_decision"] = {
+        "decision": "accepted",
+        "justification": "one row short of parity; reviewed and accepted",
+    }
+    path = _write(tmp_path, materialized, qualification=block,
+                  aggregate_baselines=baselines)
+    assert s1.load_instance(path, materialized).governs_run
+
+    # `true` is wrong here, and must be refused -- it would skip the decision.
+    block["S1_district"]["comparable_or_greater"] = True
+    block["S1_district"].pop("owner_decision")
+    path = _write(tmp_path, materialized, qualification=block,
+                  aggregate_baselines=baselines)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "may not be asserted independently of the measurement" in str(exc.value)
+
+
+def test_the_other_side_of_the_boundary_is_comparable(materialized, tmp_path):
+    """20,001 against 20,000 exceeds parity, so no decision is required."""
+    block = _qualification_block()
+    block["S1_district"]["measured_rows"] = 20_000
+    block["S1_district"]["measured_neighbour_rows"] = 20_001
+    block["S1_district"]["measured_neighbour_ratio"] = round(20_001 / 20_000, 4)
+    block["S1_district"]["comparable_or_greater"] = True
+    block["S2_district"]["measured_rows"] = 20_001
+    path = _write(tmp_path, materialized, qualification=block,
+                  aggregate_baselines={**BASELINES, "S1_full": 20_000,
+                                       "S3_full": 40, "S9_full": 55})
+    assert s1.load_instance(path, materialized).governs_run
+
+
+def test_exact_parity_is_comparable(materialized, tmp_path):
+    """"comparable or GREATER" -- equal volume qualifies."""
+    block = _qualification_block()
+    block["S1_district"]["measured_rows"] = 20_000
+    block["S1_district"]["measured_neighbour_rows"] = 20_000
+    block["S1_district"]["measured_neighbour_ratio"] = 1.0
+    block["S1_district"]["comparable_or_greater"] = True
+    block["S2_district"]["measured_rows"] = 20_000
+    path = _write(tmp_path, materialized, qualification=block,
+                  aggregate_baselines={**BASELINES, "S1_full": 20_000})
+    assert s1.load_instance(path, materialized).governs_run
+
+
+def test_the_display_ratio_is_still_validated_at_four_decimals(materialized,
+                                                               tmp_path):
+    """Rounding keeps its one job: checking the human-readable field.
+
+    Dropping the exact ratio into that field instead would make the check
+    reject every candidate `qualify` writes.
+    """
+    block = _qualification_block()
+    block["S1_district"]["measured_rows"] = 20_001
+    block["S1_district"]["measured_neighbour_rows"] = 20_000
+    block["S1_district"]["measured_neighbour_ratio"] = 0.9999   # wrong rounding
+    block["S1_district"]["comparable_or_greater"] = False
+    block["S1_district"]["owner_decision"] = {"decision": "accepted",
+                                              "justification": "reviewed"}
+    block["S2_district"]["measured_rows"] = 20_000
+    path = _write(tmp_path, materialized, qualification=block,
+                  aggregate_baselines={**BASELINES, "S1_full": 20_001})
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "must follow from the counts" in str(exc.value)
+
+
+def test_the_baselines_note_names_the_effective_geographies(materialized):
+    """A substituted run's note must not claim B5 / B5 4.
+
+    The note tells a reviewer which geographies the three baselines were
+    counted over. Hard-coding the defaults made it wrong for exactly the runs
+    where getting it right matters most.
+    """
+    default = s1.qualify(materialized)
+    assert "B5" in default["baselines_note"]
+    assert "B5 4" in default["baselines_note"]
+
+
+def test_the_baselines_note_follows_a_substitution(tmp_path):
+    rows = [row(f"T-M37-{i:03d}", "M3 7AA", "2026-05-04", 200_000 + i,
+                town="MANCHESTER") for i in range(30)]
+    rows += [row(f"T-M30-{i:03d}", "M30 4AA", "2026-05-04", 300_000 + i,
+                 town="MANCHESTER") for i in range(40)]
+    build_snapshot(tmp_path, rows, version="v20260828T194003Z")
+    opened = s1.open_materialized(tmp_path)
+    try:
+        out = s1.qualify(opened, today=date(2026, 6, 15), substitutions={
+            "S1_district": {"geography": "M3", "justification": "r"},
+            "S2_neighbour_district": {"geography": "M30", "justification": "r"},
+            "S3_sector": {"geography": "M3 7", "justification": "r"}})
+    finally:
+        opened.adapter.close()
+    note = out["baselines_note"]
+    assert "M3 7" in note and "M3" in note
+    assert "B5" not in note, f"the note still claims a default geography: {note}"
+
+
+def test_qualify_decides_comparability_on_the_exact_ratio(materialized,
+                                                          monkeypatch):
+    """The same boundary, on the writing side rather than the reading side.
+
+    `qualify` and `load_instance` must agree at 20,000/20,001 or a correct
+    candidate is refused by the tool that produced it. Reaching this through a
+    real artifact would need 40,001 rows; the counts are substituted instead,
+    which isolates exactly the arithmetic under test.
+
+    Mutation: round the ratio before comparing it and `comparable_or_greater`
+    flips to true, the adjudication disappears, and the shortfall is never put
+    to anybody.
+    """
+    real = s1._aggregate
+
+    def counted(m, *, geography_sql, geo_params, **kwargs):
+        if geography_sql == "outcode = ?" and geo_params == ["B5"]:
+            return 20_001
+        if geography_sql == "outcode = ?" and geo_params == ["B50"]:
+            return 20_000
+        return real(m, geography_sql=geography_sql, geo_params=geo_params,
+                    **kwargs)
+
+    monkeypatch.setattr(s1, "_aggregate", counted)
+    out = s1.qualify(materialized, today=date(2026, 6, 15))
+    block = out["candidate_instance"]["qualification"]["S1_district"]
+    assert block["measured_rows"] == 20_001
+    assert block["measured_neighbour_rows"] == 20_000
+    # The display field rounds to parity; the decision does not.
+    assert block["measured_neighbour_ratio"] == 1.0
+    assert block["comparable_or_greater"] is False, (
+        "qualify treated a smaller neighbour as comparable because the ratio "
+        "rounded to 1.0")
+    assert "S1_district" in out["requires_owner_adjudication"]
+
+
+def test_qualify_treats_exact_parity_as_comparable(materialized, monkeypatch):
+    """The boundary is >=, so equal volume needs no adjudication."""
+    real = s1._aggregate
+
+    def counted(m, *, geography_sql, geo_params, **kwargs):
+        if geography_sql == "outcode = ?" and geo_params in (["B5"], ["B50"]):
+            return 20_000
+        return real(m, geography_sql=geography_sql, geo_params=geo_params,
+                    **kwargs)
+
+    monkeypatch.setattr(s1, "_aggregate", counted)
+    out = s1.qualify(materialized, today=date(2026, 6, 15))
+    block = out["candidate_instance"]["qualification"]["S1_district"]
+    assert block["comparable_or_greater"] is True
+    assert "S1_district" not in out["requires_owner_adjudication"]

--- a/tests/snapshot/test_stage1_shadow.py
+++ b/tests/snapshot/test_stage1_shadow.py
@@ -78,6 +78,37 @@ def materialized(tmp_path):
     opened.adapter.close()
 
 
+#: One consistent set of figures, shared by the fixture Instance and its
+#: qualification block so the loader's cross-checks pass.
+BASELINES = {"S1_full": 100, "S3_full": 40, "S9_full": 55}
+NEIGHBOUR_ROWS = 120
+
+
+def _shortfall_block(ratio_numerator: int = 31, definitional=None,
+                     **s1_overrides) -> dict:
+    """A qualification block whose neighbour falls short of the literal rule.
+
+    Still internally consistent -- the shortfall is in the measurement, not in
+    the bookkeeping, which is what makes it an adjudication question rather
+    than a malformed Instance.
+    """
+    block = _qualification_block(definitional)
+    geo = block["S1_district"]["geography"]
+    block["S1_district"] = {
+        "rule": "the neighbour holds comparable or greater volume",
+        "geography": geo,
+        "measured_rows": BASELINES["S1_full"],
+        "neighbour_geography": block["S2_district"]["geography"],
+        "measured_neighbour_rows": ratio_numerator,
+        "measured_neighbour_ratio": round(
+            ratio_numerator / BASELINES["S1_full"], 4),
+        "comparable_or_greater": False,
+        **s1_overrides,
+    }
+    block["S2_district"]["measured_rows"] = ratio_numerator
+    return block
+
+
 def _qualification_block(definitional=None, **overrides) -> dict:
     """A complete qualification block bound to the effective geographies."""
     from tools.ppd_snapshot.corpus import DEFINITIONAL_GEOGRAPHIES
@@ -85,19 +116,31 @@ def _qualification_block(definitional=None, **overrides) -> dict:
     geo = {**DEFINITIONAL_GEOGRAPHIES, **(definitional or {})}
     block = {key: {"rule": "qualified for the test fixture"}
              for key in sorted(s1.REQUIRED_QUALIFICATION_KEYS)}
+    # Internally consistent with BASELINES below: the loader cross-checks every
+    # one of these against the baselines and against the effective geographies,
+    # so a fixture carrying arbitrary numbers is not a valid Instance either.
     block["S1_district"] = {
         "rule": "the neighbour holds comparable or greater volume",
         "geography": geo["S1_district"],
-        "measured_neighbour_ratio": 1.2,
+        "measured_rows": BASELINES["S1_full"],
+        "neighbour_geography": geo["S2_neighbour_district"],
+        "measured_neighbour_rows": NEIGHBOUR_ROWS,
+        "measured_neighbour_ratio": round(
+            NEIGHBOUR_ROWS / BASELINES["S1_full"], 4),
         "comparable_or_greater": True,
     }
     block["S2_district"] = {
         "rule": "non-empty under frozen parameters",
         "geography": geo["S2_neighbour_district"],
+        "measured_rows": NEIGHBOUR_ROWS,
     }
     block["S3_sector"] = {
         "rule": "a strict subset of S1's district",
         "geography": geo["S3_sector"],
+        "measured_rows": BASELINES["S3_full"],
+        "measured_rows_category_all": BASELINES["S9_full"],
+        "inside_s1_district": (
+            geo["S3_sector"].split()[0] == geo["S1_district"]),
     }
     for key, value in overrides.items():
         block[key] = value
@@ -110,7 +153,7 @@ def _instance_dict(m) -> dict:
         "snapshot_version": m.version,
         "bundle_sha256": m.bundle_sha256,
         "geographies": dict(GEOGRAPHIES),
-        "aggregate_baselines": {"S1_full": 100, "S3_full": 40, "S9_full": 55},
+        "aggregate_baselines": dict(BASELINES),
         "qualified_at": "2026-09-01",
         # Complete: every case whose geography the Instance fixes, with the
         # three definitional entries bound to the geographies they measured.
@@ -2329,13 +2372,7 @@ def test_a_pending_adjudication_is_refused_not_carried(materialized, tmp_path):
     nothing. Mutation: accept a False `comparable_or_greater` with no
     `owner_decision` and a pending judgement qualifies a Stage 1 run.
     """
-    block = _qualification_block()
-    block["S1_district"] = {
-        "rule": "the neighbour holds comparable or greater volume",
-        "geography": "B5",
-        "measured_neighbour_ratio": 0.31,
-        "comparable_or_greater": False,
-    }
+    block = _shortfall_block()
     path = _write(tmp_path, materialized, qualification=block)
     with pytest.raises(InstanceRefused) as exc:
         s1.load_instance(path, materialized)
@@ -2345,12 +2382,8 @@ def test_a_pending_adjudication_is_refused_not_carried(materialized, tmp_path):
 
 def test_an_accepted_shortfall_needs_a_justification(materialized, tmp_path):
     """A decision nobody can review is not a decision that was recorded."""
-    block = _qualification_block()
-    block["S1_district"] = {
-        "rule": "neighbour volume", "geography": "B5",
-        "measured_neighbour_ratio": 0.31, "comparable_or_greater": False,
-        "owner_decision": {"decision": "accepted", "justification": "   "},
-    }
+    block = _shortfall_block(owner_decision={"decision": "accepted",
+                                             "justification": "   "})
     path = _write(tmp_path, materialized, qualification=block)
     with pytest.raises(InstanceRefused) as exc:
         s1.load_instance(path, materialized)
@@ -2360,29 +2393,20 @@ def test_an_accepted_shortfall_needs_a_justification(materialized, tmp_path):
 def test_a_recorded_acceptance_with_a_reason_qualifies_the_case(materialized,
                                                                 tmp_path):
     """The route the Definition offers, taken properly, is accepted."""
-    block = _qualification_block()
-    block["S1_district"] = {
-        "rule": "neighbour volume", "geography": "B5",
-        "measured_neighbour_ratio": 0.31, "comparable_or_greater": False,
-        "owner_decision": {
-            "decision": "accepted",
-            "justification": ("B50 is a small rural outcode; 31% still returns "
-                              "hundreds of rows, enough for contamination to "
-                              "show. Reviewed 2026-09-01."),
-        },
-    }
+    block = _shortfall_block(owner_decision={
+        "decision": "accepted",
+        "justification": ("B50 is a small rural outcode; 31% still returns "
+                          "hundreds of rows, enough for contamination to "
+                          "show. Reviewed 2026-09-01."),
+    })
     path = _write(tmp_path, materialized, qualification=block)
     assert s1.load_instance(path, materialized).governs_run
 
 
 @pytest.mark.parametrize("decision", ["pending", "rejected", "deferred", ""])
 def test_only_an_explicit_acceptance_qualifies(materialized, tmp_path, decision):
-    block = _qualification_block()
-    block["S1_district"] = {
-        "rule": "neighbour volume", "geography": "B5",
-        "measured_neighbour_ratio": 0.31, "comparable_or_greater": False,
-        "owner_decision": {"decision": decision, "justification": "a reason"},
-    }
+    block = _shortfall_block(owner_decision={"decision": decision,
+                                             "justification": "a reason"})
     path = _write(tmp_path, materialized, qualification=block)
     with pytest.raises(InstanceRefused) as exc:
         s1.load_instance(path, materialized)
@@ -2391,13 +2415,19 @@ def test_only_an_explicit_acceptance_qualifies(materialized, tmp_path, decision)
 
 def test_an_instance_that_does_not_record_comparability_is_refused(
         materialized, tmp_path):
-    """It is the fact an adjudication would be answering."""
+    """It is the fact an adjudication would be answering.
+
+    Refused by the cross-check, which recomputes the field from the counts --
+    a missing value cannot equal the recomputed one. There is deliberately no
+    second guard for it: an unreachable check is not a safety net.
+    """
     block = _qualification_block()
-    block["S1_district"] = {"rule": "neighbour volume", "geography": "B5"}
+    block["S1_district"].pop("comparable_or_greater")
     path = _write(tmp_path, materialized, qualification=block)
     with pytest.raises(InstanceRefused) as exc:
         s1.load_instance(path, materialized)
     assert "comparable_or_greater" in str(exc.value)
+    assert "may not be asserted independently" in str(exc.value)
 
 
 def test_a_substitution_bolted_onto_unchanged_evidence_is_refused(
@@ -2543,9 +2573,10 @@ def test_qualify_re_measures_against_a_substitution(tmp_path):
     build_snapshot(tmp_path, rows, version="v20260828T194003Z")
     opened = s1.open_materialized(tmp_path)
     try:
-        out = s1.qualify(opened, today=date(2026, 6, 15), definitional={
-            "S1_district": "M3", "S2_neighbour_district": "M30",
-            "S3_sector": "M3 7"})
+        out = s1.qualify(opened, today=date(2026, 6, 15), substitutions={
+            "S1_district": {"geography": "M3", "justification": "r"},
+            "S2_neighbour_district": {"geography": "M30", "justification": "r"},
+            "S3_sector": {"geography": "M3 7", "justification": "r"}})
     finally:
         opened.adapter.close()
     assert out["substituted"] is True
@@ -2646,3 +2677,358 @@ def test_the_qualify_cli_refuses_a_geometrically_broken_substitutions_file(
                     "--substitutions", str(subs), "--out", str(out_path)])
     assert code == 2
     assert not out_path.exists(), "a refused qualification still wrote output"
+
+
+# ---------------------------------------------------------------------------
+# The emitted candidate is a document the loader accepts
+# ---------------------------------------------------------------------------
+
+#: Inside the frozen 24-month window and inside the 6-month one.
+RECENT = "2026-05-04"
+#: Inside the 24-month window, outside the 6-month one -- which is what makes a
+#: sector empty for S11 while still being a sector the artifact knows about.
+OLDER = "2025-01-15"
+
+
+def _fully_qualifiable_rows() -> list[dict]:
+    """Rows that satisfy every qualification rule, so `qualify` emits a
+    complete candidate.
+
+    Each group exists for one placeholder, and the comments say which -- a
+    fixture that qualifies by accident is one nobody can repair when a rule
+    changes.
+    """
+    rows: list[dict] = []
+    # The definitional trio, twice over: B5/B50/B5 4 and the M3/M30/M3 7 set a
+    # substitution moves to. Both need S3 < S1 strictly and S9 > S3.
+    for district, sector, neighbour in (("B5", "B5 4", "B50"),
+                                        ("M3", "M3 7", "M30")):
+        rows += [row(f"T-{sector}-{i:03d}", f"{sector}AA", RECENT, 200_000 + i)
+                 for i in range(30)]
+        rows.append(row(f"T-{sector}-CATB", f"{sector}AB", RECENT, 900_000,
+                        ppd_category="B"))
+        rows += [row(f"T-{neighbour}-{i:03d}", f"{neighbour} 4AA", RECENT,
+                     400_000 + i) for i in range(60)]
+        # A second, thin sector inside the district: S4, and it keeps S3 a
+        # STRICT subset of S1 rather than equal to it.
+        rows += [row(f"T-{district}6-{i}", f"{district} 6QQ", RECENT,
+                     300_000 + i, property_type=t)
+                 for i, t in enumerate("DSTF")]
+    # S5 (dense, well past limit), S7 (>=90% F) and S6/S13 (a dense unit with
+    # no D rows) all come from one deliberately large single-type sector.
+    rows += [row(f"T-NG11-{i:03d}", "NG1 1AA", RECENT, 250_000 + i)
+             for i in range(260)]
+    # S8: a real spread across F/D/S/T with F well under half.
+    rows += [row(f"T-NG21-{i:03d}", "NG2 1AA", RECENT, 260_000 + i,
+                 property_type="FDST"[i % 4]) for i in range(60)]
+    # S11: known to the artifact over 24 months, empty over 6.
+    rows += [row(f"T-NG41-{i:03d}", "NG4 1AA", OLDER, 270_000 + i)
+             for i in range(20)]
+    return rows
+
+
+def _emit_candidate(tmp_path, monkeypatch, substitutions=None) -> dict:
+    """Run the CLI and return the candidate instance it wrote."""
+    build_snapshot(tmp_path, _fully_qualifiable_rows(),
+                   version="v20260828T194003Z")
+    argv = ["qualify", "--cache-dir", str(tmp_path),
+            "--out", str(tmp_path / "candidate.json")]
+    if substitutions is not None:
+        subs = tmp_path / "subs.json"
+        subs.write_text(json.dumps({"substitutions": substitutions}))
+        argv += ["--substitutions", str(subs)]
+    monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
+    code = s1.main(argv)
+    written = json.loads((tmp_path / "candidate.json").read_text())
+    assert not written["unqualified_placeholders"], (
+        f"the fixture does not qualify every placeholder: "
+        f"{written['unqualified_placeholders']}")
+    assert not written["unqualified_definitional_cases"], (
+        written["unqualified_definitional_cases"])
+    assert code in (0, 1)   # 1 only if adjudication is pending
+    return written["candidate_instance"]
+
+def test_a_cli_candidate_round_trips_into_a_loadable_substituted_instance(
+        tmp_path, monkeypatch):
+    """The acceptance test for the whole qualify -> review -> run path.
+
+    Run the CLI against a substitution, take exactly what it wrote, change
+    ONLY the two fields a reviewer is meant to fill in -- `governs_run`, and
+    the owner decision where the neighbour falls short -- and load it. Then
+    confirm the corpus actually executes the substituted trio.
+
+    Everything else is used verbatim. If the tool emitted a document its own
+    loader rejects, an operator would have to hand-reconstruct a block the tool
+    had already validated, and any hand-reconstruction is a place for the
+    evidence and the run to drift apart. Before this test the candidate carried
+    substituted measurements and no `substitutions` key, so it was refused by
+    the very check that exists to keep those two together.
+    """
+    candidate = _emit_candidate(tmp_path, monkeypatch, substitutions={
+        "S1_district": {"geography": "M3",
+                        "justification": "B50 too thin on this artifact"},
+        "S2_neighbour_district": {"geography": "M30",
+                                  "justification": "the longer neighbour of M3"},
+        "S3_sector": {"geography": "M3 7", "justification": "inside M3"},
+    })
+
+    # The substitution survives into the candidate, justifications intact.
+    assert candidate["substitutions"]["S1_district"]["geography"] == "M3"
+    assert candidate["substitutions"]["S1_district"]["justification"] == (
+        "B50 too thin on this artifact")
+    assert set(candidate["substitutions"]) == {
+        "S1_district", "S2_neighbour_district", "S3_sector"}
+
+    # --- the only edits a reviewer makes -------------------------------------
+    candidate["governs_run"] = "stage-1-substituted"
+    if candidate["qualification"]["S1_district"]["comparable_or_greater"] is False:
+        candidate["qualification"]["S1_district"]["owner_decision"] = {
+            "decision": "accepted",
+            "justification": "reviewed and accepted for this artifact",
+        }
+
+    instance_path = tmp_path / "instance.json"
+    instance_path.write_text(json.dumps(candidate))
+    opened = s1.open_materialized(tmp_path)
+    try:
+        loaded = s1.load_instance(instance_path, opened)
+    finally:
+        opened.adapter.close()
+
+    assert loaded.governs_run == "stage-1-substituted"
+    assert loaded.substitutions == {
+        "S1_district": "M3", "S2_neighbour_district": "M30",
+        "S3_sector": "M3 7"}
+
+    # --- and the corpus executes the substituted trio ------------------------
+    from tools.ppd_snapshot.corpus import cases as build
+
+    shapes = {c.shape: (c.postcode, c.search_level)
+              for c in build(loaded.geographies, loaded.substitutions)}
+    assert shapes["S1"] == ("M3", "district")
+    assert shapes["S2"] == ("M30", "district")
+    assert shapes["S3"] == ("M3 7", "sector")
+    assert shapes["S9"] == ("M3 7", "sector")
+    assert shapes["S12"] == ("M3", "district")
+    assert shapes["S14"] == ("M3 7", "sector")
+    # Only the six shapes the definitional trio drives. The seven placeholders
+    # are selected independently and may legitimately sit anywhere in the
+    # artifact -- S4's thin sector here is `B5 6`, which is not a leftover.
+    driven = ("S1", "S2", "S3", "S9", "S12", "S14")
+    assert not any(shapes[shape][0].split()[0] in {"B5", "B50"}
+                   for shape in driven), (
+        f"a default B5/B50 geography survived into a substituted run: "
+        f"{ {k: shapes[k] for k in driven} }")
+
+
+def test_an_unsubstituted_candidate_round_trips_too(tmp_path, monkeypatch):
+    """The same path with no substitution: no `substitutions` key is emitted."""
+    candidate = _emit_candidate(tmp_path, monkeypatch)
+    assert "substitutions" not in candidate
+    candidate["governs_run"] = "stage-1-default"
+    if candidate["qualification"]["S1_district"]["comparable_or_greater"] is False:
+        candidate["qualification"]["S1_district"]["owner_decision"] = {
+            "decision": "accepted", "justification": "reviewed"}
+    path = tmp_path / "instance.json"
+    path.write_text(json.dumps(candidate))
+    opened = s1.open_materialized(tmp_path)
+    try:
+        loaded = s1.load_instance(path, opened)
+    finally:
+        opened.adapter.close()
+    assert loaded.substitutions == {}
+    from tools.ppd_snapshot.corpus import cases as build
+
+    assert {c.shape: c.postcode
+            for c in build(loaded.geographies, loaded.substitutions)}["S1"] == "B5"
+
+
+# ---------------------------------------------------------------------------
+# Measurements, baselines and geographies must be the same numbers
+# ---------------------------------------------------------------------------
+
+def test_a_measurement_disagreeing_with_its_baseline_is_refused(materialized,
+                                                                tmp_path):
+    """The same count over the same geography cannot be two numbers.
+
+    Mutation: skip the cross-check and an Instance can name the right places
+    while carrying a figure pasted from a previous run.
+    """
+    block = _qualification_block()
+    block["S1_district"]["measured_rows"] = BASELINES["S1_full"] + 1
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "S1_full" in str(exc.value)
+    assert "cannot be two numbers" in str(exc.value)
+
+
+@pytest.mark.parametrize("field,baseline", [
+    ("measured_rows", "S3_full"),
+    ("measured_rows_category_all", "S9_full"),
+])
+def test_the_sector_measurements_must_match_their_baselines(
+        materialized, tmp_path, field, baseline):
+    block = _qualification_block()
+    block["S3_sector"][field] = BASELINES[baseline] + 7
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert baseline in str(exc.value)
+
+
+def test_the_neighbour_count_must_agree_with_itself(materialized, tmp_path):
+    """It appears twice -- as S2's measurement and as S1's ratio input."""
+    block = _qualification_block()
+    block["S2_district"]["measured_rows"] = NEIGHBOUR_ROWS + 5
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "same count over the same geography" in str(exc.value)
+
+
+def test_a_ratio_edited_to_clear_the_rule_is_refused(materialized, tmp_path):
+    """The most consequential single edit anyone could make to an Instance.
+
+    Raising the ratio past 1.0 without moving the counts turns a case that
+    needs an owner decision into one that appears to qualify outright.
+    Mutation: trust the recorded ratio instead of recomputing it, and this
+    Instance loads.
+    """
+    block = _shortfall_block()
+    block["S1_district"]["measured_neighbour_ratio"] = 1.5
+    block["S1_district"]["comparable_or_greater"] = True
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "must follow from the counts" in str(exc.value)
+
+
+def test_comparability_asserted_against_the_measurement_is_refused(
+        materialized, tmp_path):
+    """`comparable_or_greater` decides whether a decision is required.
+
+    Asserting it independently of the counts would let an Instance skip the
+    adjudication entirely while every number beside it stayed honest.
+    """
+    block = _shortfall_block()
+    block["S1_district"]["comparable_or_greater"] = True
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "may not be asserted independently of the measurement" in str(exc.value)
+
+
+def test_the_neighbour_geography_must_be_the_effective_one(materialized,
+                                                           tmp_path):
+    """Otherwise the ratio describes a district the run does not use."""
+    block = _qualification_block()
+    block["S1_district"]["neighbour_geography"] = "M30"
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "the ratio would describe" in str(exc.value)
+
+
+def test_a_false_inside_s1_district_claim_is_refused(materialized, tmp_path):
+    block = _qualification_block()
+    block["S3_sector"]["inside_s1_district"] = False
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "inside_s1_district" in str(exc.value)
+
+
+@pytest.mark.parametrize("entry,field", [
+    ("S1_district", "measured_rows"),
+    ("S1_district", "measured_neighbour_rows"),
+    ("S1_district", "measured_neighbour_ratio"),
+    ("S2_district", "measured_rows"),
+    ("S3_sector", "measured_rows"),
+    ("S3_sector", "measured_rows_category_all"),
+])
+def test_a_missing_definitional_measurement_is_refused(materialized, tmp_path,
+                                                       entry, field):
+    """The baselines cannot be checked against a measurement not recorded."""
+    block = _qualification_block()
+    block[entry].pop(field)
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert field in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Malformed substitution JSON refuses cleanly
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("payload", ["[]", '"a string"', "42", "null", "true",
+                                     '{"substitutions": []}',
+                                     '{"substitutions": "M3"}'])
+def test_non_object_substitution_json_is_refused_with_exit_two(
+        tmp_path, monkeypatch, payload):
+    """A clean refusal, not an AttributeError traceback.
+
+    `raw.get(...)` on a list or a string raises, and that reached the operator
+    as a stack trace from inside the tool rather than a sentence saying what
+    was wrong with their file.
+    """
+    build_snapshot(tmp_path, _rows(), version="v20260828T194003Z")
+    subs = tmp_path / "subs.json"
+    subs.write_text(payload)
+    monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
+    out_path = tmp_path / "candidate.json"
+    code = s1.main(["qualify", "--cache-dir", str(tmp_path),
+                    "--substitutions", str(subs), "--out", str(out_path)])
+    assert code == 2
+    assert not out_path.exists(), "a refused qualification still wrote output"
+
+
+def test_unreadable_substitution_json_is_refused_with_exit_two(
+        tmp_path, monkeypatch):
+    build_snapshot(tmp_path, _rows(), version="v20260828T194003Z")
+    subs = tmp_path / "subs.json"
+    subs.write_text("{not json at all")
+    monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
+    code = s1.main(["qualify", "--cache-dir", str(tmp_path),
+                    "--substitutions", str(subs),
+                    "--out", str(tmp_path / "candidate.json")])
+    assert code == 2
+
+
+def test_a_missing_substitutions_file_is_refused_with_exit_two(
+        tmp_path, monkeypatch):
+    build_snapshot(tmp_path, _rows(), version="v20260828T194003Z")
+    monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
+    code = s1.main(["qualify", "--cache-dir", str(tmp_path),
+                    "--substitutions", str(tmp_path / "nope.json"),
+                    "--out", str(tmp_path / "candidate.json")])
+    assert code == 2
+
+
+def test_a_non_object_substitutions_value_is_refused_by_the_validator():
+    """Not by a second isinstance check in the CLI, which would be unreachable.
+
+    Pins where the refusal comes from, so removing the validator's own guard
+    fails here rather than silently relying on a CLI check that no longer
+    exists.
+    """
+    from tools.ppd_snapshot.corpus import validate_substitutions
+
+    for value in ([], "M3", 42, True):
+        with pytest.raises(InstanceRefused) as exc:
+            validate_substitutions(value)
+        assert "must be a JSON object" in str(exc.value)
+
+
+def test_the_runbook_says_the_candidate_is_taken_as_written():
+    body = RUNBOOK.read_text()
+    assert "justifications included" in body
+    assert "hand-reconstructing any of it" in body
+
+
+def test_the_runbook_documents_the_measurement_cross_checks():
+    body = RUNBOOK.read_text()
+    assert "must agree with each other" in body
+    assert "recomputed from the counts" in body
+    assert "most consequential edit" in body

--- a/tests/snapshot/test_stage1_shadow.py
+++ b/tests/snapshot/test_stage1_shadow.py
@@ -1547,3 +1547,18 @@ def test_a_correct_total_with_one_short_case_is_still_insufficient(instance):
     assert sorted(criterion["cases_short_of_the_required_repeats"]) == sorted(
         [shapes[0], shapes[1]])
     assert report["passed"] is False
+
+
+def test_the_default_repeat_count_is_the_count_the_gate_requires():
+    """A default run must be able to satisfy the gate it is measured against.
+
+    Three independent literals -- the dataclass default, the CLI default and
+    the gate constant -- would drift, and the symptom would be a full run that
+    reports `insufficient_evidence` for no reason an operator could see.
+    """
+    assert s1.RunLimits().latency_repeats == s1.REQUIRED_LATENCY_REPEATS
+    parsed = s1.build_parser().parse_args(
+        ["compare", "--instance", "i.json", "--report", "r.json"])
+    assert parsed.latency_repeats == s1.REQUIRED_LATENCY_REPEATS
+    assert (s1.REQUIRED_LATENCY_REPEATS * s1.REQUIRED_CASES
+            == s1.REQUIRED_LATENCY_OBSERVATIONS == 390)

--- a/tests/snapshot/test_stage1_shadow.py
+++ b/tests/snapshot/test_stage1_shadow.py
@@ -613,7 +613,12 @@ ALLOWED_KEYS = {
     "failed", "false_empty_shapes", "findings", "errors", "mismatch_rows",
     # a contamination finding: which arm, and the outcodes it strayed into.
     # Outcode granularity only -- never a unit postcode, never a row.
-    "arm", "unexpected_outcodes",
+    # a contamination finding: which arm, the level the case asked at, and the
+    # geographies it strayed into. Sector and outcode granularity only; a
+    # unit-level violation inside the requested sector is a COUNT, never a
+    # named postcode.
+    "arm", "level", "unexpected_outcodes", "unexpected_sectors",
+    "same_sector_unit_violations",
     "vacuous_comparison_shapes", "verdict", "n", "p95_ms",
     "required_observations", "required_repeats_per_case",
     "cases_short_of_the_required_repeats",
@@ -1562,3 +1567,338 @@ def test_the_default_repeat_count_is_the_count_the_gate_requires():
     assert parsed.latency_repeats == s1.REQUIRED_LATENCY_REPEATS
     assert (s1.REQUIRED_LATENCY_REPEATS * s1.REQUIRED_CASES
             == s1.REQUIRED_LATENCY_OBSERVATIONS == 390)
+
+
+# ---------------------------------------------------------------------------
+# Geography containment, judged at the level the case asked at
+# ---------------------------------------------------------------------------
+
+def _case(shape, postcode, level):
+    from tools.ppd_snapshot.corpus import Case
+    return Case(shape, "test", postcode, level)
+
+
+def test_a_same_outcode_neighbouring_sector_is_contamination():
+    """The trap an outcode-only check calls clean.
+
+    `B5 4` asked at sector level and handed a `B5 6` row shares the outcode, so
+    `all(o == "B5")` passes -- while the Definition names sector isolation
+    (`M3 7` returns only `M3 7`) as a trap in its own right.
+
+    Mutation: compare outcodes only and this row reads as in-area.
+    """
+    rows = [PPDTransaction(transaction_id="A", postcode="B5 4AA", date="2026-05-01"),
+            PPDTransaction(transaction_id="B", postcode="B5 6QQ", date="2026-05-01")]
+    violations = s1.geography_violations(_case("S3", "B5 4", "sector"), rows)
+    assert violations["unexpected_outcodes"] == []
+    assert violations["unexpected_sectors"] == ["B5 6"]
+    assert s1.is_contaminated(violations) is True
+
+
+def test_a_same_sector_neighbouring_unit_is_contamination():
+    """A `postcode` case handed a different unit in the same sector.
+
+    Both an outcode check and a sector check call this clean.
+    """
+    rows = [PPDTransaction(transaction_id="A", postcode="B5 7AA", date="2026-05-01"),
+            PPDTransaction(transaction_id="B", postcode="B5 7AB", date="2026-05-01")]
+    violations = s1.geography_violations(_case("S6", "B5 7AA", "postcode"), rows)
+    assert violations["unexpected_outcodes"] == []
+    assert violations["unexpected_sectors"] == []
+    assert violations["same_sector_unit_violations"] == 1
+    assert s1.is_contaminated(violations) is True
+
+
+def test_a_unit_violation_is_counted_never_named():
+    """Hygiene: sector and outcode granularity only.
+
+    The offending unit postcode would be the most identifying thing in the
+    report, and the count is what proves the contamination.
+    """
+    rows = [PPDTransaction(transaction_id="B", postcode="B5 7AB", date="2026-05-01")]
+    violations = s1.geography_violations(_case("S6", "B5 7AA", "postcode"), rows)
+    assert "B5 7AB" not in json.dumps(violations)
+    assert violations["same_sector_unit_violations"] == 1
+
+
+def test_a_district_case_is_still_judged_by_outcode():
+    """A district case legitimately spans every sector inside its outcode."""
+    rows = [PPDTransaction(transaction_id="A", postcode="B5 4AA", date="2026-05-01"),
+            PPDTransaction(transaction_id="B", postcode="B5 6QQ", date="2026-05-01")]
+    clean = s1.geography_violations(_case("S1", "B5", "district"), rows)
+    assert s1.is_contaminated(clean) is False
+    dirty = s1.geography_violations(
+        _case("S1", "B5", "district"),
+        rows + [PPDTransaction(transaction_id="C", postcode="B50 4AA",
+                               date="2026-05-01")])
+    assert dirty["unexpected_outcodes"] == ["B50"]
+    assert s1.is_contaminated(dirty) is True
+
+
+def test_sector_contamination_on_either_arm_fails_the_verdict(
+        materialized, instance, tmp_path, monkeypatch, agreeing_live):
+    """End to end, on the LIVE arm -- contamination is a defect in whichever
+    source produced it, so neither arm is assumed clean because the other is."""
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
+    real = s1._geography_contamination
+
+    def dirty(response, case):
+        if case.shape == "S3":
+            return {"level": "sector", "unexpected_outcodes": [],
+                    "unexpected_sectors": ["B5 6"],
+                    "same_sector_unit_violations": 0}
+        return real(response, case)
+
+    monkeypatch.setattr(s1, "_geography_contamination", dirty)
+    report = _full_run(materialized, instance, tmp_path, monkeypatch,
+                       live=agreeing_live, repeats=1)
+    criterion = report["exit_criteria"]["zero_geography_contamination"]
+    assert criterion["passed"] is False
+    assert {f["arm"] for f in criterion["findings"]} == {"live", "snapshot"}
+    assert report["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# B5 / B50 qualification
+# ---------------------------------------------------------------------------
+
+def test_qualification_fails_when_b50_is_empty(tmp_path, monkeypatch):
+    """S2 is "non-empty under frozen parameters", and B50 empty breaks S1 too.
+
+    Against a near-empty neighbour a clean S1 result proves nothing: the
+    contamination boundary is a test that cannot fail. Mutation: measure
+    `S1_full` and never look at the neighbour, and both cases qualify silently.
+    """
+    rows = [row(f"T-B57-{i:03d}", "B5 7AA", "2026-05-04", 200_000 + i)
+            for i in range(20)]
+    build_snapshot(tmp_path, rows, version="v20260828T194003Z")
+    monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
+    code = s1.main(["qualify", "--cache-dir", str(tmp_path),
+                    "--out", str(tmp_path / "candidate.json")])
+    assert code == 1
+    out = json.loads((tmp_path / "candidate.json").read_text())
+    assert "S2_district" in out["unqualified_definitional_cases"]
+    assert "S1_district" in out["unqualified_definitional_cases"]
+    assert out["candidate_instance"]["qualification"]["S2_district"][
+        "measured_rows"] == 0
+
+
+def test_a_definitional_failure_alone_makes_qualify_exit_non_zero(
+        tmp_path, monkeypatch, materialized):
+    """Isolated from the placeholder branch, which would otherwise mask it.
+
+    On a small artifact several placeholders also fail to qualify, so a run
+    exits 1 either way and the definitional branch could be dead without any
+    test noticing. This drives the exit code from a definitional failure alone.
+    """
+    payload = s1.qualify(materialized)
+    payload["unqualified_placeholders"] = []
+    payload["baselines_satisfy_their_relations"] = True
+    payload["baselines_refusal"] = None
+    payload["unqualified_definitional_cases"] = ["S2_district"]
+    monkeypatch.setattr(s1, "qualify", lambda *a, **k: payload)
+    monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
+    code = s1.main(["qualify", "--cache-dir", str(materialized.directory.parents[1]),
+                    "--out", str(tmp_path / "candidate.json")])
+    assert code == 1
+
+
+def test_qualification_records_the_neighbour_ratio_it_judged_on(tmp_path):
+    """The threshold is an operationalisation, so the measurement is recorded.
+
+    The Definition states "comparable or greater volume" qualitatively; a tool
+    needs a number, so the number is named and the measured ratio published
+    beside it for a reviewer to judge rather than trust.
+    """
+    rows = [row(f"T-B57-{i:03d}", "B5 7AA", "2026-05-04", 200_000 + i)
+            for i in range(20)]
+    rows += [row(f"T-B50-{i:03d}", "B50 4AA", "2026-05-04", 400_000 + i)
+             for i in range(20)]
+    build_snapshot(tmp_path, rows, version="v20260828T194003Z")
+    opened = s1.open_materialized(tmp_path)
+    try:
+        out = s1.qualify(opened, today=date(2026, 6, 15))
+    finally:
+        opened.adapter.close()
+    s1_block = out["candidate_instance"]["qualification"]["S1_district"]
+    assert s1_block["measured_neighbour_rows"] == 20
+    assert s1_block["measured_neighbour_ratio"] == 1.0
+    assert s1_block["threshold_is_an_operationalisation"] is True
+    assert "S1_district" not in out["unqualified_definitional_cases"]
+    assert "S2_district" not in out["unqualified_definitional_cases"]
+
+
+# ---------------------------------------------------------------------------
+# Instance staleness
+# ---------------------------------------------------------------------------
+
+def test_a_stale_instance_is_refused(materialized, tmp_path):
+    """The bound is enforced against the calendar, not merely type-checked.
+
+    The artifact is fixed, but the frozen window moves forward every day, so
+    counts qualified months ago describe a query nobody now runs. Mutation:
+    validate `staleness_bound_days` and never compare it to `qualified_at`, and
+    a months-old Instance qualifies a Stage 1 run while looking well-formed.
+    """
+    old = (date.today() - timedelta(days=90)).isoformat()
+    path = _write(tmp_path, materialized, qualified_at=old,
+                  staleness_bound_days=45)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "staleness_bound_days" in str(exc.value)
+    assert "90 days ago" in str(exc.value)
+
+
+def test_an_instance_inside_its_staleness_bound_is_accepted(materialized, tmp_path):
+    fresh = (date.today() - timedelta(days=10)).isoformat()
+    path = _write(tmp_path, materialized, qualified_at=fresh,
+                  staleness_bound_days=45)
+    assert s1.load_instance(path, materialized).qualified_at == fresh
+
+
+@pytest.mark.parametrize("qualified_at", [
+    "", "not-a-date", "2026-13-45", "01/09/2026", None, 20260901,
+    # Both of these PARSE. `fromisoformat` accepts basic format and ISO week
+    # dates, so "2026-W36-2" resolves silently to 2026-09-01 -- a real date,
+    # spelled in a way no operator reading the Instance would recognise. Only
+    # the canonical round-trip rejects them.
+    "20260901", "2026-W36-2",
+])
+def test_a_malformed_qualified_at_is_refused(materialized, tmp_path, qualified_at):
+    """An Instance whose age cannot be established cannot be checked at all."""
+    path = _write(tmp_path, materialized, qualified_at=qualified_at)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "qualified_at" in str(exc.value)
+
+
+def test_a_future_qualified_at_is_refused(materialized, tmp_path):
+    """It cannot have been qualified against this artifact yet."""
+    ahead = (date.today() + timedelta(days=3)).isoformat()
+    path = _write(tmp_path, materialized, qualified_at=ahead)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "future" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# The live-call bound is real
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", [0, -1])
+def test_max_live_per_case_below_one_is_refused_before_any_work(
+        materialized, instance, tmp_path, value):
+    """An option that silently does nothing is worse than no option.
+
+    `max_live_per_case=0` previously left the run making thirteen live calls
+    anyway -- the field was recorded in the report and enforced nowhere, so it
+    told an operator they had a control they did not have.
+    """
+    with pytest.raises(s1.ComparisonRefused) as exc:
+        s1.run_compare(
+            instance=instance, materialized=materialized,
+            limits=s1.RunLimits(max_live_per_case=value, latency_repeats=1),
+            report_path=tmp_path / "report.json",
+            live_service=FakeLive(), snapshot_service=None)
+    assert "max_live_per_case" in str(exc.value)
+    assert not (tmp_path / "report.json").exists(), (
+        "a refused run still wrote a report")
+
+
+def test_zero_latency_repeats_is_refused(materialized, instance, tmp_path):
+    """A run taking no latency observation cannot produce the gate's sample."""
+    with pytest.raises(s1.ComparisonRefused) as exc:
+        s1.run_compare(
+            instance=instance, materialized=materialized,
+            limits=s1.RunLimits(latency_repeats=0),
+            report_path=tmp_path / "report.json",
+            live_service=FakeLive(), snapshot_service=None)
+    assert "latency_repeats" in str(exc.value)
+
+
+def test_the_live_budget_refuses_a_call_that_would_exceed_it():
+    """Checked before every live call, so the bound survives a code change.
+
+    The loop takes one observation per case today, so the budget is never
+    reached by the current path -- which is exactly why it is a separate,
+    directly tested guard rather than an assumption about the loop's shape. A
+    change that added a second live call would stop the run instead of quietly
+    making more requests to HM Land Registry than the run declared.
+    """
+    limits = s1.RunLimits(max_live_per_case=1)
+    # Inside budget: silent.
+    s1.check_live_budget(0, limits, 13, "S1")
+    s1.check_live_budget(12, limits, 13, "S13")
+    # At and beyond it: refused.
+    with pytest.raises(s1.RunAborted) as exc:
+        s1.check_live_budget(13, limits, 13, "S14")
+    assert "live-call budget of 13" in str(exc.value)
+    assert "separate authorisation" in str(exc.value)
+
+
+def test_the_budget_scales_with_an_authorised_retry_allowance():
+    """A higher allowance is the documented route for an authorised retry."""
+    s1.check_live_budget(13, s1.RunLimits(max_live_per_case=2), 13, "S1")
+    with pytest.raises(s1.RunAborted):
+        s1.check_live_budget(26, s1.RunLimits(max_live_per_case=2), 13, "S1")
+
+
+# ---------------------------------------------------------------------------
+# The runbook describes the deploy path that actually exists
+# ---------------------------------------------------------------------------
+
+RUNBOOK = REPO / "docs" / "ops" / "ppd-stage1-shadow-runbook.md"
+
+
+def test_the_runbook_uses_the_release_workflow_not_a_manual_deploy():
+    """A local `fly deploy` ships the working directory, not a commit.
+
+    Stage 1 evidence has to be attributable to a revision. An image built from
+    whatever was on a laptop makes "which code produced this p95?"
+    unanswerable, which is precisely what a deployment gate cannot afford.
+    """
+    body = RUNBOOK.read_text()
+    assert "release.yml" in body
+    assert "publish a GitHub release" in body
+    assert "ships **the working directory, not a commit**" in body
+    assert "fly deploy --ha=false" not in body, (
+        "the runbook still tells an operator to deploy from a working directory")
+
+
+def test_the_runbook_states_that_a_release_redeploys_propertydata():
+    """Honest about the shared workflow rather than repeating "untouched".
+
+    `release.yml` deploys both apps on every release. Claiming propertydata is
+    untouched full stop would be wrong; what is true is that its configuration
+    and scope do not change.
+    """
+    body = RUNBOOK.read_text()
+    assert "redeploys `propertydata` too" in body
+    assert "untouched in configuration and scope" in body
+
+
+def test_the_release_workflow_still_deploys_both_apps():
+    """Pins the fact the runbook's honesty depends on.
+
+    If release.yml ever stopped deploying propertydata, the runbook's warning
+    would become misleading in the other direction.
+    """
+    workflow = (REPO / ".github" / "workflows" / "release.yml").read_text()
+    assert "flyctl deploy --remote-only --ha=false" in workflow
+    assert "--config fly.app.toml" in workflow
+    assert "release:" in workflow and "published" in workflow
+
+
+def test_the_runbook_documents_the_search_level_containment_rule():
+    body = RUNBOOK.read_text()
+    assert "at the level each case asked at" in body
+    assert "same_sector_unit_violations" in body
+    assert "never named" in body
+
+
+def test_the_runbook_documents_enforced_staleness_and_b50_qualification():
+    body = RUNBOOK.read_text()
+    assert "enforced at load, not merely recorded" in body
+    assert "unqualified_definitional_cases" in body
+    assert "MIN_NEIGHBOUR_VOLUME_RATIO" in body

--- a/tests/snapshot/test_stage1_shadow.py
+++ b/tests/snapshot/test_stage1_shadow.py
@@ -1,0 +1,902 @@
+"""Guards for the Stage 1 shadow comparator.
+
+The comparator runs out of band on the deployed Machine, alongside a process
+that is serving real requests, and produces the evidence a deployment gate is
+decided on. Two families of property matter, and both are asserted here by
+mutation -- breaking the mechanism and proving the test notices -- rather than
+by reading the code:
+
+**Safety.** Production keeps answering from the live source; the comparison is
+off unless deliberately enabled; the scope is `comps` and nothing else; the run
+is bounded; a failure in either arm is recorded rather than propagated; and the
+tool never installs into, routes through, or writes to anything the server owns.
+
+**Evidential honesty.** Every divergence is classified or counted as
+unclassified; a comparison that shares no transaction id is a failure and never
+a vacuous pass; and no id, address or price ever reaches a report.
+
+Everything here runs against a synthetic parquet artifact built in `tmp_path`.
+No Tigris, no production access, no network -- `conftest.py`'s autouse
+`_no_network` fixture hard-fails sockets for the whole module.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("duckdb")
+
+from property_core.models.ppd import PPDTransaction  # noqa: E402
+from property_core.provenance import TransportEvidence  # noqa: E402
+from tools.ppd_snapshot import stage1_shadow as s1  # noqa: E402
+from tools.ppd_snapshot.corpus import InstanceRefused, cases  # noqa: E402
+from tests.snapshot.rehearsal_fixtures import FORBIDDEN_IN_REPORT  # noqa: E402
+from tests.snapshot.snapshot_fixtures import build_snapshot, row  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+
+GEOGRAPHIES = {
+    "S4_thin": "B5 6",
+    "S5_dense": "B5 7",
+    "S6_unit": "B5 7AA",
+    "S7_type_weak": "B5 7",
+    "S8_type_strong": "B5 6",
+    "S11_provisional_empty": "B5 9",
+    "S13_empty_unit": "B5 7AA",
+}
+
+
+def _rows() -> list[dict]:
+    """Enough rows that the frozen cases have something to disagree about."""
+    today = date.today()
+    recent = (today - timedelta(days=120)).isoformat()
+    older = (today - timedelta(days=400)).isoformat()
+    rows = [
+        row(f"T-B57-{i:03d}", "B5 7AA", recent, 200_000 + i,
+            property_type="F") for i in range(30)
+    ]
+    rows += [row("T-B56-D", "B5 6QQ", older, 300_000, property_type="D"),
+             row("T-B56-S", "B5 6QR", older, 310_000, property_type="S"),
+             row("T-B56-T", "B5 6QS", older, 320_000, property_type="T"),
+             row("T-B56-F", "B5 6QT", older, 330_000, property_type="F"),
+             row("T-B50-A", "B50 4AA", older, 400_000),
+             row("T-B57-CATB", "B5 7AB", recent, 999_000, ppd_category="B")]
+    return rows
+
+
+@pytest.fixture
+def materialized(tmp_path):
+    """A real materialized snapshot, opened exactly as the tool opens one."""
+    build_snapshot(tmp_path, _rows(), version="v20260828T194003Z",
+                   coverage_from="2016-01-01", coverage_to="2026-06-30",
+                   provisional_from="2026-04-01")
+    opened = s1.open_materialized(tmp_path)
+    yield opened
+    opened.adapter.close()
+
+
+def _instance_dict(m) -> dict:
+    return {
+        "instance_kind": "stage1",
+        "snapshot_version": m.version,
+        "bundle_sha256": m.bundle_sha256,
+        "geographies": dict(GEOGRAPHIES),
+        "aggregate_baselines": {"S1_full": 100, "S3_full": 40, "S9_full": 55},
+        "qualified_at": "2026-09-01",
+        "qualification": {"S5_dense": {"rule": "dense", "measured_rows": 30}},
+        "staleness_bound_days": 45,
+        "governs_run": "stage-1-2026-09",
+    }
+
+
+@pytest.fixture
+def instance(materialized, tmp_path):
+    path = tmp_path / "instance.json"
+    path.write_text(json.dumps(_instance_dict(materialized)))
+    return s1.load_instance(path, materialized)
+
+
+# ---------------------------------------------------------------------------
+# Comparison is OFF by default
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", [None, "", "0", "false", "no", "nonsense", " "])
+def test_the_comparison_refuses_unless_deliberately_enabled(value):
+    """Anything unrecognised means off. A flag like this must fail CLOSED.
+
+    Mutation: make `require_enabled` truthy-test the raw string instead of
+    parsing it, and "nonsense" enables a production comparison run.
+    """
+    env = {} if value is None else {s1.SHADOW_COMPARE_ENABLED_ENV: value}
+    with pytest.raises(s1.ComparisonRefused) as exc:
+        s1.require_enabled(env)
+    assert s1.SHADOW_COMPARE_ENABLED_ENV in str(exc.value)
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE"])
+def test_the_comparison_runs_only_when_the_flag_parses_true(value):
+    s1.require_enabled({s1.SHADOW_COMPARE_ENABLED_ENV: value})
+
+
+def test_a_refused_invocation_opens_nothing_and_writes_nothing(tmp_path, monkeypatch):
+    """The refusal must precede every side effect, not follow the first one."""
+    monkeypatch.delenv(s1.SHADOW_COMPARE_ENABLED_ENV, raising=False)
+    opened = []
+    monkeypatch.setattr(s1, "open_materialized",
+                        lambda *a, **k: opened.append(a) or pytest.fail("opened"))
+    report = tmp_path / "report.json"
+    code = s1.main(["compare", "--instance", str(tmp_path / "i.json"),
+                    "--report", str(report), "--cache-dir", str(tmp_path)])
+    assert code == 2
+    assert not opened
+    assert not report.exists()
+
+
+# ---------------------------------------------------------------------------
+# It observes what the server booted; it never materializes or mutates
+# ---------------------------------------------------------------------------
+
+def test_it_refuses_rather_than_materializing_its_own_snapshot(tmp_path):
+    """A tool that would build its own artifact could measure a different one."""
+    with pytest.raises(s1.ComparisonRefused) as exc:
+        s1.open_materialized(tmp_path / "nothing-here")
+    assert "never materializes one of its own" in str(exc.value)
+    assert not (tmp_path / "nothing-here").exists()
+
+
+def test_opening_the_snapshot_writes_nothing_into_it(tmp_path):
+    """Read-only in the way that matters: the bytes on disk do not move."""
+    build_snapshot(tmp_path, _rows(), version="v20260828T194003Z")
+    directory = tmp_path / "snapshots" / "v20260828T194003Z"
+    before = {p.relative_to(directory): (p.stat().st_size, p.stat().st_mtime_ns)
+              for p in sorted(directory.rglob("*")) if p.is_file()}
+    opened = s1.open_materialized(tmp_path)
+    try:
+        s1.qualify(opened)
+    finally:
+        opened.adapter.close()
+    after = {p.relative_to(directory): (p.stat().st_size, p.stat().st_mtime_ns)
+             for p in sorted(directory.rglob("*")) if p.is_file()}
+    assert before == after, "qualification altered the materialized snapshot"
+
+
+def test_it_never_installs_into_the_servers_process_state(materialized, instance,
+                                                          tmp_path, monkeypatch):
+    """The serving process owns `state`. This tool must not touch it.
+
+    Mutation: add a `state.install(...)` anywhere in the run and this fails --
+    which matters because an installed adapter plus the serving flag is exactly
+    what routing production traffic to the snapshot would look like.
+    """
+    from property_core.snapshot import state
+
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    _run(materialized, instance, tmp_path, monkeypatch, latency_repeats=1,
+         stop_on_unclassified=False)
+    assert state.installed_adapter() is None
+    assert state.active_adapter() is None
+
+
+def test_the_serving_flag_is_never_read_or_set(materialized, instance, tmp_path,
+                                               monkeypatch):
+    """`PPD_SNAPSHOT_ENABLED` stays absent throughout. Routing is not ours."""
+    import os
+
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    _run(materialized, instance, tmp_path, monkeypatch, latency_repeats=1,
+         stop_on_unclassified=False)
+    assert "PPD_SNAPSHOT_ENABLED" not in os.environ
+
+
+def test_production_still_answers_from_live_while_the_comparator_runs(materialized):
+    """The property the whole design turns on.
+
+    An adapter is open in this process and the corpus is about to be run through
+    it -- and a plain `PPDService()`, which is what every consumer constructs,
+    must still route to the live source because the serving flag is off.
+    """
+    from property_core.ppd_service import PPDService
+
+    assert PPDService()._active_adapter() is None
+    assert PPDService(adapter=materialized.adapter)._active_adapter() is not None
+
+
+# ---------------------------------------------------------------------------
+# A controllable live arm
+# ---------------------------------------------------------------------------
+
+class FakeLive:
+    """A live arm whose answers, failures and latency the test chooses.
+
+    The real live arm is HM Land Registry's SPARQL endpoint. Every property
+    asserted below is about what the comparator *does* with an answer, so the
+    answer is supplied rather than fetched -- and sockets are hard-failed for
+    this module anyway.
+    """
+
+    def __init__(self, transactions=None, *, raises=None, per_shape=None):
+        self.transactions = transactions if transactions is not None else []
+        self.raises = raises
+        self.per_shape = per_shape or {}
+        self.calls: list[dict] = []
+
+    def comps(self, **kwargs):
+        from property_core.models.ppd import PPDCompsQuery, PPDCompsResponse
+        from property_core.ppd_source import live_provenance
+
+        self.calls.append(kwargs)
+        if self.raises is not None:
+            raise self.raises
+        rows = self.per_shape.get(kwargs["postcode"], self.transactions)
+        return PPDCompsResponse(
+            query=PPDCompsQuery(postcode=kwargs["postcode"],
+                                months=kwargs["months"],
+                                search_level=kwargs["search_level"]),
+            count=len(rows), thin_market=len(rows) < 5, warnings=(),
+            transactions=list(rows),
+            provenance=live_provenance(
+                evidence=TransportEvidence(raw_bindings_returned=len(rows),
+                                           fetch_limit=50),
+                sample_count=len(rows), sample_limit=50),
+        )
+
+
+def _run(materialized, instance, tmp_path, monkeypatch, *, live=None,
+         latency_repeats=1, **limit_kwargs):
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
+    limits = s1.RunLimits(live_delay_seconds=0.0,
+                          latency_repeats=latency_repeats, **limit_kwargs)
+    return s1.run_compare(
+        instance=instance, materialized=materialized, limits=limits,
+        report_path=tmp_path / "report.json",
+        live_service=live if live is not None else FakeLive(),
+        snapshot_service=None)
+
+
+# ---------------------------------------------------------------------------
+# Scope: comps only
+# ---------------------------------------------------------------------------
+
+def test_the_only_service_method_the_comparator_calls_is_comps():
+    """Stage 1 is `comps`-only. Nothing may quietly widen it.
+
+    Mutation: add a `search_transactions(` or `analyze_blocks(` call to the
+    module and this fails. Scope creep here would mean Stage 1 evidence about
+    a surface the frozen corpus never agreed to cover.
+    """
+    source = (REPO / "tools" / "ppd_snapshot" / "stage1_shadow.py").read_text()
+    for forbidden in ("search_transactions(", "analyze_blocks(", "get_transaction_record(",
+                      "calculate_yield(", "analyze_rentals(", "PropertyReportService"):
+        assert forbidden not in source, (
+            f"the Stage 1 comparator reaches beyond comps: {forbidden!r}")
+    assert ".comps(" in source
+
+
+def test_every_frozen_case_is_a_comps_shape():
+    corpus = cases(GEOGRAPHIES)
+    assert len(corpus) == 13
+    assert {c.shape for c in corpus} == {
+        "S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8", "S9", "S11", "S12",
+        "S13", "S14"}
+
+
+# ---------------------------------------------------------------------------
+# Bounded work
+# ---------------------------------------------------------------------------
+
+def test_the_run_is_sequential_with_no_concurrency_of_its_own():
+    """One process, one adapter, one query at a time.
+
+    The comparator shares a 2 GB Machine with the process that is serving. A
+    thread pool or an async gather here is how a diagnostic run turns into an
+    outage, so the absence of one is asserted rather than assumed.
+    """
+    source = (REPO / "tools" / "ppd_snapshot" / "stage1_shadow.py").read_text()
+    for forbidden in ("threading", "ThreadPoolExecutor", "ProcessPoolExecutor",
+                      "asyncio", "anyio", "multiprocessing", "concurrent.futures"):
+        assert forbidden not in source, (
+            f"the comparator introduces concurrency: {forbidden!r}")
+
+
+def test_live_calls_are_capped_at_one_per_case(materialized, instance, tmp_path,
+                                               monkeypatch):
+    """The live source is HMLR's. Thirteen cases means thirteen calls, once.
+
+    Mutation: move the live call inside the latency loop and this count jumps
+    from 13 to 13 * repeats.
+    """
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    live = FakeLive()
+    report = _run(materialized, instance, tmp_path, monkeypatch, live=live,
+                  latency_repeats=5, stop_on_unclassified=False)
+    assert len(live.calls) == 13
+    assert report["limits"]["live_calls_made"] == 13
+
+
+def test_the_latency_pass_makes_no_live_call_at_all(materialized, instance,
+                                                    tmp_path, monkeypatch):
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    live = FakeLive()
+    report = _run(materialized, instance, tmp_path, monkeypatch, live=live,
+                  latency_repeats=4, stop_on_unclassified=False)
+    # 13 correctness observations, and 13 * 4 latency observations on top.
+    assert report["latency"]["snapshot_arm"]["n"] == 13 * 4
+    assert len(live.calls) == 13
+
+
+def test_the_deadline_stops_the_run_and_still_writes_a_report(
+        materialized, instance, tmp_path, monkeypatch):
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    report = _run(materialized, instance, tmp_path, monkeypatch,
+                  latency_repeats=1, deadline_seconds=-1.0,
+                  stop_on_unclassified=False)
+    assert report["aborted"] and "deadline" in report["aborted"]
+    assert report["passed"] is False
+    assert (tmp_path / "report.json").is_file()
+
+
+def test_a_memory_floor_breach_stops_the_run(materialized, instance, tmp_path,
+                                             monkeypatch):
+    """A Machine under memory pressure is a reason to stop, not to push on."""
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    monkeypatch.setattr(s1, "available_memory_bytes", lambda *a, **k: 1024)
+    report = _run(materialized, instance, tmp_path, monkeypatch, latency_repeats=1,
+                  stop_on_unclassified=False)
+    assert report["aborted"] and "available memory" in report["aborted"]
+    assert report["excluded"]["memory"] >= 1
+
+
+def test_an_unhealthy_application_stops_the_run(materialized, instance, tmp_path,
+                                                monkeypatch):
+    """The serving app is the priority; the diagnostic yields to it."""
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (False, "503"))
+    report = _run(materialized, instance, tmp_path, monkeypatch, latency_repeats=1,
+                  stop_on_unclassified=False)
+    assert report["aborted"] and "health" in report["aborted"]
+    assert report["excluded"]["health"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation
+# ---------------------------------------------------------------------------
+
+def test_a_failing_live_arm_is_recorded_and_the_run_continues(
+        materialized, instance, tmp_path, monkeypatch):
+    """A live failure is a fact about the run, not the end of it.
+
+    Mutation: let the exception escape the per-arm `except` and the run dies
+    with no report -- which is the outcome that leaves a gate undecidable.
+    """
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    live = FakeLive(raises=RuntimeError("upstream exploded"))
+    report = _run(materialized, instance, tmp_path, monkeypatch, live=live,
+                  latency_repeats=1, stop_on_unclassified=False)
+    assert report["aborted"] is None
+    assert len(report["live_errors"]) == 13
+    assert "upstream exploded" in report["live_errors"][0]["error"]
+    assert report["cases_total"] == 13
+
+
+def test_a_failing_snapshot_arm_is_recorded_and_fails_the_gate(
+        materialized, instance, tmp_path, monkeypatch):
+    """Recorded, not propagated -- and it must still fail the exit criterion.
+
+    "Zero snapshot errors on the frozen corpus" is only meaningful if an error
+    that was caught still counts. Swallowing it into a green report would be
+    the worst of both.
+    """
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+
+    class Exploding:
+        def comps(self, **kwargs):
+            raise RuntimeError("snapshot query failed")
+
+    report = s1.run_compare(
+        instance=instance, materialized=materialized,
+        limits=s1.RunLimits(live_delay_seconds=0.0, latency_repeats=1,
+                            stop_on_unclassified=False),
+        report_path=tmp_path / "report.json",
+        live_service=FakeLive(), snapshot_service=Exploding())
+    assert report["aborted"] is None
+    assert report["exit_criteria"]["zero_snapshot_errors"]["passed"] is False
+    assert report["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Complete divergence recording
+# ---------------------------------------------------------------------------
+
+def test_an_unexplainable_divergence_is_counted_unclassified_not_excused():
+    """The class that must never be quietly absorbed by another.
+
+    A row present on one side only, outside the provisional tail, with no
+    truncation evidence, has no explanation this comparison can offer. The
+    taxonomy says an unclassified divergence blocks exit -- so it must be
+    counted, not rounded into `live_truncation_or_ordering`.
+    """
+    result = s1.classify(
+        only_live_months={"2019-05": 3}, only_snapshot_months={},
+        mismatch_months={}, provisional_from="2026-04-01",
+        live_saturated=False, snapshot_saturated=False,
+        live_truncation_evidenced=False)
+    assert result["unclassified"] == 3
+    assert result["live_truncation_or_ordering"] == 0
+    assert result["provisional_tail_lag"] == 0
+
+
+def test_truncation_is_only_claimed_on_evidence():
+    """Definition section 7: class 3 must be evidenced, never assumed.
+
+    Mutation: let `classify` infer truncation from "the snapshot returned more"
+    and the first case flips from unclassified to explained -- turning an open
+    question into a fake answer.
+    """
+    without = s1.classify(
+        only_live_months={"2019-05": 2}, only_snapshot_months={},
+        mismatch_months={}, provisional_from="2026-04-01",
+        live_saturated=False, snapshot_saturated=False,
+        live_truncation_evidenced=False)
+    with_evidence = s1.classify(
+        only_live_months={"2019-05": 2}, only_snapshot_months={},
+        mismatch_months={}, provisional_from="2026-04-01",
+        live_saturated=False, snapshot_saturated=False,
+        live_truncation_evidenced=True)
+    assert without["unclassified"] == 2 and without["live_truncation_or_ordering"] == 0
+    assert with_evidence["unclassified"] == 0
+    assert with_evidence["live_truncation_or_ordering"] == 2
+
+
+def test_a_provisional_tail_row_is_classified_as_lag():
+    result = s1.classify(
+        only_live_months={"2026-05": 4}, only_snapshot_months={},
+        mismatch_months={}, provisional_from="2026-04-01",
+        live_saturated=False, snapshot_saturated=False,
+        live_truncation_evidenced=False)
+    assert result["provisional_tail_lag"] == 4
+    assert result["unclassified"] == 0
+
+
+def test_a_revision_outside_the_provisional_tail_needs_operator_confirmation():
+    """Class 2 cannot be evidenced from these two sources, and says so.
+
+    Confirming an A/C/D revision needs the monthly change records published
+    after the build. Asserting it from a field mismatch alone would be a guess
+    wearing a taxonomy label.
+    """
+    result = s1.classify(
+        only_live_months={}, only_snapshot_months={},
+        mismatch_months={"2019-05": 2}, provisional_from="2026-04-01",
+        live_saturated=False, snapshot_saturated=False,
+        live_truncation_evidenced=False)
+    assert result["later_acd_revision"] == 2
+    assert result["operator_confirmation_required"] == 2
+
+
+def test_an_unclassified_divergence_stops_the_run_by_default(
+        materialized, instance, tmp_path, monkeypatch):
+    """The default is to stop and investigate, not to accumulate mysteries."""
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    report = _run(materialized, instance, tmp_path, monkeypatch, latency_repeats=1)
+    assert report["aborted"] and "unclassified divergence" in report["aborted"]
+    assert report["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# The vacuous-pass guard
+# ---------------------------------------------------------------------------
+
+def test_sharing_no_transaction_id_is_a_failure_not_a_pass(
+        materialized, instance, tmp_path, monkeypatch):
+    """The single way this gate could go green while proving nothing.
+
+    The live path takes `transactionId` straight from SPARQL; the snapshot
+    strips `{}` from the CSV id. If those spellings ever differ, no id is
+    shared, "100% equality on shared ids" is vacuously true, and a gate passes
+    having compared zero rows. So an empty intersection with rows on both sides
+    is recorded as a failure.
+
+    Mutation: drop the `empty_id_intersection_with_rows_on_both_sides` term
+    from the criterion and this test goes green with nothing compared.
+    """
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    disjoint = [PPDTransaction(transaction_id="UUID-STYLE-LIVE-ONLY",
+                               postcode="B5 7AA", date="2026-05-01", price=1)]
+    live = FakeLive(transactions=disjoint)
+    report = _run(materialized, instance, tmp_path, monkeypatch, live=live,
+                  latency_repeats=1, stop_on_unclassified=False)
+    criterion = report["exit_criteria"]["field_equality_on_shared_ids"]
+    assert criterion["passed"] is False
+    assert criterion["vacuous_comparison_shapes"], (
+        "an empty id intersection with rows on both sides was not flagged")
+    assert report["passed"] is False
+
+
+def test_a_shared_id_with_a_differing_field_fails_the_equality_criterion(
+        materialized, instance, tmp_path, monkeypatch):
+    """The criterion it is actually there to test."""
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    # Same id as the snapshot holds, different price.
+    live = FakeLive(transactions=[
+        PPDTransaction(transaction_id="T-B57-000", postcode="B5 7AA",
+                       date=(date.today() - timedelta(days=120)).isoformat(),
+                       price=999_999, property_type="F")])
+    report = _run(materialized, instance, tmp_path, monkeypatch, live=live,
+                  latency_repeats=1, stop_on_unclassified=False)
+    criterion = report["exit_criteria"]["field_equality_on_shared_ids"]
+    assert criterion["mismatch_rows"] >= 1
+    assert criterion["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Nothing identifying is ever persisted
+# ---------------------------------------------------------------------------
+
+def test_no_id_address_or_price_reaches_the_report(materialized, instance,
+                                                   tmp_path, monkeypatch):
+    """Ids and field values exist for one comparison, then are discarded.
+
+    The report is a file that gets pasted into a review. It carries counts,
+    month histograms, field-mismatch tallies and geography -- enough to
+    classify a divergence, and nothing that names a household's sale.
+    """
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    live = FakeLive(transactions=[
+        PPDTransaction(transaction_id="T-B57-A", postcode="B5 7AA",
+                       date="2026-05-01", price=210_000, street="HIGH STREET")])
+    _run(materialized, instance, tmp_path, monkeypatch, live=live,
+         latency_repeats=1, stop_on_unclassified=False)
+    body = (tmp_path / "report.json").read_text()
+    for forbidden in FORBIDDEN_IN_REPORT:
+        assert forbidden not in body, f"the report leaked {forbidden!r}"
+    for forbidden in ("T-B57-000", "HIGH STREET", "200000", "999000"):
+        assert forbidden not in body, f"the report leaked {forbidden!r}"
+
+
+def test_a_month_histogram_is_the_finest_granularity_recorded():
+    """Month, not date: enough to answer "is this in the provisional tail?"."""
+    rows = [PPDTransaction(transaction_id="A", date="2026-05-14", price=1),
+            PPDTransaction(transaction_id="B", date="2026-05-30", price=2),
+            PPDTransaction(transaction_id="C", date="2026-06-01", price=3)]
+    assert s1._by_month(rows, {"A", "B", "C"}) == {"2026-05": 2, "2026-06": 1}
+
+
+def test_field_values_never_leave_the_comparison():
+    """The tally names the field that differed, never what it differed to."""
+    live = [PPDTransaction(transaction_id="X", price=100, postcode="B5 7AA",
+                           date="2026-05-01")]
+    snap = [PPDTransaction(transaction_id="X", price=200, postcode="B5 7AA",
+                           date="2026-05-01")]
+    tally, months, rows = s1._field_mismatches(live, snap, {"X"})
+    assert tally == {"price": 1}
+    assert months == {"2026-05": 1}
+    assert rows == 1
+    assert "100" not in json.dumps(tally) and "200" not in json.dumps(tally)
+
+
+# ---------------------------------------------------------------------------
+# Latency: nearest rank, exactly
+# ---------------------------------------------------------------------------
+
+def test_nearest_rank_is_an_observed_value_not_an_interpolation():
+    """A gate should not be decided by a latency no request ever took."""
+    values = [float(n) for n in range(1, 101)]  # 1..100
+    assert s1.nearest_rank(values, 95) == 95.0
+    assert s1.nearest_rank(values, 50) == 50.0
+    assert s1.nearest_rank(values, 99) == 99.0
+    assert s1.nearest_rank(values, 100) == 100.0
+
+
+def test_nearest_rank_at_the_stage_1_sample_size():
+    """390 observations: 13 frozen cases x 30 repetitions. Rank 371, index 370."""
+    values = [float(n) for n in range(390)]
+    assert s1.nearest_rank(values, 95) == 370.0
+
+
+def test_nearest_rank_on_an_empty_sample_is_unknown_not_zero():
+    """`0` and "no observations" are different answers."""
+    assert s1.nearest_rank([], 95) is None
+    assert s1.latency_summary([])["p95_ms"] is None
+
+
+def test_the_p95_criterion_fails_when_there_is_no_sample():
+    """No latency sample cannot pass a latency gate."""
+    values: list[float] = []
+    summary = s1.latency_summary(values)
+    assert summary["n"] == 0
+    assert summary["p95_ms"] is None
+
+
+def test_the_report_labels_its_latency_as_the_corpus_mix_not_organic_traffic(
+        instance):
+    """Rev 10's concession, carried in the evidence itself.
+
+    A report read six months later must say what its percentile was measured
+    over. Without this the number is indistinguishable from an organic-traffic
+    p95, which is exactly the claim rev 10 refused to make.
+    """
+    report = s1._build_report(
+        instance=instance, identity={}, limits=s1.RunLimits(), results=[],
+        latency_ms=[1.0], per_case={}, snapshot_errors=[], live_errors=[],
+        contamination=[], excluded={}, aborted=None, live_calls=0)
+    assert report["latency_sample_kind"] == "deployed_machine_frozen_corpus"
+    assert "not a sample of organic traffic" in report["not_organic_traffic"]
+
+
+# ---------------------------------------------------------------------------
+# The Instance binds to the artifact actually on this Machine
+# ---------------------------------------------------------------------------
+
+def _write(tmp_path, materialized, **overrides):
+    raw = _instance_dict(materialized)
+    raw.update(overrides)
+    path = tmp_path / "instance.json"
+    path.write_text(json.dumps(raw))
+    return path
+
+
+def test_a_rehearsal_instance_cannot_be_run_as_stage_1(materialized, tmp_path):
+    """The one substitution the Definition names, refused by kind.
+
+    A rehearsal has no live arm and runs on a workstation. Letting one through
+    here is how a correctness exercise gets filed as Stage 1 evidence.
+    """
+    path = _write(tmp_path, materialized, instance_kind="rehearsal")
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "must not be run as Stage 1" in str(exc.value)
+
+
+def test_an_instance_describing_another_artifact_is_refused(materialized, tmp_path):
+    """Binding, not just validity. Otherwise the provenance is a fiction."""
+    path = _write(tmp_path, materialized, bundle_sha256="a" * 64)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "different artifact" in str(exc.value)
+
+
+def test_an_instance_naming_another_version_is_refused(materialized, tmp_path):
+    path = _write(tmp_path, materialized, snapshot_version="v20200101T000000Z")
+    with pytest.raises(InstanceRefused):
+        s1.load_instance(path, materialized)
+
+
+@pytest.mark.parametrize("baselines", [
+    {"S1_full": 40, "S3_full": 40, "S9_full": 55},   # S3 not a STRICT subset
+    {"S1_full": 100, "S3_full": 40, "S9_full": 40},  # category B cannot shrink
+    {"S1_full": 100, "S3_full": 40, "S9_full": 30},
+])
+def test_baselines_contradicting_what_they_qualify_are_refused(
+        materialized, tmp_path, baselines):
+    """A baseline set that contradicts its own relation qualifies nothing.
+
+    Worse than absent: it would look like evidence. The strict-subset rule in
+    particular -- equal counts would say the sector is the whole district.
+    """
+    path = _write(tmp_path, materialized, aggregate_baselines=baselines)
+    with pytest.raises(InstanceRefused):
+        s1.load_instance(path, materialized)
+
+
+def test_an_instance_that_does_not_say_how_it_qualified_is_refused(
+        materialized, tmp_path):
+    path = _write(tmp_path, materialized, qualification={})
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "qualified nothing" in str(exc.value) or "qualifies nothing" in str(exc.value)
+
+
+def test_unknown_instance_keys_are_refused_not_ignored(materialized, tmp_path):
+    """A typo in an Instance is a silently different run."""
+    path = _write(tmp_path, materialized, sample_rate=0.5)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "unknown key" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# qualify
+# ---------------------------------------------------------------------------
+
+def test_qualify_measures_the_baselines_and_emits_a_candidate(materialized):
+    """Read-only aggregate counts, bound to the artifact, marked as candidate."""
+    out = s1.qualify(materialized)
+    assert out["kind"] == "stage1_qualification_candidate"
+    assert out["is_instance"] is False
+    candidate = out["candidate_instance"]
+    assert candidate["snapshot_version"] == materialized.version
+    assert candidate["bundle_sha256"] == materialized.bundle_sha256
+    assert set(candidate["aggregate_baselines"]) == {"S1_full", "S3_full", "S9_full"}
+    assert candidate["instance_kind"] == "stage1"
+
+
+def test_qualify_makes_no_live_call_and_downloads_nothing(materialized):
+    """Sockets are hard-failed for this module; qualification must not need one."""
+    out = s1.qualify(materialized)
+    assert out["candidate_instance"]["qualified_at"]
+
+
+def test_qualify_reports_placeholders_it_could_not_qualify(materialized):
+    """Silence about an unqualified placeholder would produce an unusable
+    Instance that looked complete."""
+    out = s1.qualify(materialized)
+    assert isinstance(out["unqualified_placeholders"], list)
+    qualified = set(out["candidate_instance"]["geographies"])
+    unqualified = set(out["unqualified_placeholders"])
+    assert not (qualified & unqualified)
+
+
+def test_qualify_never_selects_a_sparse_unit_postcode(materialized):
+    """The Definition requires S6 to be aggregate-dense, "so not individually
+    identifying". Made executable so qualification cannot pick a postcode that
+    names one household's sale history.
+    """
+    out = s1.qualify(materialized)
+    geo = out["candidate_instance"]["geographies"]
+    if "S6_unit" in geo:
+        measured = out["candidate_instance"]["qualification"]["S6_unit"]
+        assert measured["measured_rows"] >= s1.MIN_UNIT_POSTCODE_ROWS
+
+
+def test_qualify_output_carries_no_ids_prices_or_addresses(materialized):
+    body = json.dumps(s1.qualify(materialized))
+    for forbidden in ("T-B57", "HIGH STREET", "transaction_id", "200000"):
+        assert forbidden not in body, f"qualification leaked {forbidden!r}"
+
+
+def test_qualification_is_deterministic_for_one_artifact(materialized):
+    """An Instance nobody can reproduce is not qualification evidence."""
+    today = date(2026, 9, 1)
+    first = s1.qualify(materialized, today=today)["candidate_instance"]
+    second = s1.qualify(materialized, today=today)["candidate_instance"]
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# The adapter internals qualification relies on
+# ---------------------------------------------------------------------------
+
+def test_the_adapter_names_qualification_depends_on_still_exist():
+    """`qualify` counts over the adapter's own validated view rather than
+    building a second one. That reuse is only safe while these two names hold,
+    so a rename fails here loudly instead of silently counting something else.
+    """
+    from property_core.snapshot.adapter import VIEW, SnapshotAdapter
+
+    assert VIEW == "ppd"
+    assert callable(getattr(SnapshotAdapter, "_execute", None))
+
+
+# ---------------------------------------------------------------------------
+# Image delivery
+# ---------------------------------------------------------------------------
+
+def test_the_api_image_carries_the_comparator_and_its_corpus():
+    """Both files, or the comparator cannot import its own frozen corpus.
+
+    A repository-config lint, and labelled as one: it proves what the Dockerfile
+    says, never that the wheel resolved or the module imports on that platform.
+    `tests/snapshot/image_smoke.py stage1` is what actually invokes it in the
+    built image.
+    """
+    dockerfile = (REPO / "Dockerfile").read_text()
+    for path in ("tools/ppd_snapshot/corpus.py",
+                 "tools/ppd_snapshot/stage1_shadow.py",
+                 "tools/ppd_snapshot/__init__.py"):
+        assert path in dockerfile, f"the API image does not copy {path}"
+
+
+def test_propertydata_does_not_carry_the_comparator():
+    """Stage 1 is `property-shared` only; `propertydata` stays untouched."""
+    app_dockerfile = (REPO / "Dockerfile.app").read_text()
+    assert "stage1_shadow" not in app_dockerfile
+    assert "ppd_snapshot" not in app_dockerfile
+
+
+def test_the_comparator_is_not_wired_into_the_serving_entrypoint():
+    """Never imported by the app, never in CMD. Out of band means out of band.
+
+    Mutation: import it from `app/` and this fails -- which matters because an
+    import is all it would take for rollout tooling to start loading inside the
+    process that serves requests.
+    """
+    dockerfile = (REPO / "Dockerfile").read_text()
+    cmd = [line for line in dockerfile.splitlines() if line.startswith("CMD")]
+    assert cmd and "stage1_shadow" not in cmd[0]
+    for package in ("app", "property_core", "property_app", "property_cli"):
+        for source in (REPO / package).rglob("*.py"):
+            assert "stage1_shadow" not in source.read_text(), (
+                f"{source} imports the Stage 1 comparator into shipped code")
+
+
+def test_qualify_says_when_the_measured_baselines_would_be_refused(materialized):
+    """An operator must learn this while choosing geographies, not at load time.
+
+    The baselines are measured over the definitional `B5` / `B5 4` geographies.
+    If those do not satisfy the strict-subset and category-B relations on this
+    artifact, the Instance built from them will be refused -- and the Definition's
+    remedy is a substituted geography with recorded justification, which is an
+    authoring decision this tool must surface rather than make.
+    """
+    out = s1.qualify(materialized)
+    assert "baselines_satisfy_their_relations" in out
+    if not out["baselines_satisfy_their_relations"]:
+        assert out["baselines_refusal"], (
+            "qualification reported unusable baselines without saying why")
+    else:
+        assert out["baselines_refusal"] is None
+
+
+def test_qualified_baselines_that_pass_here_are_accepted_by_the_loader(
+        tmp_path, monkeypatch):
+    """The two sides of the same rule must agree.
+
+    Mutation: loosen `validate_baselines` on one side only and a candidate that
+    qualification called usable is refused at load, or vice versa.
+    """
+    rows = [row(f"T-B54-{i:03d}", "B5 4AA", "2026-05-04", 200_000 + i)
+            for i in range(20)]
+    rows += [row(f"T-B57-{i:03d}", "B5 7AA", "2026-05-04", 200_000 + i)
+             for i in range(20)]
+    rows += [row("T-B54-CATB", "B5 4AB", "2026-05-04", 900_000, ppd_category="B")]
+    build_snapshot(tmp_path, rows, version="v20260828T194003Z")
+    opened = s1.open_materialized(tmp_path)
+    try:
+        out = s1.qualify(opened, today=date(2026, 6, 15))
+        assert out["baselines_satisfy_their_relations"] is True
+        from tools.ppd_snapshot.corpus import validate_baselines
+        validate_baselines(out["candidate_instance"]["aggregate_baselines"])
+    finally:
+        opened.adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# Return-live: the flag gate, tested one layer at a time
+# ---------------------------------------------------------------------------
+#
+# `PPD_SNAPSHOT_ENABLED` is checked twice on the way to a routable adapter --
+# in `ppd_source.active_adapter()` before `state` is even imported, and again
+# inside `state.active_adapter()`. `ppd_source`'s docstring says that redundancy
+# is deliberate, "because either call site alone must fail closed".
+#
+# That is exactly what makes an end-to-end assertion a weak guard here: remove
+# either check on its own and the other still returns None, so the behaviour
+# never changes and no behavioural test can notice. The risk is erosion -- one
+# layer removed now, the other later. So each layer is tested with the other
+# one deliberately made permissive, and each test fails if its own layer goes.
+
+def test_the_routing_layer_fails_closed_even_if_state_were_permissive(monkeypatch):
+    """`ppd_source.active_adapter()` must refuse before it consults `state`.
+
+    Mutation: delete its `ppd_snapshot_enabled()` check and this fails, even
+    though the process-state check downstream would still have caught it.
+    """
+    from property_core import ppd_source
+    from property_core.snapshot import state
+
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+    monkeypatch.setattr(state, "active_adapter", lambda: "SENTINEL-ADAPTER")
+    assert ppd_source.active_adapter() is None
+
+
+def test_process_state_fails_closed_even_if_the_routing_layer_were_permissive(
+        materialized, monkeypatch):
+    """`state.active_adapter()` must refuse independently of its caller.
+
+    Mutation: delete its `ppd_snapshot_enabled()` check and this fails. An
+    installed adapter must not outlive the flag that authorised routing to it.
+    """
+    from property_core.snapshot import state
+
+    monkeypatch.delenv("PPD_SNAPSHOT_ENABLED", raising=False)
+    state.install(materialized.adapter, None)
+    try:
+        assert state.installed_adapter() is not None
+        assert state.active_adapter() is None
+    finally:
+        # Hand back an empty state without closing an adapter we do not own.
+        state.install(None, None)

--- a/tests/snapshot/test_stage1_shadow.py
+++ b/tests/snapshot/test_stage1_shadow.py
@@ -34,7 +34,6 @@ from property_core.models.ppd import PPDTransaction  # noqa: E402
 from property_core.provenance import TransportEvidence  # noqa: E402
 from tools.ppd_snapshot import stage1_shadow as s1  # noqa: E402
 from tools.ppd_snapshot.corpus import InstanceRefused, cases  # noqa: E402
-from tests.snapshot.rehearsal_fixtures import FORBIDDEN_IN_REPORT  # noqa: E402
 from tests.snapshot.snapshot_fixtures import build_snapshot, row  # noqa: E402
 
 REPO = Path(__file__).resolve().parents[2]
@@ -210,6 +209,17 @@ def test_production_still_answers_from_live_while_the_comparator_runs(materializ
 # A controllable live arm
 # ---------------------------------------------------------------------------
 
+def _request_key(kwargs) -> tuple:
+    """What distinguishes one frozen case from another on the wire.
+
+    Keyed on the whole request, not the postcode: S6 and S13 share `B5 7AA` and
+    differ only by `property_type`, so a postcode-keyed stub silently answers
+    one case with the other's rows.
+    """
+    return (kwargs["postcode"], kwargs["search_level"], kwargs["months"],
+            kwargs.get("property_type"), kwargs.get("transaction_category"))
+
+
 class FakeLive:
     """A live arm whose answers, failures and latency the test chooses.
 
@@ -232,7 +242,7 @@ class FakeLive:
         self.calls.append(kwargs)
         if self.raises is not None:
             raise self.raises
-        rows = self.per_shape.get(kwargs["postcode"], self.transactions)
+        rows = self.per_shape.get(_request_key(kwargs), self.transactions)
         return PPDCompsResponse(
             query=PPDCompsQuery(postcode=kwargs["postcode"],
                                 months=kwargs["months"],
@@ -536,25 +546,199 @@ def test_a_shared_id_with_a_differing_field_fails_the_equality_criterion(
 # Nothing identifying is ever persisted
 # ---------------------------------------------------------------------------
 
-def test_no_id_address_or_price_reaches_the_report(materialized, instance,
-                                                   tmp_path, monkeypatch):
-    """Ids and field values exist for one comparison, then are discarded.
+#: Every key the report is allowed to emit. Dynamic key spaces -- month
+#: buckets, shape names and compared-field names -- are subtracted before the
+#: comparison; see `_static_keys`.
+#:
+#: This is the assertion that actually protects the payload. A substring search
+#: over the serialised JSON cannot: it fires on "400000" inside a latency float
+#: while missing a genuinely new `transaction_ids` field whose values happen not
+#: to collide with the fixture. A key that can carry a row cannot appear here
+#: without someone adding it to this list on purpose.
+ALLOWED_KEYS = {
+    # document
+    "kind", "stage_1_evidence", "latency_sample_kind", "not_organic_traffic",
+    "definition", "artifact", "instance", "isolation", "limits", "excluded",
+    "midnight", "aborted", "cases_total", "cases_compared", "live_errors",
+    "latency", "exit_criteria", "passed", "cases", "note", "criterion",
+    # artifact identity
+    "snapshot_version", "bundle_sha256", "coverage_from", "coverage_to",
+    "provisional_from", "comparator_version",
+    # instance
+    "instance_kind", "qualified_at", "governs_run", "staleness_bound_days",
+    "aggregate_baselines", "baselines_are", "S1_full", "S3_full", "S9_full",
+    # isolation / limits / counters
+    "installed_into_server_state", "snapshot_routing_enabled",
+    "artifacts_downloaded", "snapshot_written_to", "live_delay_seconds",
+    "latency_repeats", "max_live_per_case", "deadline_seconds",
+    "min_available_memory_bytes", "live_calls_made", "health", "memory",
+    "retries", "unrecoverable", "pair_date_mismatches",
+    # per case
+    "shape", "intent", "request", "wire", "effective", "snapshot", "live",
+    "snapshot_error", "live_error", "snapshot_invariants", "diff",
+    "classification", "snapshot_false_empty", "live_truncation_evidenced",
+    "empty_id_intersection_with_rows_on_both_sides",
+    # request echo -- the geography ASKED FOR, never one returned
+    "postcode", "search_level", "months", "limit", "transaction_category",
+    "filter_outliers", "auto_escalate", "enrich_epc", "property_type", "address",
+    # an arm: aggregates, geography membership and provenance only
+    "count", "latency_ms", "thin_market", "outcodes_returned",
+    "sectors_returned", "warning_classes", "saturated_at_limit",
+    "returned_date_from", "returned_date_to", "source", "observed_at",
+    "derived_from_date", "resolved_to_date", "recent_period_provisional",
+    "sample_complete", "transport_evidence", "raw_bindings_returned",
+    "fetch_limit", "source_exhausted",
+    # invariants
+    "coverage_clamp_warning_present", "sample_complete_is_false",
+    "completeness_basis_is_null", "answered_by_snapshot", "provisional_flagged",
+    "geography_isolation", "truncated_at_limit", "thin_market_flagged",
+    "empty_result", "expected_empty",
+    # diff -- cardinalities, histograms and tallies
+    "only_live", "only_snapshot", "shared", "by_month", "count_delta",
+    "field_mismatches", "field_mismatch_rows", "field_mismatch_by_month",
+    "compared_fields",
+    # classification
+    "provisional_tail_lag", "later_acd_revision", "live_truncation_or_ordering",
+    "unclassified", "operator_confirmation_required", "truncation_evidence",
+    "live_raw_bindings_reached_fetch_limit", "context_not_evidence",
+    "live_page_saturated", "snapshot_page_saturated",
+    # verdict
+    "all_thirteen_cases_compared", "corpus_invariants_hold",
+    "zero_unexplained_false_empties", "zero_geography_contamination",
+    "field_equality_on_shared_ids", "every_divergence_classified",
+    "no_unconfirmed_classifications", "zero_snapshot_errors",
+    "p95_under_one_second", "cases_recorded", "required",
+    "cases_missing_snapshot_arm", "cases_missing_live_arm",
+    "cases_never_reached", "snapshot_errors", "assertions_checked", "failures",
+    "failed", "false_empty_shapes", "findings", "errors", "mismatch_rows",
+    # a contamination finding: which arm, and the outcodes it strayed into.
+    # Outcode granularity only -- never a unit postcode, never a row.
+    "arm", "unexpected_outcodes",
+    "vacuous_comparison_shapes", "verdict", "n", "p95_ms",
+    "required_observations", "required_repeats_per_case",
+    "cases_short_of_the_required_repeats",
+    # latency
+    "snapshot_arm", "per_case_ms", "p50_ms", "p99_ms", "max_ms", "method",
+}
 
-    The report is a file that gets pasted into a review. It carries counts,
-    month histograms, field-mismatch tallies and geography -- enough to
-    classify a divergence, and nothing that names a household's sale.
-    """
+SHAPE_NAMES = {c.shape for c in cases(GEOGRAPHIES)}
+#: Field names may legitimately appear as KEYS of `field_mismatches` and as
+#: VALUES of `compared_fields`. Naming which field differed is not disclosing
+#: what it differed to.
+FIELD_NAMES = set(s1.COMPARED_FIELDS)
+MONTH = __import__("re").compile(r"^\d{4}-\d{2}$")
+
+
+def _scalars(node, path="$"):
+    """Every scalar in the document, with the path it was reached by."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from _scalars(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from _scalars(value, f"{path}[{index}]")
+    else:
+        yield path, node
+
+
+def _static_keys(node):
+    """Keys, minus the dynamic key spaces (months, shapes, field names)."""
+    found = set()
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if not (MONTH.match(str(key)) or key in SHAPE_NAMES
+                    or key in FIELD_NAMES):
+                found.add(key)
+            found |= _static_keys(value)
+    elif isinstance(node, list):
+        for value in node:
+            found |= _static_keys(value)
+    return found
+
+
+@pytest.fixture
+def report_with_leaky_fixture_data(materialized, instance, tmp_path, monkeypatch):
+    """A completed report over rows carrying ids, streets, towns and prices."""
     monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
     live = FakeLive(transactions=[
         PPDTransaction(transaction_id="T-B57-A", postcode="B5 7AA",
-                       date="2026-05-01", price=210_000, street="HIGH STREET")])
+                       date="2026-05-01", price=210_000, street="HIGH STREET",
+                       town="BIRMINGHAM", paon="1", saon="FLAT 2")])
     _run(materialized, instance, tmp_path, monkeypatch, live=live,
          latency_repeats=1, stop_on_unclassified=False)
-    body = (tmp_path / "report.json").read_text()
-    for forbidden in FORBIDDEN_IN_REPORT:
-        assert forbidden not in body, f"the report leaked {forbidden!r}"
-    for forbidden in ("T-B57-000", "HIGH STREET", "200000", "999000"):
-        assert forbidden not in body, f"the report leaked {forbidden!r}"
+    return json.loads((tmp_path / "report.json").read_text())
+
+
+def test_the_report_schema_admits_no_field_that_could_carry_a_row(
+        report_with_leaky_fixture_data):
+    """Structural, not textual: no unreviewed key may appear at all.
+
+    Mutation: add `"only_live_ids": sorted(only_live)` to the diff and this
+    fails on the new key -- whether or not its values happen to collide with
+    anything a substring search was looking for.
+    """
+    unexpected = _static_keys(report_with_leaky_fixture_data) - ALLOWED_KEYS
+    assert not unexpected, (
+        f"the report emits un-reviewed key(s) {sorted(unexpected)}; every field "
+        f"capable of carrying transaction data must be added deliberately")
+
+
+def test_no_report_value_equals_a_transaction_identifier(
+        report_with_leaky_fixture_data):
+    """Exact equality against the fixture's identifying values.
+
+    Equality, never substring -- that distinction is the whole point. A latency
+    of 1.400000 ms contains the digits of a 400000 price and leaks nothing; a
+    value that IS "T-B57-A" leaks a transaction.
+    """
+    identifying = {"T-B57-A", "T-B57-000", "T-B50-A", "T-B56-D",
+                   "HIGH STREET", "BIRMINGHAM", "WEST MIDLANDS", "FLAT 2"}
+    for path, value in _scalars(report_with_leaky_fixture_data):
+        if isinstance(value, str):
+            assert value not in identifying, f"{path} leaked {value!r}"
+
+
+def test_no_price_reaches_the_report_as_a_value(report_with_leaky_fixture_data):
+    """Prices are compared in memory and never recorded.
+
+    Restricted to values inside `cases`, and excluding measured timings, so a
+    latency or a byte count can never be mistaken for a sale price -- the
+    false positive that failed CI on the previous text-matching version.
+    """
+    prices = {210_000, 999_000, 400_000, 300_000, 310_000, 320_000, 330_000}
+    prices |= {200_000 + n for n in range(30)}
+    for path, value in _scalars(report_with_leaky_fixture_data["cases"], "$.cases"):
+        if path.endswith("latency_ms"):
+            continue
+        assert value not in prices, f"{path} leaked the price {value!r}"
+
+
+def test_a_latency_float_sharing_digits_with_a_price_is_not_treated_as_a_leak():
+    """Regression: the exact false positive that failed CI on PR #51.
+
+    `"latency_ms": 1.400000000000001` made a substring search for "400000"
+    fire, and the test passed or failed on timing noise. A structural check
+    cannot express that mistake.
+    """
+    document = {"cases": [{"snapshot": {"latency_ms": 1.400000000000001,
+                                        "count": 3}}]}
+    values = [v for path, v in _scalars(document["cases"], "$.cases")
+              if not path.endswith("latency_ms")]
+    assert 400_000 not in values
+    assert all(isinstance(v, (int, float, str, bool)) or v is None for v in values)
+
+
+def test_field_names_may_appear_but_only_as_names(report_with_leaky_fixture_data):
+    """`field_mismatches` names which field differed; that is not disclosure.
+
+    The distinction a key allowlist has to get right: "price" as a KEY of the
+    mismatch tally is a field name, while "price" carrying 210000 would be the
+    sale. The first is required evidence, the second is forbidden.
+    """
+    for case in report_with_leaky_fixture_data["cases"]:
+        tally = case.get("diff", {}).get("field_mismatches", {})
+        assert set(tally) <= set(s1.COMPARED_FIELDS)
+        assert all(isinstance(v, int) for v in tally.values())
 
 
 def test_a_month_histogram_is_the_finest_granularity_recorded():
@@ -622,7 +806,9 @@ def test_the_report_labels_its_latency_as_the_corpus_mix_not_organic_traffic(
     report = s1._build_report(
         instance=instance, identity={}, limits=s1.RunLimits(), results=[],
         latency_ms=[1.0], per_case={}, snapshot_errors=[], live_errors=[],
-        contamination=[], excluded={}, aborted=None, live_calls=0)
+        contamination=[], excluded={},
+        midnight={"retries": 0, "unrecoverable": False, "pair_date_mismatches": 0},
+        corpus=cases(GEOGRAPHIES), aborted=None, live_calls=0)
     assert report["latency_sample_kind"] == "deployed_machine_frozen_corpus"
     assert "not a sample of organic traffic" in report["not_organic_traffic"]
 
@@ -900,3 +1086,464 @@ def test_process_state_fails_closed_even_if_the_routing_layer_were_permissive(
     finally:
         # Hand back an empty state without closing an adapter we do not own.
         state.install(None, None)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: every one of these must make the TOP-LEVEL verdict false
+# ---------------------------------------------------------------------------
+#
+# Asserting a helper returns the right number is not the same as asserting the
+# report says "failed". The wiring between the two is where a gate silently
+# goes green: a criterion computed correctly and then not consulted, or
+# consulted and then overridden. Each test below reads `report["passed"]`.
+
+def _full_run(materialized, instance, tmp_path, monkeypatch, *, live=None,
+              repeats=s1.REQUIRED_LATENCY_REPEATS, snapshot_service=None,
+              **limit_kwargs):
+    """A run sized as the real gate defines it: 13 cases x 30 repetitions."""
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
+    limits = s1.RunLimits(live_delay_seconds=0.0, latency_repeats=repeats,
+                          stop_on_unclassified=False, **limit_kwargs)
+    return s1.run_compare(
+        instance=instance, materialized=materialized, limits=limits,
+        report_path=tmp_path / "report.json",
+        live_service=live if live is not None else FakeLive(),
+        snapshot_service=snapshot_service)
+
+
+@pytest.fixture
+def agreeing_live(materialized):
+    """A live arm that returns exactly what the snapshot holds, per case.
+
+    The only configuration in which a pass is even reachable -- so it is the
+    baseline every negative test below perturbs by one thing.
+    """
+    from property_core.ppd_service import PPDService
+
+    snapshot = PPDService(adapter=materialized.adapter)
+    per_shape = {}
+    for case in cases(GEOGRAPHIES):
+        request = dict(postcode=case.postcode, search_level=case.search_level,
+                       months=case.months, property_type=case.property_type,
+                       transaction_category=case.transaction_category)
+        response = snapshot.comps(filter_outliers=False, limit=50,
+                                  auto_escalate=True, **request)
+        per_shape[_request_key(request)] = list(response.transactions)
+    return FakeLive(per_shape=per_shape)
+
+
+def test_a_live_arm_error_makes_the_verdict_false(materialized, instance,
+                                                  tmp_path, monkeypatch):
+    """Item 1. A report is not allowed to pass while an arm failed."""
+    live = FakeLive(raises=RuntimeError("upstream exploded"))
+    report = _full_run(materialized, instance, tmp_path, monkeypatch,
+                       live=live, repeats=s1.REQUIRED_LATENCY_REPEATS)
+    assert report["exit_criteria"]["all_thirteen_cases_compared"]["passed"] is False
+    assert report["exit_criteria"]["all_thirteen_cases_compared"]["live_errors"] == 13
+    assert report["passed"] is False
+
+
+def test_a_missing_arm_makes_the_verdict_false(materialized, instance, tmp_path,
+                                               monkeypatch, agreeing_live):
+    """Item 1. `cases_compared != 13` blocks passage on its own."""
+    class OneShort:
+        def __init__(self, real):
+            self._real = real
+        def comps(self, **kwargs):
+            if kwargs["postcode"] == "B50":
+                raise RuntimeError("no snapshot answer for this case")
+            return self._real.comps(**kwargs)
+
+    from property_core.ppd_service import PPDService
+
+    report = _full_run(materialized, instance, tmp_path, monkeypatch,
+                       live=agreeing_live, repeats=1,
+                       snapshot_service=OneShort(
+                           PPDService(adapter=materialized.adapter)))
+    criterion = report["exit_criteria"]["all_thirteen_cases_compared"]
+    assert criterion["cases_compared"] < s1.REQUIRED_CASES
+    assert criterion["cases_missing_snapshot_arm"] == ["S2"]
+    assert criterion["passed"] is False
+    assert report["passed"] is False
+
+
+def test_a_short_latency_sample_is_insufficient_evidence_never_a_pass(
+        materialized, instance, tmp_path, monkeypatch, agreeing_live):
+    """Item 3. Fewer than 13 x 30 observations cannot pass the latency gate.
+
+    Mutation: compute the verdict from `p95 < 1000` alone and this run -- whose
+    latencies are microseconds -- flips straight to a pass on 13 observations.
+    """
+    report = _full_run(materialized, instance, tmp_path, monkeypatch,
+                       live=agreeing_live, repeats=1)
+    criterion = report["exit_criteria"]["p95_under_one_second"]
+    assert criterion["n"] == 13
+    assert criterion["required_observations"] == 390
+    assert criterion["verdict"] == "insufficient_evidence"
+    assert criterion["passed"] is False
+    assert report["passed"] is False
+
+
+def test_the_full_sample_is_exactly_thirteen_by_thirty(
+        materialized, instance, tmp_path, monkeypatch, agreeing_live):
+    """Item 3, the positive half: 390 observations, 30 for every case."""
+    report = _full_run(materialized, instance, tmp_path, monkeypatch,
+                       live=agreeing_live)
+    criterion = report["exit_criteria"]["p95_under_one_second"]
+    assert criterion["n"] == 390
+    assert criterion["cases_short_of_the_required_repeats"] == []
+    assert criterion["verdict"] in {"pass", "fail"}
+    per_case = report["latency"]["per_case_ms"]
+    assert len(per_case) == 13
+    assert all(v["n"] == 30 for v in per_case.values())
+
+
+def test_an_unconfirmed_revision_makes_the_verdict_false(
+        materialized, instance, tmp_path, monkeypatch, agreeing_live):
+    """Item 5. A proposed A/C/D revision blocks the verdict, never annotates it.
+
+    Mutation: drop `no_unconfirmed_classifications` from the criteria and this
+    report passes while carrying a classification nothing has confirmed.
+    """
+    # One shared id whose price differs, dated well before the provisional
+    # period -- the A/C/D signature, which this comparison cannot evidence.
+    old = "2019-05-01"
+    rows = [row("T-OLD-001", "B5 7AA", old, 250_000, property_type="F")]
+    build_snapshot(tmp_path / "art", rows, version="v20260828T194003Z")
+    opened = s1.open_materialized(tmp_path / "art")
+    try:
+        path = tmp_path / "i.json"
+        raw = _instance_dict(opened)
+        raw["governs_run"] = "negative-test"
+        path.write_text(json.dumps(raw))
+        bound = s1.load_instance(path, opened)
+        live = FakeLive(transactions=[
+            PPDTransaction(transaction_id="T-OLD-001", postcode="B5 7AA",
+                           date=old, price=999_111, property_type="F",
+                           estate_type="L", transaction_category="A",
+                           new_build=False)])
+        report = _full_run(opened, bound, tmp_path, monkeypatch, live=live,
+                           repeats=1)
+    finally:
+        opened.adapter.close()
+    criterion = report["exit_criteria"]["no_unconfirmed_classifications"]
+    assert criterion["operator_confirmation_required"] >= 1
+    assert criterion["passed"] is False
+    assert report["passed"] is False
+
+
+def test_a_broken_corpus_invariant_makes_the_verdict_false(
+        materialized, instance, tmp_path, monkeypatch, agreeing_live):
+    """Item 9. Section 3's universal invariants are enforced, not just recorded.
+
+    `sample_complete: true` on a comps case is a defect, not a divergence.
+    Mutation: record the invariants without consulting them in the verdict and
+    this passes with a broken structural guarantee.
+    """
+    real = s1.snapshot_invariants
+
+    def broken(case, response, provenance, classes):
+        result = real(case, response, provenance, classes)
+        if case.shape == "S3":
+            result["sample_complete_is_false"] = False
+        return result
+
+    monkeypatch.setattr(s1, "snapshot_invariants", broken)
+    report = _full_run(materialized, instance, tmp_path, monkeypatch,
+                       live=agreeing_live, repeats=1)
+    criterion = report["exit_criteria"]["corpus_invariants_hold"]
+    assert criterion["passed"] is False
+    assert criterion["failures"], "a broken invariant was not reported"
+    assert criterion["failures"][0]["shape"] == "S3"
+    assert "sample_complete_is_false" in criterion["failures"][0]["failed"]
+    assert report["passed"] is False
+
+
+def test_the_report_records_returned_date_bounds_for_both_arms(
+        materialized, instance, tmp_path, monkeypatch, agreeing_live):
+    """Item 9. Definition section 9 requires the date bounds of returned rows.
+
+    Two dates are not a transaction, and they are what shows a window was
+    honoured.
+    """
+    report = _full_run(materialized, instance, tmp_path, monkeypatch,
+                       live=agreeing_live, repeats=1)
+    non_empty = [c for c in report["cases"] if c["snapshot"]["count"] > 0]
+    assert non_empty
+    for case in non_empty:
+        for arm in ("snapshot", "live"):
+            assert case[arm]["returned_date_from"] is not None, (case["shape"], arm)
+            assert case[arm]["returned_date_to"] is not None, (case["shape"], arm)
+            assert case[arm]["returned_date_from"] <= case[arm]["returned_date_to"]
+
+
+def test_a_midnight_crossing_aborts_with_a_written_failed_report(
+        materialized, instance, tmp_path, monkeypatch):
+    """Item 2. Never silently skipped.
+
+    An observation that straddles midnight describes a different window from
+    the one recorded. Skipping it would leave a report claiming thirteen cases
+    while holding twelve and a latency sample short of its declared size --
+    both of which the totals would conceal. Mutation: swallow `MidnightCrossed`
+    into an exclusion counter and this run reports a clean thirteen.
+    """
+    real_today = date.today
+    flips = iter([real_today(), real_today() + timedelta(days=1)] * 40)
+
+    class _AlwaysCrossing:
+        today = staticmethod(lambda: next(flips))
+        fromisoformat = staticmethod(date.fromisoformat)
+
+    monkeypatch.setattr(s1, "date", _AlwaysCrossing)
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
+    report = s1.run_compare(
+        instance=instance, materialized=materialized,
+        limits=s1.RunLimits(live_delay_seconds=0.0, latency_repeats=1,
+                            stop_on_unclassified=False),
+        report_path=tmp_path / "report.json",
+        live_service=FakeLive(), snapshot_service=None)
+    assert report["aborted"], "a surviving midnight crossing did not abort the run"
+    assert report["midnight"]["unrecoverable"] is True
+    assert report["midnight"]["retries"] >= 1, "the bounded retry never ran"
+    assert report["passed"] is False
+    assert (tmp_path / "report.json").is_file(), (
+        "the run aborted without writing the failed report")
+
+
+def test_the_snapshot_arm_retries_a_crossing_before_giving_up(materialized):
+    """Item 2. The documented bounded retry, on the arm where it is free."""
+    real_today = date.today
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        # Cross on the first observation's second read, then settle.
+        return real_today() + timedelta(days=1) if calls["n"] == 2 else real_today()
+
+    from property_core.ppd_service import PPDService
+    import tools.ppd_snapshot.stage1_shadow as module
+
+    original = module.date
+    try:
+        class _Date:
+            today = staticmethod(flaky)
+            fromisoformat = staticmethod(original.fromisoformat)
+        module.date = _Date
+        case = cases(GEOGRAPHIES)[0]
+        _, observed, retries, _ = module._observe(
+            PPDService(adapter=materialized.adapter), case,
+            attempts=module.MIDNIGHT_ATTEMPTS)
+    finally:
+        module.date = original
+    assert retries == 1, "the crossing was not retried"
+    assert observed
+
+
+def test_arms_observed_on_different_days_abort_rather_than_compare(
+        materialized, instance, tmp_path, monkeypatch):
+    """Item 2. A pair straddling midnight compares two different windows.
+
+    Nothing downstream can detect this: both arms look internally consistent,
+    and the diff between them is just wrong. Mutation: drop the pair-date check
+    and the run compares a snapshot window against a live window one day apart
+    and reports the difference as a divergence.
+    """
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
+    real = s1._arm_record
+
+    def shifted(response, case, observed, latency_ms):
+        record = real(response, case, observed, latency_ms)
+        # Only the live arm is moved, so the pair disagrees.
+        if getattr(response, "provenance", None) is not None and \
+                "snapshot" not in str(response.provenance.source).lower():
+            record["observed_at"] = (
+                date.fromisoformat(observed) + timedelta(days=1)).isoformat()
+        return record
+
+    monkeypatch.setattr(s1, "_arm_record", shifted)
+    report = s1.run_compare(
+        instance=instance, materialized=materialized,
+        limits=s1.RunLimits(live_delay_seconds=0.0, latency_repeats=1,
+                            stop_on_unclassified=False),
+        report_path=tmp_path / "report.json",
+        live_service=FakeLive(), snapshot_service=None)
+    assert report["aborted"] and "straddles midnight" in report["aborted"]
+    assert report["midnight"]["pair_date_mismatches"] == 1
+    assert report["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Item 4: saturation is context, never evidence
+# ---------------------------------------------------------------------------
+
+def test_page_saturation_alone_cannot_classify_live_truncation():
+    """Item 4. Neither side's saturated page is evidence about the live window.
+
+    A live page at `limit` says our own presentation limit was reached, not
+    that the upstream window was. A saturated snapshot page says nothing about
+    live at all. Mutation: OR either flag back into the evidence test and these
+    divergences become "explained" without a single transport fact.
+    """
+    for live_saturated, snapshot_saturated in ((True, False), (False, True),
+                                               (True, True)):
+        result = s1.classify(
+            only_live_months={"2019-05": 2}, only_snapshot_months={"2019-06": 1},
+            mismatch_months={}, provisional_from="2026-04-01",
+            live_saturated=live_saturated, snapshot_saturated=snapshot_saturated,
+            live_truncation_evidenced=False)
+        assert result["live_truncation_or_ordering"] == 0, (
+            live_saturated, snapshot_saturated)
+        assert result["unclassified"] == 3
+
+
+def test_saturation_is_still_recorded_as_context(materialized):
+    """Considered and rejected as a basis -- visibly, so a reader can tell."""
+    result = s1.classify(
+        only_live_months={}, only_snapshot_months={}, mismatch_months={},
+        provisional_from="2026-04-01", live_saturated=True,
+        snapshot_saturated=True, live_truncation_evidenced=False)
+    context = result["truncation_evidence"]["context_not_evidence"]
+    assert context["live_page_saturated"] is True
+    assert context["snapshot_page_saturated"] is True
+    assert result["truncation_evidence"][
+        "live_raw_bindings_reached_fetch_limit"] is False
+
+
+def test_transport_evidence_comes_from_the_captured_live_call():
+    """Item 4. The evidence is `raw_bindings_returned` against `fetch_limit`."""
+    capture = s1.LiveEvidenceCapture()
+    capture.last = {"raw_bindings_returned": 50, "fetch_limit": 50}
+    assert capture.truncation_evidenced is True
+    capture.last = {"raw_bindings_returned": 12, "fetch_limit": 50}
+    assert capture.truncation_evidenced is False
+    capture.last = {"raw_bindings_returned": None, "fetch_limit": None}
+    assert capture.truncation_evidenced is False
+
+
+# ---------------------------------------------------------------------------
+# Item 6: qualify exit codes, and governs_run
+# ---------------------------------------------------------------------------
+
+def test_qualify_exits_non_zero_when_the_baselines_are_unusable(
+        tmp_path, monkeypatch):
+    """Item 6. Printing a warning and exiting 0 lets a script call it success."""
+    # No B5 4 rows at all, so S3_full == S9_full == 0 and the relation fails.
+    build_snapshot(tmp_path, [row("T-B57-1", "B5 7AA", "2026-05-04", 200_000)],
+                   version="v20260828T194003Z")
+    monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
+    code = s1.main(["qualify", "--cache-dir", str(tmp_path),
+                    "--out", str(tmp_path / "candidate.json")])
+    assert code == 1
+    written = json.loads((tmp_path / "candidate.json").read_text())
+    assert written["baselines_satisfy_their_relations"] is False
+    assert written["baselines_refusal"]
+
+
+@pytest.mark.parametrize("governs", ["", "   ", s1.GOVERNS_RUN_PLACEHOLDER])
+def test_a_blank_or_unchanged_governs_run_is_refused(materialized, tmp_path,
+                                                     governs):
+    """Item 6. The field ties an Instance to one run; unfilled, it ties nothing.
+
+    A candidate still carrying the placeholder has not been through the review
+    the field exists to record.
+    """
+    path = _write(tmp_path, materialized, governs_run=governs)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "governs_run" in str(exc.value)
+
+
+def test_the_candidate_instance_carries_the_placeholder_qualify_writes(
+        materialized):
+    """The two halves of the same rule: what qualify writes is what load refuses."""
+    candidate = s1.qualify(materialized)["candidate_instance"]
+    assert candidate["governs_run"] == s1.GOVERNS_RUN_PLACEHOLDER
+
+
+# ---------------------------------------------------------------------------
+# Item 7: a guard after the final observation
+# ---------------------------------------------------------------------------
+
+def test_a_guard_runs_after_the_final_observation(materialized, instance,
+                                                  tmp_path, monkeypatch):
+    """Item 7. Otherwise a run can finish on a Machine nobody re-checked.
+
+    Health is fine for every observation and fails only afterwards. Without a
+    closing guard the report is a clean pass measured under conditions that had
+    already gone bad.
+    """
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
+    calls = {"n": 0}
+
+    def health(url, timeout=5.0):
+        calls["n"] += 1
+        # Healthy for every guard the observations need; unhealthy only for the
+        # extra one that can exist solely at the end.
+        return (True, "200") if calls["n"] <= 13 + 1 else (False, "503")
+
+    monkeypatch.setattr(s1, "health_ok", health)
+    report = s1.run_compare(
+        instance=instance, materialized=materialized,
+        limits=s1.RunLimits(live_delay_seconds=0.0, latency_repeats=1,
+                            stop_on_unclassified=False),
+        report_path=tmp_path / "report.json",
+        live_service=FakeLive(), snapshot_service=None)
+    assert report["aborted"] and "health" in report["aborted"]
+    assert report["passed"] is False
+
+
+def test_the_final_guard_is_reached_on_an_otherwise_clean_run(
+        materialized, instance, tmp_path, monkeypatch, agreeing_live):
+    """The closing guard exists and is called with its own stage name."""
+    seen: list[str] = []
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
+
+    def health(url, timeout=5.0):
+        seen.append(url)
+        return (True, "200")
+
+    monkeypatch.setattr(s1, "health_ok", health)
+    s1.run_compare(
+        instance=instance, materialized=materialized,
+        limits=s1.RunLimits(live_delay_seconds=0.0, latency_repeats=1,
+                            stop_on_unclassified=False),
+        report_path=tmp_path / "report.json",
+        live_service=agreeing_live, snapshot_service=None)
+    # 13 correctness guards + 1 latency-repeat guard + 1 final guard.
+    assert len(seen) == 15
+
+
+def test_a_correct_total_with_one_short_case_is_still_insufficient(instance):
+    """Item 3. 390 observations is not the same as 30 for every case.
+
+    A total that happens to come out right can hide a case measured 29 times
+    and another measured 31 -- and the p95 would then be weighted towards
+    whichever shapes were over-sampled, which is a different measurement from
+    the one the gate is defined over.
+
+    Mutation: check only `n == 390` and drop the per-case test, and this
+    skewed sample reports a pass.
+    """
+    shapes = [c.shape for c in cases(GEOGRAPHIES)]
+    per_case = {shape: [1.0] * s1.REQUIRED_LATENCY_REPEATS for shape in shapes}
+    per_case[shapes[0]] = [1.0] * (s1.REQUIRED_LATENCY_REPEATS - 1)
+    per_case[shapes[1]] = [1.0] * (s1.REQUIRED_LATENCY_REPEATS + 1)
+    latency_ms = [v for values in per_case.values() for v in values]
+    assert len(latency_ms) == s1.REQUIRED_LATENCY_OBSERVATIONS
+
+    report = s1._build_report(
+        instance=instance, identity={}, limits=s1.RunLimits(), results=[],
+        latency_ms=latency_ms, per_case=per_case, snapshot_errors=[],
+        live_errors=[], contamination=[], excluded={},
+        midnight={"retries": 0, "unrecoverable": False, "pair_date_mismatches": 0},
+        corpus=cases(GEOGRAPHIES), aborted=None, live_calls=0)
+    criterion = report["exit_criteria"]["p95_under_one_second"]
+    assert criterion["n"] == s1.REQUIRED_LATENCY_OBSERVATIONS
+    assert criterion["verdict"] == "insufficient_evidence"
+    assert criterion["passed"] is False
+    assert sorted(criterion["cases_short_of_the_required_repeats"]) == sorted(
+        [shapes[0], shapes[1]])
+    assert report["passed"] is False

--- a/tests/snapshot/test_stage1_shadow.py
+++ b/tests/snapshot/test_stage1_shadow.py
@@ -78,6 +78,32 @@ def materialized(tmp_path):
     opened.adapter.close()
 
 
+def _qualification_block(definitional=None, **overrides) -> dict:
+    """A complete qualification block bound to the effective geographies."""
+    from tools.ppd_snapshot.corpus import DEFINITIONAL_GEOGRAPHIES
+
+    geo = {**DEFINITIONAL_GEOGRAPHIES, **(definitional or {})}
+    block = {key: {"rule": "qualified for the test fixture"}
+             for key in sorted(s1.REQUIRED_QUALIFICATION_KEYS)}
+    block["S1_district"] = {
+        "rule": "the neighbour holds comparable or greater volume",
+        "geography": geo["S1_district"],
+        "measured_neighbour_ratio": 1.2,
+        "comparable_or_greater": True,
+    }
+    block["S2_district"] = {
+        "rule": "non-empty under frozen parameters",
+        "geography": geo["S2_neighbour_district"],
+    }
+    block["S3_sector"] = {
+        "rule": "a strict subset of S1's district",
+        "geography": geo["S3_sector"],
+    }
+    for key, value in overrides.items():
+        block[key] = value
+    return block
+
+
 def _instance_dict(m) -> dict:
     return {
         "instance_kind": "stage1",
@@ -86,11 +112,9 @@ def _instance_dict(m) -> dict:
         "geographies": dict(GEOGRAPHIES),
         "aggregate_baselines": {"S1_full": 100, "S3_full": 40, "S9_full": 55},
         "qualified_at": "2026-09-01",
-        # Complete: every case whose geography the Instance fixes.
-        "qualification": {
-            key: {"rule": "qualified for the test fixture"}
-            for key in sorted(s1.REQUIRED_QUALIFICATION_KEYS)
-        },
+        # Complete: every case whose geography the Instance fixes, with the
+        # three definitional entries bound to the geographies they measured.
+        "qualification": _qualification_block(),
         "staleness_bound_days": 45,
         "governs_run": "stage-1-2026-09",
     }
@@ -2012,7 +2036,7 @@ def test_a_partial_qualification_block_is_refused(materialized, tmp_path):
 
 def test_an_unknown_qualification_key_is_refused(materialized, tmp_path):
     """A typo leaves the case it meant to qualify unqualified, block complete."""
-    block = {key: {"rule": "ok"} for key in s1.REQUIRED_QUALIFICATION_KEYS}
+    block = _qualification_block()
     block["S5_dnese"] = {"rule": "typo"}
     path = _write(tmp_path, materialized, qualification=block)
     with pytest.raises(InstanceRefused) as exc:
@@ -2023,7 +2047,7 @@ def test_an_unknown_qualification_key_is_refused(materialized, tmp_path):
 
 def test_a_qualification_entry_with_no_rule_is_refused(materialized, tmp_path):
     """Naming a geography is not qualifying it."""
-    block = {key: {"rule": "ok"} for key in s1.REQUIRED_QUALIFICATION_KEYS}
+    block = _qualification_block()
     block["S4_thin"] = {"measured_rows": 3}
     path = _write(tmp_path, materialized, qualification=block)
     with pytest.raises(InstanceRefused) as exc:
@@ -2036,7 +2060,8 @@ def test_the_required_qualification_keys_cover_every_fixed_geography():
     from tools.ppd_snapshot.corpus import REQUIRED_GEOGRAPHIES
 
     assert s1.REQUIRED_QUALIFICATION_KEYS == (
-        set(REQUIRED_GEOGRAPHIES) | {"S1_district", "S2_district"})
+        set(REQUIRED_GEOGRAPHIES)
+        | {"S1_district", "S2_district", "S3_sector"})
 
 
 def test_a_qualify_candidate_satisfies_the_loader_it_will_be_checked_by(
@@ -2193,11 +2218,15 @@ def test_an_instance_carrying_a_substitution_drives_the_corpus(
     """End to end: the Instance's substitution reaches the executed cases."""
     raw = _instance_dict(materialized)
     raw["governs_run"] = "substituted-run"
+    substituted = {"S1_district": "M3", "S2_neighbour_district": "M30",
+                   "S3_sector": "M3 7"}
     raw["substitutions"] = {
         "S1_district": {"geography": "M3", "justification": "B50 too thin"},
         "S2_neighbour_district": {"geography": "M30", "justification": "ditto"},
         "S3_sector": {"geography": "M3 7", "justification": "inside M3"},
     }
+    # Re-qualified: the evidence names the geographies the run will execute.
+    raw["qualification"] = _qualification_block(substituted)
     path = tmp_path / "substituted.json"
     path.write_text(json.dumps(raw))
     loaded = s1.load_instance(path, materialized)
@@ -2243,3 +2272,377 @@ def test_the_runbook_documents_adjudication_and_substitution():
     assert "NEIGHBOUR_COMPARABLE_RATIO = 1.0" in body
     assert "auto-qualified at a 10% ratio" in body
     assert '"substitutions"' in body
+
+
+# ---------------------------------------------------------------------------
+# Evidence binding: falsification tests
+# ---------------------------------------------------------------------------
+
+def test_a_latency_pass_snapshot_error_aborts_and_writes_the_partial_report(
+        materialized, instance, tmp_path, monkeypatch, agreeing_live):
+    """The latency pass stops on the first error, exactly as the first pass does.
+
+    Continuing would leave that case short of its thirty repetitions, and the
+    gate would then report `insufficient_evidence` for a reason buried in an
+    error list rather than the snapshot error that actually caused it.
+
+    Mutation: `continue` past the error and this run finishes with a short
+    sample and no abort.
+    """
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
+    from property_core.ppd_service import PPDService
+
+    real = PPDService(adapter=materialized.adapter)
+    state = {"correctness_done": False, "calls": 0}
+
+    class FailsInLatencyPass:
+        def comps(self, **kwargs):
+            state["calls"] += 1
+            if state["correctness_done"] and state["calls"] > 13:
+                raise RuntimeError("snapshot query failed mid-sample")
+            if state["calls"] == 13:
+                state["correctness_done"] = True
+            return real.comps(**kwargs)
+
+    report = s1.run_compare(
+        instance=instance, materialized=materialized,
+        limits=s1.RunLimits(live_delay_seconds=0.0, latency_repeats=5,
+                            stop_on_unclassified=False),
+        report_path=tmp_path / "report.json",
+        live_service=agreeing_live, snapshot_service=FailsInLatencyPass())
+    assert report["aborted"], "a latency-pass snapshot error did not abort"
+    assert "during the latency pass" in report["aborted"]
+    assert report["exit_criteria"]["zero_snapshot_errors"]["passed"] is False
+    assert report["exit_criteria"]["p95_under_one_second"][
+        "verdict"] == "insufficient_evidence"
+    assert report["passed"] is False
+    assert (tmp_path / "report.json").is_file(), (
+        "the run aborted without writing the partial report")
+
+
+def test_a_pending_adjudication_is_refused_not_carried(materialized, tmp_path):
+    """An Instance recording the shortfall and nothing else leaves it pending.
+
+    `qualify` deliberately refers the judgement rather than settling it. If the
+    Instance may then carry the referral unanswered, the referral achieves
+    nothing. Mutation: accept a False `comparable_or_greater` with no
+    `owner_decision` and a pending judgement qualifies a Stage 1 run.
+    """
+    block = _qualification_block()
+    block["S1_district"] = {
+        "rule": "the neighbour holds comparable or greater volume",
+        "geography": "B5",
+        "measured_neighbour_ratio": 0.31,
+        "comparable_or_greater": False,
+    }
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "records no owner_decision" in str(exc.value)
+    assert "pending judgement is not a qualification" in str(exc.value)
+
+
+def test_an_accepted_shortfall_needs_a_justification(materialized, tmp_path):
+    """A decision nobody can review is not a decision that was recorded."""
+    block = _qualification_block()
+    block["S1_district"] = {
+        "rule": "neighbour volume", "geography": "B5",
+        "measured_neighbour_ratio": 0.31, "comparable_or_greater": False,
+        "owner_decision": {"decision": "accepted", "justification": "   "},
+    }
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "records no justification" in str(exc.value)
+
+
+def test_a_recorded_acceptance_with_a_reason_qualifies_the_case(materialized,
+                                                                tmp_path):
+    """The route the Definition offers, taken properly, is accepted."""
+    block = _qualification_block()
+    block["S1_district"] = {
+        "rule": "neighbour volume", "geography": "B5",
+        "measured_neighbour_ratio": 0.31, "comparable_or_greater": False,
+        "owner_decision": {
+            "decision": "accepted",
+            "justification": ("B50 is a small rural outcode; 31% still returns "
+                              "hundreds of rows, enough for contamination to "
+                              "show. Reviewed 2026-09-01."),
+        },
+    }
+    path = _write(tmp_path, materialized, qualification=block)
+    assert s1.load_instance(path, materialized).governs_run
+
+
+@pytest.mark.parametrize("decision", ["pending", "rejected", "deferred", ""])
+def test_only_an_explicit_acceptance_qualifies(materialized, tmp_path, decision):
+    block = _qualification_block()
+    block["S1_district"] = {
+        "rule": "neighbour volume", "geography": "B5",
+        "measured_neighbour_ratio": 0.31, "comparable_or_greater": False,
+        "owner_decision": {"decision": decision, "justification": "a reason"},
+    }
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "only 'accepted' qualifies" in str(exc.value)
+
+
+def test_an_instance_that_does_not_record_comparability_is_refused(
+        materialized, tmp_path):
+    """It is the fact an adjudication would be answering."""
+    block = _qualification_block()
+    block["S1_district"] = {"rule": "neighbour volume", "geography": "B5"}
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "comparable_or_greater" in str(exc.value)
+
+
+def test_a_substitution_bolted_onto_unchanged_evidence_is_refused(
+        materialized, tmp_path):
+    """The exact shortcut the runbook must not invite.
+
+    An Instance qualified over `B5`/`B50`/`B5 4` with a `substitutions` block
+    added afterwards looks complete: every required key is present and every
+    rule is stated. It is evidence about one set of geographies attached to a
+    run that will execute another.
+
+    Mutation: drop the geography binding and this Instance is accepted, and
+    Stage 1 runs `M3` while its baselines describe `B5`.
+    """
+    raw = _instance_dict(materialized)
+    raw["governs_run"] = "bolted-on"
+    raw["substitutions"] = {
+        "S1_district": {"geography": "M3", "justification": "why"},
+        "S2_neighbour_district": {"geography": "M30", "justification": "why"},
+        "S3_sector": {"geography": "M3 7", "justification": "why"},
+    }
+    # qualification left as generated for B5/B50/B5 4 -- deliberately unchanged.
+    path = tmp_path / "bolted.json"
+    path.write_text(json.dumps(raw))
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "must be re-qualified against the artifact" in str(exc.value)
+    assert "cannot be attached to a run over another" in str(exc.value)
+
+
+def test_a_partially_requalified_substitution_is_refused(materialized, tmp_path):
+    """Re-qualifying S1 and forgetting S3 leaves the baselines misattributed."""
+    substituted = {"S1_district": "M3", "S2_neighbour_district": "M30",
+                   "S3_sector": "M3 7"}
+    raw = _instance_dict(materialized)
+    raw["governs_run"] = "partial"
+    raw["substitutions"] = {
+        "S1_district": {"geography": "M3", "justification": "why"},
+        "S2_neighbour_district": {"geography": "M30", "justification": "why"},
+        "S3_sector": {"geography": "M3 7", "justification": "why"},
+    }
+    block = _qualification_block(substituted)
+    block["S3_sector"]["geography"] = "B5 4"   # forgotten
+    raw["qualification"] = block
+    path = tmp_path / "partial.json"
+    path.write_text(json.dumps(raw))
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "S3_sector" in str(exc.value)
+    assert "re-qualified" in str(exc.value)
+
+
+def test_a_qualification_entry_that_names_no_geography_is_refused(
+        materialized, tmp_path):
+    block = _qualification_block()
+    block["S2_district"] = {"rule": "non-empty"}
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "does not record the geography it was measured over" in str(exc.value)
+
+
+# --- structural geometry of a substitution ---------------------------------
+
+@pytest.mark.parametrize("geographies,expected", [
+    # S2 does not extend S1: two unrelated districts test nothing.
+    ({"S1_district": "M3", "S2_neighbour_district": "B50", "S3_sector": "M3 7"},
+     "does not extend"),
+    # S2 equal to S1 is not longer.
+    ({"S1_district": "M3", "S2_neighbour_district": "M3", "S3_sector": "M3 7"},
+     "does not extend"),
+    # S3 outside S1's district breaks both baseline relations.
+    ({"S1_district": "M3", "S2_neighbour_district": "M30", "S3_sector": "B5 4"},
+     "does not lie inside"),
+    # S1 given as a sector: a district case needs a district.
+    ({"S1_district": "M3 7", "S2_neighbour_district": "M30", "S3_sector": "M3 7"},
+     "is not an outward code"),
+    # S3 given as an outcode: S3 and S9 are sector cases.
+    ({"S1_district": "M3", "S2_neighbour_district": "M30", "S3_sector": "M3"},
+     "is not a sector"),
+])
+def test_a_substitution_breaking_the_corpus_geometry_is_refused(
+        geographies, expected):
+    """Substituting is permitted; substituting into a shape that tests nothing
+    is not. Each of these is structurally well-formed and semantically empty.
+    """
+    from tools.ppd_snapshot.corpus import validate_definitional_geometry
+
+    with pytest.raises(InstanceRefused) as exc:
+        validate_definitional_geometry(geographies)
+    assert expected in str(exc.value)
+
+
+def test_the_default_definitional_geometry_satisfies_its_own_rules():
+    """B5 / B50 / B5 4 -- the geometry every substitution is measured against."""
+    from tools.ppd_snapshot.corpus import (
+        DEFINITIONAL_GEOGRAPHIES, validate_definitional_geometry)
+
+    validate_definitional_geometry(DEFINITIONAL_GEOGRAPHIES)
+
+
+def test_a_geometrically_valid_substitution_is_accepted():
+    from tools.ppd_snapshot.corpus import validate_substitutions
+
+    resolved = validate_substitutions({
+        "S1_district": {"geography": "M3", "justification": "r"},
+        "S2_neighbour_district": {"geography": "M30", "justification": "r"},
+        "S3_sector": {"geography": "M3 7", "justification": "r"},
+    })
+    assert resolved == {"S1_district": "M3", "S2_neighbour_district": "M30",
+                        "S3_sector": "M3 7"}
+
+
+def test_geometry_is_enforced_through_the_instance_loader(materialized, tmp_path):
+    """End to end: a broken geometry is refused at load, not at run time."""
+    raw = _instance_dict(materialized)
+    raw["governs_run"] = "broken-geometry"
+    raw["substitutions"] = {
+        "S1_district": {"geography": "M3", "justification": "why"},
+        "S2_neighbour_district": {"geography": "M30", "justification": "why"},
+        "S3_sector": {"geography": "B5 4", "justification": "why"},
+    }
+    path = tmp_path / "geometry.json"
+    path.write_text(json.dumps(raw))
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "does not lie inside" in str(exc.value)
+
+
+def test_qualify_re_measures_against_a_substitution(tmp_path):
+    """The supported route: re-qualify, do not re-label.
+
+    Every measurement in the candidate is taken over the substituted
+    geographies, which is what makes a substituted Instance carry evidence
+    about the run it governs.
+    """
+    rows = [row(f"T-M37-{i:03d}", "M3 7AA", "2026-05-04", 200_000 + i,
+                town="MANCHESTER") for i in range(30)]
+    rows += [row(f"T-M30-{i:03d}", "M30 4AA", "2026-05-04", 300_000 + i,
+                 town="MANCHESTER") for i in range(40)]
+    rows += [row("T-M37-CATB", "M3 7AB", "2026-05-04", 900_000,
+                 ppd_category="B", town="MANCHESTER")]
+    build_snapshot(tmp_path, rows, version="v20260828T194003Z")
+    opened = s1.open_materialized(tmp_path)
+    try:
+        out = s1.qualify(opened, today=date(2026, 6, 15), definitional={
+            "S1_district": "M3", "S2_neighbour_district": "M30",
+            "S3_sector": "M3 7"})
+    finally:
+        opened.adapter.close()
+    assert out["substituted"] is True
+    assert out["definitional_geographies"]["S1_district"] == "M3"
+    block = out["candidate_instance"]["qualification"]
+    assert block["S1_district"]["geography"] == "M3"
+    assert block["S2_district"]["geography"] == "M30"
+    assert block["S3_sector"]["geography"] == "M3 7"
+    assert block["S3_sector"]["inside_s1_district"] is True
+    # Measured over M3, not B5: the baselines describe the substituted run.
+    assert out["candidate_instance"]["aggregate_baselines"]["S1_full"] == 30
+    assert block["S1_district"]["measured_neighbour_rows"] == 40
+
+
+def test_the_runbook_does_not_invite_bolting_a_substitution_onto_old_evidence():
+    """The shortcut the runbook must actively steer away from.
+
+    Telling an operator to "add a substitutions block" would produce exactly
+    the Instance the loader refuses -- complete-looking, and describing
+    geographies the run will never touch.
+    """
+    body = RUNBOOK.read_text()
+    assert "A substitution is a re-qualification, not an annotation" in body
+    assert "qualify --substitutions" in body
+    assert "geographies the run will never touch" in body
+
+
+def test_the_runbook_documents_the_substitution_geometry_rules():
+    body = RUNBOOK.read_text()
+    for rule in ("extends", "lies **inside**", "test nothing",
+                 "still look like numbers"):
+        assert rule in body, f"the runbook omits the geometry rule: {rule}"
+
+
+def test_the_runbook_documents_the_owner_decision_requirement():
+    body = RUNBOOK.read_text()
+    assert "the Instance must\nanswer the referral" in body or \
+        "answer the referral" in body
+    assert "owner_decision" in body
+    assert 'Only `"accepted"` qualifies' in body
+
+
+def test_the_runbook_documents_the_latency_pass_abort():
+    body = RUNBOOK.read_text()
+    assert "This applies to the latency pass too" in body
+    assert "short of\nits thirty observations" in body or \
+        "short of" in body
+
+
+def test_the_qualify_cli_re_measures_against_the_substitutions_file(
+        tmp_path, monkeypatch):
+    """End to end through `main`, not just the function it calls.
+
+    Testing `qualify(definitional=...)` directly leaves the CLI wiring
+    unexercised: the flag could be parsed and then dropped, and the candidate
+    would silently describe `B5` while the operator believed they had
+    re-qualified against `M3`.
+    """
+    rows = [row(f"T-M37-{i:03d}", "M3 7AA", "2026-05-04", 200_000 + i,
+                town="MANCHESTER") for i in range(30)]
+    rows += [row(f"T-M30-{i:03d}", "M30 4AA", "2026-05-04", 300_000 + i,
+                 town="MANCHESTER") for i in range(40)]
+    rows += [row("T-M37-CATB", "M3 7AB", "2026-05-04", 900_000,
+                 ppd_category="B", town="MANCHESTER")]
+    build_snapshot(tmp_path, rows, version="v20260828T194003Z")
+    subs = tmp_path / "subs.json"
+    subs.write_text(json.dumps({"substitutions": {
+        "S1_district": {"geography": "M3", "justification": "B50 too thin"},
+        "S2_neighbour_district": {"geography": "M30", "justification": "ditto"},
+        "S3_sector": {"geography": "M3 7", "justification": "inside M3"},
+    }}))
+    monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
+    out_path = tmp_path / "candidate.json"
+    s1.main(["qualify", "--cache-dir", str(tmp_path),
+             "--substitutions", str(subs), "--out", str(out_path)])
+    out = json.loads(out_path.read_text())
+    assert out["substituted"] is True
+    assert out["definitional_geographies"]["S1_district"] == "M3"
+    block = out["candidate_instance"]["qualification"]
+    assert block["S1_district"]["geography"] == "M3"
+    assert block["S2_district"]["geography"] == "M30"
+    assert block["S3_sector"]["geography"] == "M3 7"
+
+
+def test_the_qualify_cli_refuses_a_geometrically_broken_substitutions_file(
+        tmp_path, monkeypatch):
+    """Refused before anything is measured, with exit 2."""
+    build_snapshot(tmp_path, _rows(), version="v20260828T194003Z")
+    subs = tmp_path / "subs.json"
+    subs.write_text(json.dumps({"substitutions": {
+        "S1_district": {"geography": "M3", "justification": "r"},
+        "S2_neighbour_district": {"geography": "M30", "justification": "r"},
+        "S3_sector": {"geography": "B5 4", "justification": "r"},
+    }}))
+    monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
+    out_path = tmp_path / "candidate.json"
+    code = s1.main(["qualify", "--cache-dir", str(tmp_path),
+                    "--substitutions", str(subs), "--out", str(out_path)])
+    assert code == 2
+    assert not out_path.exists(), "a refused qualification still wrote output"

--- a/tests/snapshot/test_stage1_shadow.py
+++ b/tests/snapshot/test_stage1_shadow.py
@@ -86,7 +86,11 @@ def _instance_dict(m) -> dict:
         "geographies": dict(GEOGRAPHIES),
         "aggregate_baselines": {"S1_full": 100, "S3_full": 40, "S9_full": 55},
         "qualified_at": "2026-09-01",
-        "qualification": {"S5_dense": {"rule": "dense", "measured_rows": 30}},
+        # Complete: every case whose geography the Instance fixes.
+        "qualification": {
+            key: {"rule": "qualified for the test fixture"}
+            for key in sorted(s1.REQUIRED_QUALIFICATION_KEYS)
+        },
         "staleness_bound_days": 45,
         "governs_run": "stage-1-2026-09",
     }
@@ -375,46 +379,65 @@ def test_an_unhealthy_application_stops_the_run(materialized, instance, tmp_path
 # Failure isolation
 # ---------------------------------------------------------------------------
 
-def test_a_failing_live_arm_is_recorded_and_the_run_continues(
+def test_a_failing_snapshot_arm_aborts_before_any_live_call(
         materialized, instance, tmp_path, monkeypatch):
-    """A live failure is a fact about the run, not the end of it.
+    """Recorded, then fatal -- and the live call for that case never happens.
 
-    Mutation: let the exception escape the per-arm `except` and the run dies
-    with no report -- which is the outcome that leaves a gate undecidable.
+    Once the snapshot arm has failed, "zero snapshot errors on the frozen
+    corpus" is unreachable, so every later case is work whose result cannot
+    change the verdict. Making the live call anyway would be a request to HM
+    Land Registry for a comparison that can no longer take place.
+
+    Mutation: keep recording the error and fall through, and this run makes
+    thirteen live calls in service of a verdict already decided.
     """
     monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
-    live = FakeLive(raises=RuntimeError("upstream exploded"))
-    report = _run(materialized, instance, tmp_path, monkeypatch, live=live,
-                  latency_repeats=1, stop_on_unclassified=False)
-    assert report["aborted"] is None
-    assert len(report["live_errors"]) == 13
-    assert "upstream exploded" in report["live_errors"][0]["error"]
-    assert report["cases_total"] == 13
-
-
-def test_a_failing_snapshot_arm_is_recorded_and_fails_the_gate(
-        materialized, instance, tmp_path, monkeypatch):
-    """Recorded, not propagated -- and it must still fail the exit criterion.
-
-    "Zero snapshot errors on the frozen corpus" is only meaningful if an error
-    that was caught still counts. Swallowing it into a green report would be
-    the worst of both.
-    """
-    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
 
     class Exploding:
         def comps(self, **kwargs):
             raise RuntimeError("snapshot query failed")
 
+    live = FakeLive()
     report = s1.run_compare(
         instance=instance, materialized=materialized,
         limits=s1.RunLimits(live_delay_seconds=0.0, latency_repeats=1,
                             stop_on_unclassified=False),
         report_path=tmp_path / "report.json",
-        live_service=FakeLive(), snapshot_service=Exploding())
-    assert report["aborted"] is None
+        live_service=live, snapshot_service=Exploding())
+    assert report["aborted"] and "snapshot arm failed" in report["aborted"]
+    assert "no live call is made" in report["aborted"]
+    assert live.calls == [], "a live call was made after the snapshot arm failed"
+    assert len(report["cases"]) == 1, "a later case ran after the first failure"
     assert report["exit_criteria"]["zero_snapshot_errors"]["passed"] is False
     assert report["passed"] is False
+    assert (tmp_path / "report.json").is_file(), (
+        "the run aborted without writing the partial failed report")
+
+
+def test_a_failing_live_arm_aborts_and_no_later_case_runs(
+        materialized, instance, tmp_path, monkeypatch):
+    """Completeness is already lost, so continuing gathers nothing usable.
+
+    Mutation: record the error and continue, and the report accumulates twelve
+    more cases whose comparisons cannot rescue a verdict that has already
+    failed `all_thirteen_cases_compared`.
+    """
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
+    live = FakeLive(raises=RuntimeError("upstream exploded"))
+    report = s1.run_compare(
+        instance=instance, materialized=materialized,
+        limits=s1.RunLimits(live_delay_seconds=0.0, latency_repeats=1,
+                            stop_on_unclassified=False),
+        report_path=tmp_path / "report.json",
+        live_service=live, snapshot_service=None)
+    assert report["aborted"] and "live arm failed" in report["aborted"]
+    assert len(report["live_errors"]) == 1, "more than one case was attempted"
+    assert len(live.calls) == 1
+    assert len(report["cases"]) == 1
+    assert report["passed"] is False
+    assert (tmp_path / "report.json").is_file()
 
 
 # ---------------------------------------------------------------------------
@@ -618,7 +641,7 @@ ALLOWED_KEYS = {
     # unit-level violation inside the requested sector is a COUNT, never a
     # named postcode.
     "arm", "level", "unexpected_outcodes", "unexpected_sectors",
-    "same_sector_unit_violations",
+    "same_sector_unit_violations", "rows_without_postcode",
     "vacuous_comparison_shapes", "verdict", "n", "p95_ms",
     "required_observations", "required_repeats_per_case",
     "cases_short_of_the_required_repeats",
@@ -1140,12 +1163,18 @@ def agreeing_live(materialized):
 
 def test_a_live_arm_error_makes_the_verdict_false(materialized, instance,
                                                   tmp_path, monkeypatch):
-    """Item 1. A report is not allowed to pass while an arm failed."""
+    """A report is not allowed to pass while an arm failed.
+
+    The run now stops at the first failure, so the evidence is one error and
+    twelve cases never reached -- both of which block completeness.
+    """
     live = FakeLive(raises=RuntimeError("upstream exploded"))
     report = _full_run(materialized, instance, tmp_path, monkeypatch,
                        live=live, repeats=s1.REQUIRED_LATENCY_REPEATS)
-    assert report["exit_criteria"]["all_thirteen_cases_compared"]["passed"] is False
-    assert report["exit_criteria"]["all_thirteen_cases_compared"]["live_errors"] == 13
+    criterion = report["exit_criteria"]["all_thirteen_cases_compared"]
+    assert criterion["passed"] is False
+    assert criterion["live_errors"] == 1
+    assert len(criterion["cases_never_reached"]) == 12
     assert report["passed"] is False
 
 
@@ -1678,10 +1707,14 @@ def test_qualification_fails_when_b50_is_empty(tmp_path, monkeypatch):
                     "--out", str(tmp_path / "candidate.json")])
     assert code == 1
     out = json.loads((tmp_path / "candidate.json").read_text())
+    # S2 has nothing in it: an outright qualification failure.
     assert "S2_district" in out["unqualified_definitional_cases"]
-    assert "S1_district" in out["unqualified_definitional_cases"]
     assert out["candidate_instance"]["qualification"]["S2_district"][
         "measured_rows"] == 0
+    # S1's district is populated, so the question is not "did it fail" but
+    # "is a neighbour holding 0% comparable?" -- which is the owner's call.
+    assert "S1_district" in out["requires_owner_adjudication"]
+    assert "S1_district" not in out["unqualified_definitional_cases"]
 
 
 def test_a_definitional_failure_alone_makes_qualify_exit_non_zero(
@@ -1693,9 +1726,14 @@ def test_a_definitional_failure_alone_makes_qualify_exit_non_zero(
     test noticing. This drives the exit code from a definitional failure alone.
     """
     payload = s1.qualify(materialized)
+    # Every OTHER reason to exit non-zero is cleared, so the exit code can only
+    # be coming from the definitional branch. Leaving adjudication populated
+    # masked this: the run exited 1 either way and the branch could have been
+    # dead without any test noticing.
     payload["unqualified_placeholders"] = []
     payload["baselines_satisfy_their_relations"] = True
     payload["baselines_refusal"] = None
+    payload["requires_owner_adjudication"] = []
     payload["unqualified_definitional_cases"] = ["S2_district"]
     monkeypatch.setattr(s1, "qualify", lambda *a, **k: payload)
     monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
@@ -1724,9 +1762,12 @@ def test_qualification_records_the_neighbour_ratio_it_judged_on(tmp_path):
     s1_block = out["candidate_instance"]["qualification"]["S1_district"]
     assert s1_block["measured_neighbour_rows"] == 20
     assert s1_block["measured_neighbour_ratio"] == 1.0
-    assert s1_block["threshold_is_an_operationalisation"] is True
+    # Equal volume IS "comparable or greater", so this one qualifies outright
+    # and needs no judgement from anybody.
+    assert s1_block["comparable_or_greater"] is True
     assert "S1_district" not in out["unqualified_definitional_cases"]
     assert "S2_district" not in out["unqualified_definitional_cases"]
+    assert "S1_district" not in out["requires_owner_adjudication"]
 
 
 # ---------------------------------------------------------------------------
@@ -1901,4 +1942,304 @@ def test_the_runbook_documents_enforced_staleness_and_b50_qualification():
     body = RUNBOOK.read_text()
     assert "enforced at load, not merely recorded" in body
     assert "unqualified_definitional_cases" in body
-    assert "MIN_NEIGHBOUR_VOLUME_RATIO" in body
+    assert "NEIGHBOUR_COMPARABLE_RATIO" in body
+
+
+# ---------------------------------------------------------------------------
+# A row with no usable postcode is a containment failure
+# ---------------------------------------------------------------------------
+
+def test_a_row_with_no_postcode_is_a_containment_violation():
+    """Skipping it would decide an open question in the weakest direction.
+
+    Definition section 11 lists rows with no geography as a known limit and
+    leaves the question open. Silently skipping them settles it: a source could
+    return arbitrary rows with the postcode blanked and every containment check
+    would pass. Mutation: `continue` past them and this returns clean.
+    """
+    rows = [PPDTransaction(transaction_id="A", postcode="B5 4AA", date="2026-05-01"),
+            PPDTransaction(transaction_id="B", postcode=None, date="2026-05-01"),
+            PPDTransaction(transaction_id="C", postcode="   ", date="2026-05-01")]
+    violations = s1.geography_violations(_case("S3", "B5 4", "sector"), rows)
+    assert violations["rows_without_postcode"] == 2
+    assert s1.is_contaminated(violations) is True
+
+
+def test_a_postcode_less_row_is_counted_never_described():
+    """Only a count. The row is by definition the one whose geography cannot
+    be stated, so there is nothing safe to record about it beyond how many."""
+    rows = [PPDTransaction(transaction_id="SECRET-ID", postcode=None,
+                           date="2026-05-01", price=999_000, street="HIGH STREET")]
+    violations = s1.geography_violations(_case("S1", "B5", "district"), rows)
+    body = json.dumps(violations)
+    assert "SECRET-ID" not in body and "HIGH STREET" not in body
+    assert "999000" not in body
+    assert violations["rows_without_postcode"] == 1
+
+
+def test_postcode_less_rows_block_the_verdict_on_either_arm(
+        materialized, instance, tmp_path, monkeypatch, agreeing_live):
+    """End to end, on the live arm."""
+    monkeypatch.setattr(s1, "health_ok", lambda *a, **k: (True, "200"))
+    monkeypatch.setattr(s1.time, "sleep", lambda *_: None)
+    blank = FakeLive(transactions=[
+        PPDTransaction(transaction_id="X", postcode=None, date="2026-05-01")])
+    report = _full_run(materialized, instance, tmp_path, monkeypatch,
+                       live=blank, repeats=1)
+    criterion = report["exit_criteria"]["zero_geography_contamination"]
+    assert criterion["passed"] is False
+    assert any(f["rows_without_postcode"] > 0 for f in criterion["findings"])
+    assert report["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# The qualification block must be complete and exact
+# ---------------------------------------------------------------------------
+
+def test_a_partial_qualification_block_is_refused(materialized, tmp_path):
+    """Silent about the cases it omits, while looking like evidence.
+
+    Mutation: accept any non-empty dict and an Instance naming one rule for one
+    case qualifies all thirteen.
+    """
+    partial = {"S5_dense": {"rule": "dense"}}
+    path = _write(tmp_path, materialized, qualification=partial)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "qualification is missing" in str(exc.value)
+    assert "S1_district" in str(exc.value)
+
+
+def test_an_unknown_qualification_key_is_refused(materialized, tmp_path):
+    """A typo leaves the case it meant to qualify unqualified, block complete."""
+    block = {key: {"rule": "ok"} for key in s1.REQUIRED_QUALIFICATION_KEYS}
+    block["S5_dnese"] = {"rule": "typo"}
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "unknown key" in str(exc.value)
+    assert "S5_dnese" in str(exc.value)
+
+
+def test_a_qualification_entry_with_no_rule_is_refused(materialized, tmp_path):
+    """Naming a geography is not qualifying it."""
+    block = {key: {"rule": "ok"} for key in s1.REQUIRED_QUALIFICATION_KEYS}
+    block["S4_thin"] = {"measured_rows": 3}
+    path = _write(tmp_path, materialized, qualification=block)
+    with pytest.raises(InstanceRefused) as exc:
+        s1.load_instance(path, materialized)
+    assert "records no rule" in str(exc.value)
+
+
+def test_the_required_qualification_keys_cover_every_fixed_geography():
+    """Placeholders plus the definitional cases -- nothing fixed goes unrecorded."""
+    from tools.ppd_snapshot.corpus import REQUIRED_GEOGRAPHIES
+
+    assert s1.REQUIRED_QUALIFICATION_KEYS == (
+        set(REQUIRED_GEOGRAPHIES) | {"S1_district", "S2_district"})
+
+
+def test_a_qualify_candidate_satisfies_the_loader_it_will_be_checked_by(
+        tmp_path):
+    """The two halves of the same rule, again: what qualify writes, load accepts.
+
+    Mutation: add a key to one side only and a freshly generated candidate is
+    refused by the tool that generated it.
+    """
+    rows = [row(f"T-B54-{i:03d}", "B5 4AA", "2026-05-04", 200_000 + i)
+            for i in range(30)]
+    rows += [row(f"T-B50-{i:03d}", "B50 4AA", "2026-05-04", 400_000 + i)
+             for i in range(60)]
+    rows += [row("T-B54-CATB", "B5 4AB", "2026-05-04", 900_000, ppd_category="B")]
+    rows += [row(f"T-B56-{i:03d}", "B5 6QQ", "2026-05-04", 300_000 + i,
+                 property_type=t) for i, t in enumerate("DST")]
+    build_snapshot(tmp_path, rows, version="v20260828T194003Z")
+    opened = s1.open_materialized(tmp_path)
+    try:
+        candidate = s1.qualify(opened)["candidate_instance"]
+        assert set(candidate["qualification"]) == s1.REQUIRED_QUALIFICATION_KEYS - (
+            s1.REQUIRED_QUALIFICATION_KEYS - set(candidate["qualification"])), (
+            "qualify emitted qualification keys the loader does not expect")
+        assert not (set(candidate["qualification"])
+                    - s1.REQUIRED_QUALIFICATION_KEYS), (
+            "qualify emits a qualification key load_instance would refuse")
+    finally:
+        opened.adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# The Definition's B5/B50 rule, unredefined; its substitution route, restored
+# ---------------------------------------------------------------------------
+
+def test_the_neighbour_rule_is_the_literal_one_not_a_weaker_threshold():
+    """A tenth is not "comparable or greater", and the tool no longer says so.
+
+    An earlier version auto-qualified S1 at a 10% neighbour ratio, quietly
+    redefining a frozen rule downwards inside an implementation. Mutation: set
+    this back below 1.0 and the deferral tests below stop deferring -- the tool
+    resumes deciding a question that is not its to decide.
+    """
+    assert s1.NEIGHBOUR_COMPARABLE_RATIO == 1.0
+    source = (REPO / "tools" / "ppd_snapshot" / "stage1_shadow.py").read_text()
+    assert "MIN_NEIGHBOUR_VOLUME_RATIO" not in source
+    assert "threshold_is_an_operationalisation" not in source
+
+
+def test_a_thin_neighbour_is_referred_to_the_owner_not_decided(tmp_path):
+    """Neither auto-passed nor auto-failed: measured, and handed over.
+
+    "Is 6% comparable for this artifact?" is a judgement about the corpus, and
+    the Definition already provides the two ways to settle it -- accept it, or
+    substitute a geography with recorded justification.
+    """
+    rows = [row(f"T-B54-{i:03d}", "B5 4AA", "2026-05-04", 200_000 + i)
+            for i in range(30)]
+    rows += [row("T-B50-001", "B50 4AA", "2026-05-04", 400_000)]
+    build_snapshot(tmp_path, rows, version="v20260828T194003Z")
+    opened = s1.open_materialized(tmp_path)
+    try:
+        out = s1.qualify(opened, today=date(2026, 6, 15))
+    finally:
+        opened.adapter.close()
+    block = out["candidate_instance"]["qualification"]["S1_district"]
+    assert block["comparable_or_greater"] is False
+    assert 0 < block["measured_neighbour_ratio"] < 1.0
+    assert "S1_district" in out["requires_owner_adjudication"]
+    # Not silently failed either -- the distinction is the point.
+    assert "S1_district" not in out["unqualified_definitional_cases"]
+    assert "This tool does not decide" in block["adjudication"]
+
+
+def test_adjudication_pending_makes_qualify_exit_non_zero(materialized, tmp_path,
+                                                          monkeypatch):
+    """A candidate awaiting a judgement is not a candidate ready to run."""
+    payload = s1.qualify(materialized)
+    # Symmetrically: every other reason cleared, so only adjudication remains.
+    payload["unqualified_placeholders"] = []
+    payload["unqualified_definitional_cases"] = []
+    payload["baselines_satisfy_their_relations"] = True
+    payload["baselines_refusal"] = None
+    payload["requires_owner_adjudication"] = ["S1_district"]
+    monkeypatch.setattr(s1, "qualify", lambda *a, **k: payload)
+    monkeypatch.setenv(s1.SHADOW_COMPARE_ENABLED_ENV, "1")
+    code = s1.main(["qualify", "--cache-dir", str(materialized.directory.parents[1]),
+                    "--out", str(tmp_path / "candidate.json")])
+    assert code == 1
+
+
+def test_the_substitution_route_the_definition_documents_still_exists():
+    """Section 4 permits substituting a definitional geography WITH justification.
+
+    A previous revision asserted these "cannot be substituted", which removed a
+    route the frozen contract grants. Mutation: drop `validate_substitutions`
+    and an Instance exercising the documented route is refused.
+    """
+    from tools.ppd_snapshot.corpus import DEFINITIONAL_GEOGRAPHIES, cases
+
+    assert set(DEFINITIONAL_GEOGRAPHIES) == {
+        "S1_district", "S2_neighbour_district", "S3_sector"}
+    substituted = {"S1_district": "M3", "S2_neighbour_district": "M30",
+                   "S3_sector": "M3 7"}
+    shapes = {c.shape: c.postcode for c in cases(GEOGRAPHIES, substituted)}
+    assert shapes["S1"] == "M3" and shapes["S12"] == "M3"
+    assert shapes["S2"] == "M30"
+    assert shapes["S3"] == "M3 7" and shapes["S9"] == "M3 7"
+    assert shapes["S14"] == "M3 7"
+    # Defaults still apply when nothing is substituted.
+    assert {c.shape: c.postcode for c in cases(GEOGRAPHIES)}["S1"] == "B5"
+
+
+def test_a_substitution_must_supply_all_three_linked_geographies():
+    """S3 is a sector inside S1's district; S2 is its neighbour.
+
+    Substituting one alone leaves S3 outside S1 and the containment relation
+    the baselines exist to establish silently false.
+    """
+    from tools.ppd_snapshot.corpus import validate_substitutions
+
+    with pytest.raises(InstanceRefused) as exc:
+        validate_substitutions({"S1_district": {"geography": "M3",
+                                                "justification": "why"}})
+    assert "all of" in str(exc.value)
+    assert "silently false" in str(exc.value)
+
+
+def test_a_substitution_without_a_justification_is_refused():
+    """The Definition permits substitution *with recorded justification*."""
+    from tools.ppd_snapshot.corpus import validate_substitutions
+
+    entry = {key: {"geography": geo, "justification": "recorded reason"}
+             for key, geo in (("S1_district", "M3"),
+                              ("S2_neighbour_district", "M30"),
+                              ("S3_sector", "M3 7"))}
+    assert validate_substitutions(entry) == {
+        "S1_district": "M3", "S2_neighbour_district": "M30",
+        "S3_sector": "M3 7"}
+    entry["S3_sector"] = {"geography": "M3 7", "justification": "  "}
+    with pytest.raises(InstanceRefused) as exc:
+        validate_substitutions(entry)
+    assert "records no justification" in str(exc.value)
+
+
+def test_absent_substitutions_are_the_normal_case():
+    from tools.ppd_snapshot.corpus import validate_substitutions
+
+    assert validate_substitutions(None) == {}
+    assert validate_substitutions({}) == {}
+
+
+def test_an_instance_carrying_a_substitution_drives_the_corpus(
+        materialized, tmp_path):
+    """End to end: the Instance's substitution reaches the executed cases."""
+    raw = _instance_dict(materialized)
+    raw["governs_run"] = "substituted-run"
+    raw["substitutions"] = {
+        "S1_district": {"geography": "M3", "justification": "B50 too thin"},
+        "S2_neighbour_district": {"geography": "M30", "justification": "ditto"},
+        "S3_sector": {"geography": "M3 7", "justification": "inside M3"},
+    }
+    path = tmp_path / "substituted.json"
+    path.write_text(json.dumps(raw))
+    loaded = s1.load_instance(path, materialized)
+    assert loaded.substitutions["S1_district"] == "M3"
+    from tools.ppd_snapshot.corpus import cases as build
+
+    assert {c.shape: c.postcode
+            for c in build(loaded.geographies, loaded.substitutions)}["S1"] == "M3"
+
+
+def test_the_runbook_carries_post_release_checks_for_propertydata():
+    """It is redeployed by the same release, so it is checked, not assumed.
+
+    "Out of scope" is a statement about what changes, not a reason to skip
+    verifying that nothing did.
+    """
+    body = RUNBOOK.read_text()
+    assert "Post-release checks — `propertydata`" in body
+    assert "must be checked, not assumed" in body
+    for check in ("propertydata.fly.dev/health", "fly secrets list -a propertydata",
+                  "fly status -a propertydata", "stage1_shadow.py",
+                  "fly image show -a propertydata"):
+        assert check in body, f"the runbook omits the propertydata check: {check}"
+    assert "stop" in body.lower()
+
+
+def test_the_runbook_documents_abort_on_first_arm_error():
+    body = RUNBOOK.read_text()
+    assert "the first error on\neither arm" in body or \
+        "**the first error on" in body
+    assert "before that case makes its live call" in body
+
+
+def test_the_runbook_documents_the_postcode_less_row_rule():
+    body = RUNBOOK.read_text()
+    assert "no usable postcode" in body
+    assert "rows_without_postcode" in body
+
+
+def test_the_runbook_documents_adjudication_and_substitution():
+    body = RUNBOOK.read_text()
+    assert "requires_owner_adjudication" in body
+    assert "NEIGHBOUR_COMPARABLE_RATIO = 1.0" in body
+    assert "auto-qualified at a 10% ratio" in body
+    assert '"substitutions"' in body

--- a/tests/test_ppd_spec_and_attribution.py
+++ b/tests/test_ppd_spec_and_attribution.py
@@ -26,13 +26,13 @@ def test_governing_specification_ships_with_the_code():
 
 
 def test_specification_is_version_stamped():
-    """Rev 9 -- the Phase D review round, which made the boot non-blocking.
+    """Rev 10 -- the Stage 1 mechanism round, which revised the p95 criterion.
 
     The stamp moves only on a decision round, never on an edit in passing, so
     this assertion is what makes "frozen" mean something.
     """
     head = SPEC.read_text().splitlines()[0]
-    assert "rev 9" in head and "FROZEN" in head, head
+    assert "rev 10" in head and "FROZEN" in head, head
 
 
 def _normalised(text: str) -> str:

--- a/tools/ppd_snapshot/corpus.py
+++ b/tools/ppd_snapshot/corpus.py
@@ -42,6 +42,26 @@ REQUIRED_GEOGRAPHIES = frozenset({
 #: declared, and checked for consistency with what they claim to establish.
 REQUIRED_BASELINES = frozenset({"S1_full", "S3_full", "S9_full"})
 
+#: The definitional geographies of section 4, and the route by which an
+#: Instance may replace them.
+#:
+#: `B5` / `B50` / `B5 4` are named in the Definition because the contamination
+#: boundary is a definitional choice rather than an artifact property -- but
+#: section 4 is equally explicit that an Instance "must still qualify them and
+#: may substitute with recorded justification". The substitution route is part
+#: of the frozen contract, not a convenience, so it is implemented rather than
+#: asserted away.
+#:
+#: The three move together. S3 and S9 are a sector *inside* S1's district and
+#: S2 is its neighbouring outcode; substituting S1 alone would leave S3 outside
+#: it and quietly invalidate the containment relation the baselines exist to
+#: establish. So an Instance supplies all three or none.
+DEFINITIONAL_GEOGRAPHIES: dict[str, str] = {
+    "S1_district": "B5",
+    "S2_neighbour_district": "B50",
+    "S3_sector": "B5 4",
+}
+
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 VERSION_RE = re.compile(r"^v\d{8}T\d{6}Z$")
 #: Outward code, optional sector digit, optional unit. Deliberately narrow: a
@@ -107,12 +127,21 @@ class Case:
         }
 
 
-def cases(geo: dict[str, str]) -> list[Case]:
-    """The Definition's thirteen shapes, with placeholders resolved."""
+def cases(geo: dict[str, str],
+          definitional: Optional[dict[str, str]] = None) -> list[Case]:
+    """The Definition's thirteen shapes, with placeholders resolved.
+
+    `definitional` overrides the section 4 geographies for an Instance that
+    recorded a substitution and its justification; omitted, the defaults apply.
+    """
+    fixed = {**DEFINITIONAL_GEOGRAPHIES, **(definitional or {})}
+    district = fixed["S1_district"]
+    neighbour = fixed["S2_neighbour_district"]
+    sector = fixed["S3_sector"]
     return [
-        Case("S1", "contamination boundary", "B5", "district"),
-        Case("S2", "reverse boundary", "B50", "district"),
-        Case("S3", "sector isolation", "B5 4", "sector"),
+        Case("S1", "contamination boundary", district, "district"),
+        Case("S2", "reverse boundary", neighbour, "district"),
+        Case("S3", "sector isolation", sector, "sector"),
         Case("S4", "thin market", geo["S4_thin"], "sector"),
         Case("S5", "dense market and truncation", geo["S5_dense"], "sector"),
         Case("S6", "exact-postcode geography", geo["S6_unit"], "postcode"),
@@ -120,16 +149,17 @@ def cases(geo: dict[str, str]) -> list[Case]:
              property_type="F"),
         Case("S8", "type filter genuinely bites", geo["S8_type_strong"], "sector",
              property_type="F"),
-        Case("S9", "category filtering", "B5 4", "sector",
+        Case("S9", "category filtering", sector, "sector",
              transaction_category=None),
         # S10 removed: "provisional tail, non-empty" discriminates nothing now
         # that every comps case is provisional (Definition section 3).
         Case("S11", "provisional flag is a window property",
              geo["S11_provisional_empty"], "sector", months=6),
-        Case("S12", "widest window, deepest history", "B5", "district", months=120),
+        Case("S12", "widest window, deepest history", district, "district",
+             months=120),
         Case("S13", "expected empty", geo["S13_empty_unit"], "postcode",
              property_type="D"),
-        Case("S14", "expected empty, sector shape", "B5 4", "sector",
+        Case("S14", "expected empty, sector shape", sector, "sector",
              property_type="T"),
     ]
 
@@ -220,10 +250,19 @@ def geography_violations(case: "Case", transactions: Iterable[Any]) -> dict[str,
     unexpected_outcodes: set[str] = set()
     unexpected_sectors: set[str] = set()
     same_sector_unit_violations = 0
+    rows_without_postcode = 0
 
     for transaction in transactions:
         pc = (getattr(transaction, "postcode", None) or "").strip().upper()
         if not pc:
+            # A row a geography-filtered query cannot justify returning. Section
+            # 11 lists these as a known limit and leaves the question open;
+            # skipping them here would decide it silently and in the weakest
+            # direction -- a source could return arbitrary rows with the
+            # postcode blanked and every containment check would pass. Counted,
+            # and blocking. Only the count is persisted: the row is by
+            # definition the one whose geography cannot be stated.
+            rows_without_postcode += 1
             continue
         row_head, _, row_tail = pc.partition(" ")
         row_sector = f"{row_head} {row_tail[0]}" if row_tail else None
@@ -244,13 +283,16 @@ def geography_violations(case: "Case", transactions: Iterable[Any]) -> dict[str,
         "unexpected_outcodes": sorted(unexpected_outcodes),
         "unexpected_sectors": sorted(unexpected_sectors),
         "same_sector_unit_violations": same_sector_unit_violations,
+        "rows_without_postcode": rows_without_postcode,
     }
 
 
 def is_contaminated(violations: dict[str, Any]) -> bool:
+    """Any of the four is a containment failure, on whichever arm produced it."""
     return bool(violations["unexpected_outcodes"]
                 or violations["unexpected_sectors"]
-                or violations["same_sector_unit_violations"])
+                or violations["same_sector_unit_violations"]
+                or violations["rows_without_postcode"])
 
 
 def ids(transactions: Iterable[Any]) -> set[str]:
@@ -400,3 +442,45 @@ def returned_date_bounds(transactions: Any) -> tuple[Optional[str], Optional[str
     """
     dates = sorted(t.date for t in transactions if getattr(t, "date", None))
     return (dates[0], dates[-1]) if dates else (None, None)
+
+
+def validate_substitutions(raw: Any) -> dict[str, str]:
+    """An Instance's recorded substitution of the definitional geographies.
+
+    Absent is the normal case and yields `{}`. Present, it must supply all
+    three linked geographies, each with a justification: the Definition permits
+    substitution *with recorded justification*, so a substitution carrying no
+    reason is not the route it documents.
+    """
+    if raw in (None, {}):
+        return {}
+    if not isinstance(raw, dict):
+        raise InstanceRefused("substitutions must be a JSON object")
+    supplied = set(raw)
+    expected = set(DEFINITIONAL_GEOGRAPHIES)
+    if supplied != expected:
+        raise InstanceRefused(
+            f"substitutions must supply all of {sorted(expected)} or none; got "
+            f"{sorted(supplied)}. S3 is a sector inside S1's district and S2 is "
+            f"its neighbouring outcode, so substituting one alone would leave "
+            f"the containment relation the baselines establish silently false.")
+    resolved: dict[str, str] = {}
+    for key in sorted(expected):
+        entry = raw[key]
+        if not isinstance(entry, dict):
+            raise InstanceRefused(
+                f"substitutions[{key}] must be an object with a geography and "
+                f"a justification")
+        geography = entry.get("geography")
+        justification = entry.get("justification")
+        if not isinstance(geography, str) or not GEOGRAPHY_RE.match(
+                geography.strip().upper()):
+            raise InstanceRefused(
+                f"substitutions[{key}].geography is {geography!r}, which is "
+                f"not a postcode, sector or outcode")
+        if not isinstance(justification, str) or not justification.strip():
+            raise InstanceRefused(
+                f"substitutions[{key}] records no justification; the Definition "
+                f"permits substitution only WITH recorded justification")
+        resolved[key] = geography.strip().upper()
+    return resolved

--- a/tools/ppd_snapshot/corpus.py
+++ b/tools/ppd_snapshot/corpus.py
@@ -1,0 +1,284 @@
+"""The frozen shadow-corpus Definition, in one place, for both consumers.
+
+`docs/design/ppd-shadow-corpus.md` is ACCEPTED AND FROZEN. Two tools execute it:
+
+* `rehearse.py` -- the local rehearsal, snapshot arm only, no network;
+* `stage1_shadow.py` -- the out-of-band production comparator, both arms.
+
+**Both must execute the same corpus, or neither result means anything.** A
+second copy of the case shapes, the frozen parameters, the warning-class
+predicates or the `months` arithmetic is precisely the drift the freeze exists
+to prevent: the two tools would diverge silently, and the rehearsal would stop
+being a rehearsal *of* the Stage 1 run. So the Definition lives here and both
+import it. Nothing in this module is artifact-specific, dated, or aggregate --
+those belong to an Instance (Definition section 0).
+
+This module makes no network call, opens no adapter and reads no environment.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Iterable, Optional
+
+#: The page size every case is frozen at (Definition section 2, `limit`). A
+#: result of exactly this length was truncated, and a truncated page cannot
+#: answer a containment question.
+LIMIT = 50
+
+#: The Definition's placeholder geographies. Every one must be supplied by an
+#: Instance; no others. `B5`, `B50` and `B5 4` are definitional and are not
+#: placeholders -- see the `cases()` table.
+REQUIRED_GEOGRAPHIES = frozenset({
+    "S4_thin", "S5_dense", "S6_unit", "S7_type_weak",
+    "S8_type_strong", "S11_provisional_empty", "S13_empty_unit",
+})
+
+#: Full-artifact counts that qualify the containment relations. A paged run
+#: cannot re-derive these -- Definition section 9 says containment is
+#: established during instance qualification, not from a page -- so they are
+#: declared, and checked for consistency with what they claim to establish.
+REQUIRED_BASELINES = frozenset({"S1_full", "S3_full", "S9_full"})
+
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+VERSION_RE = re.compile(r"^v\d{8}T\d{6}Z$")
+#: Outward code, optional sector digit, optional unit. Deliberately narrow: a
+#: placeholder that is not a real geography is a corpus error, not a query that
+#: happens to return nothing.
+GEOGRAPHY_RE = re.compile(r"^[A-Z]{1,2}\d[A-Z\d]?( \d([A-Z]{2})?)?$")
+
+
+class InstanceRefused(Exception):
+    """The instance is malformed, incomplete, or bound to another artifact.
+
+    Raised before anything is materialized or queried. Both CLIs map it to
+    exit 2.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Case shapes -- the Definition's S1..S14
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Case:
+    """One corpus shape, with the Definition's frozen parameters attached."""
+
+    shape: str
+    intent: str
+    postcode: str
+    search_level: str
+    months: int = 24
+    property_type: Optional[str] = None
+    transaction_category: Optional[str] = "A"
+
+    def request(self) -> dict[str, Any]:
+        """The wire request, with omissions recorded as omissions.
+
+        `property_type=None` and `address=None` are not values the HTTP surface
+        can carry: omission is the only way to ask for the residential default.
+        The record says so rather than implying a null was sent.
+        """
+        wire: dict[str, Any] = {
+            "postcode": self.postcode,
+            "search_level": self.search_level,
+            "months": self.months,
+            "limit": LIMIT,
+            "transaction_category": self.transaction_category or "all",
+            "filter_outliers": False,
+            "auto_escalate": True,
+            "enrich_epc": False,
+        }
+        if self.property_type is None:
+            wire["property_type"] = "<omitted>"
+        else:
+            wire["property_type"] = self.property_type
+        wire["address"] = "<omitted>"
+        return wire
+
+    def effective(self) -> dict[str, Any]:
+        return {
+            "property_type": (self.property_type
+                              or "residential_default (F/D/S/T)"),
+            "address": None,
+            "transaction_category": self.transaction_category,
+        }
+
+
+def cases(geo: dict[str, str]) -> list[Case]:
+    """The Definition's thirteen shapes, with placeholders resolved."""
+    return [
+        Case("S1", "contamination boundary", "B5", "district"),
+        Case("S2", "reverse boundary", "B50", "district"),
+        Case("S3", "sector isolation", "B5 4", "sector"),
+        Case("S4", "thin market", geo["S4_thin"], "sector"),
+        Case("S5", "dense market and truncation", geo["S5_dense"], "sector"),
+        Case("S6", "exact-postcode geography", geo["S6_unit"], "postcode"),
+        Case("S7", "type filter barely bites", geo["S7_type_weak"], "sector",
+             property_type="F"),
+        Case("S8", "type filter genuinely bites", geo["S8_type_strong"], "sector",
+             property_type="F"),
+        Case("S9", "category filtering", "B5 4", "sector",
+             transaction_category=None),
+        # S10 removed: "provisional tail, non-empty" discriminates nothing now
+        # that every comps case is provisional (Definition section 3).
+        Case("S11", "provisional flag is a window property",
+             geo["S11_provisional_empty"], "sector", months=6),
+        Case("S12", "widest window, deepest history", "B5", "district", months=120),
+        Case("S13", "expected empty", geo["S13_empty_unit"], "postcode",
+             property_type="D"),
+        Case("S14", "expected empty, sector shape", "B5 4", "sector",
+             property_type="T"),
+    ]
+
+
+def derived_from_date(observed_at: date, months: int) -> str:
+    """The window a harness must reconstruct; `comps` does not report it.
+
+    Mirrors `PPDService.comps`. Pinned behaviourally in
+    `tests/snapshot/test_shadow_corpus_definition.py`, because if this drifts,
+    every window recorded by every observation is wrong.
+    """
+    return (observed_at - timedelta(days=months * 30)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Warning classes -- Definition section 5's executable predicates
+# ---------------------------------------------------------------------------
+
+def warning_classes(warnings: tuple[str, ...]) -> list[str]:
+    """The Definition's classes, matched by their published predicates.
+
+    Classes, never text: snapshot and live warnings are deliberately worded
+    differently by source, so comparing strings would fail the corpus on a
+    wording change and would encode prose as contract.
+    """
+    found = []
+    for w in warnings:
+        if "beyond snapshot coverage" in w and "are not included" in w:
+            found.append("coverage_clamp")
+        if "narrowed to" in w and "coverage" in w:
+            found.append("coverage_floor_narrowing")
+        if "days behind its coverage end" in w:
+            found.append("freshness")
+        if w.startswith("auto-escalation not applied:"):
+            found.append("escalation_containment")
+        if "the upstream window was not exhausted" in w:
+            found.append("live_incompleteness")
+        if "removed by geography containment" in w:
+            found.append("geography_containment")
+    return sorted(set(found))
+
+
+# ---------------------------------------------------------------------------
+# Geography and identity helpers
+# ---------------------------------------------------------------------------
+
+def outcodes(transactions: Iterable[Any]) -> list[str]:
+    """Distinct outcodes in a result. Geography membership, never rows."""
+    seen = set()
+    for t in transactions:
+        pc = (getattr(t, "postcode", None) or "").strip().upper()
+        head = pc.partition(" ")[0]
+        if head:
+            seen.add(head)
+    return sorted(seen)
+
+
+def sectors(transactions: Iterable[Any]) -> list[str]:
+    seen = set()
+    for t in transactions:
+        pc = (getattr(t, "postcode", None) or "").strip().upper()
+        head, _, tail = pc.partition(" ")
+        if head and tail:
+            seen.add(f"{head} {tail[0]}")
+    return sorted(seen)
+
+
+def ids(transactions: Iterable[Any]) -> set[str]:
+    """In-memory only. Used for containment and diffing; never persisted."""
+    return {t.transaction_id for t in transactions
+            if getattr(t, "transaction_id", None)}
+
+
+# ---------------------------------------------------------------------------
+# Instance validation shared by the rehearsal and the Stage 1 comparator
+# ---------------------------------------------------------------------------
+
+def validate_geographies(raw: Any) -> dict[str, str]:
+    """Every placeholder supplied, no others, each a plausible geography."""
+    if not isinstance(raw, dict):
+        raise InstanceRefused("geographies must be a JSON object")
+    supplied = set(raw)
+    if missing := REQUIRED_GEOGRAPHIES - supplied:
+        raise InstanceRefused(
+            f"the Definition's placeholder(s) {sorted(missing)} are unsupplied")
+    if unknown := supplied - REQUIRED_GEOGRAPHIES:
+        raise InstanceRefused(
+            f"geographies carries unknown placeholder(s): {sorted(unknown)}")
+    cleaned: dict[str, str] = {}
+    for key, value in sorted(raw.items()):
+        if not isinstance(value, str) or not GEOGRAPHY_RE.match(
+                value.strip().upper()):
+            raise InstanceRefused(
+                f"{key} is {value!r}, which is not a postcode, sector or outcode")
+        cleaned[key] = value.strip().upper()
+    return cleaned
+
+
+def validate_baselines(raw: Any) -> dict[str, int]:
+    """The three full-aggregate counts, and the relations they establish.
+
+    A baseline set contradicting the relation it exists to establish is
+    refused: it would look like evidence while qualifying nothing.
+    """
+    if not isinstance(raw, dict):
+        raise InstanceRefused("aggregate_baselines must be a JSON object")
+    supplied = set(raw)
+    if missing := REQUIRED_BASELINES - supplied:
+        raise InstanceRefused(
+            f"aggregate_baselines is missing {sorted(missing)}; these are the "
+            f"qualification evidence for the containment relations")
+    if unknown := supplied - REQUIRED_BASELINES:
+        raise InstanceRefused(
+            f"aggregate_baselines carries unknown key(s): {sorted(unknown)}")
+    for key in sorted(REQUIRED_BASELINES):
+        value = raw[key]
+        # `bool` is an `int` subclass; True would sail through an isinstance
+        # check and then compare as 1.
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise InstanceRefused(
+                f"aggregate_baselines[{key}] is {value!r}, not a count")
+    baselines = {k: int(v) for k, v in raw.items()}
+    # The baselines exist to establish two relations. A set that contradicts
+    # them qualifies nothing, and would be worse than absent: it would look
+    # like evidence.
+    #
+    # STRICT on the S1/S3 side. Equal counts would say the sector IS the whole
+    # district, which qualifies nothing -- the Definition (section 4) requires
+    # a strict subset, so `>=` is the refusal and `>` would be a relaxation.
+    if baselines["S3_full"] >= baselines["S1_full"]:
+        raise InstanceRefused(
+            f"aggregate_baselines say S3 holds {baselines['S3_full']} rows and "
+            f"S1 holds {baselines['S1_full']}; S3 is one sector inside S1's "
+            f"district, and the Definition requires a STRICT subset. Equal "
+            f"counts would say the sector is the whole district, which "
+            f"qualifies nothing.")
+    if baselines["S9_full"] <= baselines["S3_full"]:
+        raise InstanceRefused(
+            f"aggregate_baselines say S9 ({baselines['S9_full']}) does not "
+            f"exceed S3 ({baselines['S3_full']}); including category B cannot "
+            f"return fewer rows than excluding it")
+    return baselines
+
+
+def validate_artifact_identity(version: Any, digest: Any) -> tuple[str, str]:
+    """A version string and a full 64-character bundle digest, or a refusal."""
+    if not isinstance(version, str) or not VERSION_RE.match(version):
+        raise InstanceRefused(
+            f"snapshot_version is not a version string: {version!r}")
+    if not isinstance(digest, str) or not SHA256_RE.match(digest):
+        raise InstanceRefused("bundle_sha256 is not a 64-character hex digest")
+    return version, digest

--- a/tools/ppd_snapshot/corpus.py
+++ b/tools/ppd_snapshot/corpus.py
@@ -197,6 +197,62 @@ def sectors(transactions: Iterable[Any]) -> list[str]:
     return sorted(seen)
 
 
+def geography_violations(case: "Case", transactions: Iterable[Any]) -> dict[str, Any]:
+    """Rows outside the geography a case asked for, **at the level it asked at**.
+
+    Outcode equality is the right test for a `district` case and far too weak
+    for the others. A `sector` case asking for `B5 4` and handed a `B5 6` row
+    has been contaminated exactly as surely as a `B5` case handed a `B50` row --
+    the Definition names sector isolation (`M3 7` returns only `M3 7`) as its
+    own trap -- and an outcode-only check calls both of those clean. The same
+    goes for a `postcode` case handed a different unit in the same sector.
+
+    **Reported at sector and outcode granularity only**, which is the hygiene
+    rule the local rehearsal already follows. A unit-level violation that stays
+    inside the requested sector is therefore recorded as a count rather than by
+    naming the postcode: the count is what proves contamination, and the unit
+    would be the most identifying thing in the report.
+    """
+    requested = case.postcode.strip().upper()
+    head, _, tail = requested.partition(" ")
+    requested_sector = f"{head} {tail[0]}" if tail else None
+
+    unexpected_outcodes: set[str] = set()
+    unexpected_sectors: set[str] = set()
+    same_sector_unit_violations = 0
+
+    for transaction in transactions:
+        pc = (getattr(transaction, "postcode", None) or "").strip().upper()
+        if not pc:
+            continue
+        row_head, _, row_tail = pc.partition(" ")
+        row_sector = f"{row_head} {row_tail[0]}" if row_tail else None
+
+        if row_head != head:
+            unexpected_outcodes.add(row_head)
+            continue
+        if case.search_level in {"sector", "postcode"} and requested_sector:
+            if row_sector != requested_sector:
+                # Same outcode, wrong sector -- invisible to an outcode check.
+                unexpected_sectors.add(row_sector or row_head)
+                continue
+        if case.search_level == "postcode" and pc != requested:
+            same_sector_unit_violations += 1
+
+    return {
+        "level": case.search_level,
+        "unexpected_outcodes": sorted(unexpected_outcodes),
+        "unexpected_sectors": sorted(unexpected_sectors),
+        "same_sector_unit_violations": same_sector_unit_violations,
+    }
+
+
+def is_contaminated(violations: dict[str, Any]) -> bool:
+    return bool(violations["unexpected_outcodes"]
+                or violations["unexpected_sectors"]
+                or violations["same_sector_unit_violations"])
+
+
 def ids(transactions: Iterable[Any]) -> set[str]:
     """In-memory only. Used for containment and diffing; never persisted."""
     return {t.transaction_id for t in transactions
@@ -317,10 +373,12 @@ def snapshot_invariants(case: Case, response: Any, provenance: Any,
             provenance is not None and provenance.recent_period_provisional is True),
     }
 
-    found = outcodes(response.transactions)
-    requested_outcode = case.postcode.split()[0].upper()
     if case.search_level in {"district", "sector", "postcode"}:
-        inv["geography_isolation"] = all(o == requested_outcode for o in found)
+        # Checked at the level the case asked at, not merely by outcode: a
+        # sector case handed a same-outcode neighbouring sector is contaminated,
+        # and an outcode-only test reports that as clean.
+        inv["geography_isolation"] = not is_contaminated(
+            geography_violations(case, response.transactions))
 
     if case.shape in {"S5", "S12"}:
         inv["truncated_at_limit"] = response.count == LIMIT

--- a/tools/ppd_snapshot/corpus.py
+++ b/tools/ppd_snapshot/corpus.py
@@ -282,3 +282,63 @@ def validate_artifact_identity(version: Any, digest: Any) -> tuple[str, str]:
     if not isinstance(digest, str) or not SHA256_RE.match(digest):
         raise InstanceRefused("bundle_sha256 is not a 64-character hex digest")
     return version, digest
+
+
+# ---------------------------------------------------------------------------
+# Per-case assertions -- Definition sections 3 and 9
+# ---------------------------------------------------------------------------
+
+def snapshot_invariants(case: Case, response: Any, provenance: Any,
+                        classes: list[str]) -> dict[str, bool]:
+    """The Definition's per-case assertions over a SNAPSHOT-arm response.
+
+    Shared by the local rehearsal and the Stage 1 comparator so that the two
+    check the same things. The universal block (section 3) is structural, not
+    situational: `comps` never sends `to_date`, so routing takes the clamp
+    branch unconditionally on every case, whatever the artifact, date or row
+    count. A case reporting `sample_complete: true` is a defect, not a
+    divergence.
+
+    Booleans only -- no id, address or price is reachable from the result.
+    """
+    inv: dict[str, bool] = {
+        # Universal (Definition section 3): comps never sends to_date.
+        "coverage_clamp_warning_present": "coverage_clamp" in classes,
+        "sample_complete_is_false": bool(
+            provenance is not None and provenance.sample_complete is False),
+        "completeness_basis_is_null": bool(
+            provenance is not None and provenance.completeness_basis is None),
+        "answered_by_snapshot": bool(
+            provenance is not None and "snapshot" in str(provenance.source).lower()),
+        # Universal, not per-shape: the resolved upper bound is always
+        # `coverage_to` and `provisional_from` never exceeds it, so every comps
+        # window intersects the provisional period (Definition section 3).
+        "provisional_flagged": bool(
+            provenance is not None and provenance.recent_period_provisional is True),
+    }
+
+    found = outcodes(response.transactions)
+    requested_outcode = case.postcode.split()[0].upper()
+    if case.search_level in {"district", "sector", "postcode"}:
+        inv["geography_isolation"] = all(o == requested_outcode for o in found)
+
+    if case.shape in {"S5", "S12"}:
+        inv["truncated_at_limit"] = response.count == LIMIT
+    if case.shape == "S4":
+        inv["thin_market_flagged"] = response.thin_market is True
+    if case.shape == "S11":
+        inv["empty_result"] = response.count == 0
+    if case.shape in {"S13", "S14"}:
+        inv["expected_empty"] = response.count == 0
+    return inv
+
+
+def returned_date_bounds(transactions: Any) -> tuple[Optional[str], Optional[str]]:
+    """The earliest and latest transfer date in a result. Bounds, never rows.
+
+    Definition section 9 requires the date bounds of returned rows to be
+    recorded: they are what shows a window was honoured, and two dates are not
+    a transaction.
+    """
+    dates = sorted(t.date for t in transactions if getattr(t, "date", None))
+    return (dates[0], dates[-1]) if dates else (None, None)

--- a/tools/ppd_snapshot/corpus.py
+++ b/tools/ppd_snapshot/corpus.py
@@ -483,4 +483,61 @@ def validate_substitutions(raw: Any) -> dict[str, str]:
                 f"substitutions[{key}] records no justification; the Definition "
                 f"permits substitution only WITH recorded justification")
         resolved[key] = geography.strip().upper()
+
+    validate_definitional_geometry(resolved)
     return resolved
+
+
+#: An outward code: no space, no sector digit.
+_OUTCODE_RE = re.compile(r"^[A-Z]{1,2}\d[A-Z\d]?$")
+#: An outward code plus one sector digit.
+_SECTOR_RE = re.compile(r"^[A-Z]{1,2}\d[A-Z\d]? \d$")
+
+
+def validate_definitional_geometry(geographies: dict[str, str]) -> None:
+    """The three definitional geographies must stand in the same relation.
+
+    Substituting them is permitted; substituting them into a shape that no
+    longer tests anything is not. The corpus is built on one specific geometry
+    and every case below depends on it:
+
+    * **S1 is a district**, S2 a district, S3 a sector -- a `search_level` and
+      a geography that disagree describe a query the corpus never specified.
+    * **S2 extends S1** and is longer (`B5` -> `B50`). That IS the contamination
+      boundary: a district search for the shorter outcode can wrongly prefix-
+      match the longer one, and S1/S2 exist to catch exactly that. Two
+      unrelated outcodes are merely two districts, and the pair tests nothing.
+    * **S3 lies inside S1**, because S3's aggregate count is qualified as a
+      strict subset of S1's and S9's as exceeding S3's on identical geography.
+      A sector outside S1's district makes both relations meaningless while the
+      baselines still look like numbers.
+    """
+    district = geographies["S1_district"]
+    neighbour = geographies["S2_neighbour_district"]
+    sector = geographies["S3_sector"]
+
+    if not _OUTCODE_RE.match(district):
+        raise InstanceRefused(
+            f"S1_district {district!r} is not an outward code; S1 is a district "
+            f"case and its geography must be one")
+    if not _OUTCODE_RE.match(neighbour):
+        raise InstanceRefused(
+            f"S2_neighbour_district {neighbour!r} is not an outward code")
+    if not _SECTOR_RE.match(sector):
+        raise InstanceRefused(
+            f"S3_sector {sector!r} is not a sector (outward code plus one "
+            f"sector digit); S3 and S9 are sector cases")
+
+    if not (neighbour.startswith(district) and len(neighbour) > len(district)):
+        raise InstanceRefused(
+            f"S2_neighbour_district {neighbour!r} does not extend "
+            f"{district!r}. The contamination boundary is a district search for "
+            f"the shorter outcode wrongly prefix-matching the longer one; two "
+            f"unrelated outcodes are merely two districts and test nothing.")
+    if sector.split()[0] != district:
+        raise InstanceRefused(
+            f"S3_sector {sector!r} does not lie inside S1_district {district!r}. "
+            f"S3's count is qualified as a strict subset of S1's and S9's as "
+            f"exceeding S3's on identical geography; a sector outside the "
+            f"district makes both relations meaningless while the baselines "
+            f"still look like numbers.")

--- a/tools/ppd_snapshot/rehearse.py
+++ b/tools/ppd_snapshot/rehearse.py
@@ -45,6 +45,7 @@ from tools.ppd_snapshot.corpus import (
     cases,
     derived_from_date,
     ids as _ids,
+    snapshot_invariants as _invariants,
     outcodes as _outcodes,
     sectors as _sectors,
     validate_artifact_identity,
@@ -429,41 +430,6 @@ def run_rehearsal(*, instance: RehearsalInstance, dist_dir: Path,
     report_path.parent.mkdir(parents=True, exist_ok=True)
     report_path.write_text(json.dumps(report, indent=2, sort_keys=False))
     return report
-
-
-def _invariants(case: Case, response: Any, provenance: Any,
-                classes: list[str]) -> dict[str, bool]:
-    """The Definition's per-case assertions. Booleans only."""
-    inv: dict[str, bool] = {
-        # Universal (Definition section 3): comps never sends to_date.
-        "coverage_clamp_warning_present": "coverage_clamp" in classes,
-        "sample_complete_is_false": bool(
-            provenance is not None and provenance.sample_complete is False),
-        "completeness_basis_is_null": bool(
-            provenance is not None and provenance.completeness_basis is None),
-        "answered_by_snapshot": bool(
-            provenance is not None and "snapshot" in str(provenance.source).lower()),
-        # Universal, not per-shape: the resolved upper bound is always
-        # `coverage_to` and `provisional_from` never exceeds it, so every comps
-        # window intersects the provisional period (Definition section 3).
-        "provisional_flagged": bool(
-            provenance is not None and provenance.recent_period_provisional is True),
-    }
-
-    outcodes = _outcodes(response.transactions)
-    requested_outcode = case.postcode.split()[0].upper()
-    if case.search_level in {"district", "sector", "postcode"}:
-        inv["geography_isolation"] = all(o == requested_outcode for o in outcodes)
-
-    if case.shape in {"S5", "S12"}:
-        inv["truncated_at_limit"] = response.count == 50
-    if case.shape == "S4":
-        inv["thin_market_flagged"] = response.thin_market is True
-    if case.shape == "S11":
-        inv["empty_result"] = response.count == 0
-    if case.shape in {"S13", "S14"}:
-        inv["expected_empty"] = response.count == 0
-    return inv
 
 
 _SATURATED = (

--- a/tools/ppd_snapshot/rehearse.py
+++ b/tools/ppd_snapshot/rehearse.py
@@ -31,13 +31,27 @@ Three rules shape the implementation:
 from __future__ import annotations
 
 import json
-import re
 import socket
 from dataclasses import dataclass, field
 import time
-from datetime import date, timedelta
+from datetime import date
 from pathlib import Path
 from typing import Any, Optional
+
+from tools.ppd_snapshot.corpus import (
+    LIMIT,
+    Case,
+    InstanceRefused,
+    cases,
+    derived_from_date,
+    ids as _ids,
+    outcodes as _outcodes,
+    sectors as _sectors,
+    validate_artifact_identity,
+    validate_baselines,
+    validate_geographies,
+    warning_classes as _warning_classes,
+)
 
 #: Exactly these top-level keys. Unknown keys are refused rather than ignored:
 #: a typo in an instance is a silently different rehearsal.
@@ -46,36 +60,9 @@ REQUIRED_KEYS = frozenset({
     "aggregate_baselines",
 })
 
-#: Full-artifact counts that qualify the containment relations. A paged
-#: rehearsal cannot re-derive these -- section 9 says containment is
-#: established here, during instance qualification, not from a page -- so they
-#: are declared, and checked for consistency with what they claim to establish.
-REQUIRED_BASELINES = frozenset({"S1_full", "S3_full", "S9_full"})
-
-#: The Definition's placeholders. Every one must be supplied; no others.
-REQUIRED_GEOGRAPHIES = frozenset({
-    "S4_thin", "S5_dense", "S6_unit", "S7_type_weak",
-    "S8_type_strong", "S11_provisional_empty", "S13_empty_unit",
-})
-
 #: `rehearsal`, never `stage1`. The kind is in the file so a rehearsal instance
 #: cannot be handed to a Stage 1 runner by accident.
 INSTANCE_KIND = "rehearsal"
-
-_SHA256 = re.compile(r"^[0-9a-f]{64}$")
-_VERSION = re.compile(r"^v\d{8}T\d{6}Z$")
-#: Outward code, optional sector digit, optional unit. Deliberately narrow: a
-#: placeholder that is not a real geography is a corpus error, not a query that
-#: happens to return nothing.
-_GEOGRAPHY = re.compile(r"^[A-Z]{1,2}\d[A-Z\d]?( \d([A-Z]{2})?)?$")
-
-
-class InstanceRefused(Exception):
-    """The instance is malformed, incomplete, or bound to another artifact.
-
-    Raised before anything is materialized. The CLI maps it to exit 2.
-    """
-
 
 @dataclass(frozen=True)
 class RehearsalInstance:
@@ -128,58 +115,10 @@ def load_instance(path: Path, dist_dir: Path) -> RehearsalInstance:
             f"rehearsal and must not be run through it."
         )
 
-    version, digest = raw["snapshot_version"], raw["bundle_sha256"]
-    if not isinstance(version, str) or not _VERSION.match(version):
-        raise InstanceRefused(f"snapshot_version is not a version string: {version!r}")
-    if not isinstance(digest, str) or not _SHA256.match(digest):
-        raise InstanceRefused("bundle_sha256 is not a 64-character hex digest")
-
-    geographies = raw["geographies"]
-    if not isinstance(geographies, dict):
-        raise InstanceRefused("geographies must be a JSON object")
-    supplied = set(geographies)
-    if missing := REQUIRED_GEOGRAPHIES - supplied:
-        raise InstanceRefused(
-            f"the Definition's placeholder(s) {sorted(missing)} are unsupplied")
-    if unknown := supplied - REQUIRED_GEOGRAPHIES:
-        raise InstanceRefused(
-            f"geographies carries unknown placeholder(s): {sorted(unknown)}")
-    for key, value in sorted(geographies.items()):
-        if not isinstance(value, str) or not _GEOGRAPHY.match(value.strip().upper()):
-            raise InstanceRefused(
-                f"{key} is {value!r}, which is not a postcode, sector or outcode")
-
-    baselines = raw["aggregate_baselines"]
-    if not isinstance(baselines, dict):
-        raise InstanceRefused("aggregate_baselines must be a JSON object")
-    supplied_b = set(baselines)
-    if missing := REQUIRED_BASELINES - supplied_b:
-        raise InstanceRefused(
-            f"aggregate_baselines is missing {sorted(missing)}; these are the "
-            f"qualification evidence for the containment relations")
-    if unknown := supplied_b - REQUIRED_BASELINES:
-        raise InstanceRefused(
-            f"aggregate_baselines carries unknown key(s): {sorted(unknown)}")
-    for key in sorted(REQUIRED_BASELINES):
-        value = baselines[key]
-        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
-            raise InstanceRefused(
-                f"aggregate_baselines[{key}] is {value!r}, not a count")
-    # The baselines exist to establish two relations. A set that contradicts
-    # them qualifies nothing, and would be worse than absent: it would look
-    # like evidence.
-    if baselines["S3_full"] >= baselines["S1_full"]:
-        raise InstanceRefused(
-            f"aggregate_baselines say S3 holds {baselines['S3_full']} rows and "
-            f"S1 holds {baselines['S1_full']}; S3 is one sector inside S1's "
-            f"district, and the Definition requires a STRICT subset. Equal "
-            f"counts would say the sector is the whole district, which "
-            f"qualifies nothing.")
-    if baselines["S9_full"] <= baselines["S3_full"]:
-        raise InstanceRefused(
-            f"aggregate_baselines say S9 ({baselines['S9_full']}) does not "
-            f"exceed S3 ({baselines['S3_full']}); including category B cannot "
-            f"return fewer rows than excluding it")
+    version, digest = validate_artifact_identity(
+        raw["snapshot_version"], raw["bundle_sha256"])
+    geographies = validate_geographies(raw["geographies"])
+    baselines = validate_baselines(raw["aggregate_baselines"])
 
     # Binding: the instance must name the artifact it is about to be run
     # against. An instance that is internally valid but describes a different
@@ -200,7 +139,7 @@ def load_instance(path: Path, dist_dir: Path) -> RehearsalInstance:
         instance_kind=raw["instance_kind"],
         snapshot_version=version,
         bundle_sha256=digest,
-        geographies={k: v.strip().upper() for k, v in geographies.items()},
+        geographies=dict(geographies),
         aggregate_baselines=dict(baselines),
     )
 
@@ -254,120 +193,8 @@ class SocketBlocker:
 
 
 # ---------------------------------------------------------------------------
-# Case shapes -- the Definition's S1..S14
-# ---------------------------------------------------------------------------
-
-@dataclass(frozen=True)
-class Case:
-    """One corpus shape, with the Definition's frozen parameters attached."""
-
-    shape: str
-    intent: str
-    postcode: str
-    search_level: str
-    months: int = 24
-    property_type: Optional[str] = None
-    transaction_category: Optional[str] = "A"
-
-    def request(self) -> dict[str, Any]:
-        """The wire request, with omissions recorded as omissions.
-
-        `property_type=None` and `address=None` are not values the HTTP surface
-        can carry: omission is the only way to ask for the residential default.
-        The record says so rather than implying a null was sent.
-        """
-        wire: dict[str, Any] = {
-            "postcode": self.postcode,
-            "search_level": self.search_level,
-            "months": self.months,
-            "limit": 50,
-            "transaction_category": self.transaction_category or "all",
-            "filter_outliers": False,
-            "auto_escalate": True,
-            "enrich_epc": False,
-        }
-        if self.property_type is None:
-            wire["property_type"] = "<omitted>"
-        else:
-            wire["property_type"] = self.property_type
-        wire["address"] = "<omitted>"
-        return wire
-
-    def effective(self) -> dict[str, Any]:
-        return {
-            "property_type": (self.property_type
-                              or "residential_default (F/D/S/T)"),
-            "address": None,
-            "transaction_category": self.transaction_category,
-        }
-
-
-def cases(geo: dict[str, str]) -> list[Case]:
-    """The Definition's thirteen shapes, with placeholders resolved."""
-    return [
-        Case("S1", "contamination boundary", "B5", "district"),
-        Case("S2", "reverse boundary", "B50", "district"),
-        Case("S3", "sector isolation", "B5 4", "sector"),
-        Case("S4", "thin market", geo["S4_thin"], "sector"),
-        Case("S5", "dense market and truncation", geo["S5_dense"], "sector"),
-        Case("S6", "exact-postcode geography", geo["S6_unit"], "postcode"),
-        Case("S7", "type filter barely bites", geo["S7_type_weak"], "sector",
-             property_type="F"),
-        Case("S8", "type filter genuinely bites", geo["S8_type_strong"], "sector",
-             property_type="F"),
-        Case("S9", "category filtering", "B5 4", "sector",
-             transaction_category=None),
-        # S10 removed: "provisional tail, non-empty" discriminates nothing now
-        # that every comps case is provisional (Definition section 3).
-        Case("S11", "provisional flag is a window property",
-             geo["S11_provisional_empty"], "sector", months=6),
-        Case("S12", "widest window, deepest history", "B5", "district", months=120),
-        Case("S13", "expected empty", geo["S13_empty_unit"], "postcode",
-             property_type="D"),
-        Case("S14", "expected empty, sector shape", "B5 4", "sector",
-             property_type="T"),
-    ]
-
-
-def derived_from_date(observed_at: date, months: int) -> str:
-    """The window a harness must reconstruct; `comps` does not report it.
-
-    Mirrors `PPDService.comps`. Pinned behaviourally in
-    `tests/snapshot/test_shadow_corpus_definition.py`, because if this drifts,
-    every window recorded by every observation is wrong.
-    """
-    return (observed_at - timedelta(days=months * 30)).isoformat()
-
-
-# ---------------------------------------------------------------------------
 # Running the rehearsal
 # ---------------------------------------------------------------------------
-
-def _outcodes(transactions: Any) -> list[str]:
-    """Distinct outcodes in a result. Geography membership, never rows."""
-    seen = set()
-    for t in transactions:
-        pc = (getattr(t, "postcode", None) or "").strip().upper()
-        head = pc.partition(" ")[0]
-        if head:
-            seen.add(head)
-    return sorted(seen)
-
-
-def _sectors(transactions: Any) -> list[str]:
-    seen = set()
-    for t in transactions:
-        pc = (getattr(t, "postcode", None) or "").strip().upper()
-        head, _, tail = pc.partition(" ")
-        if head and tail:
-            seen.add(f"{head} {tail[0]}")
-    return sorted(seen)
-
-
-def _ids(transactions: Any) -> set[str]:
-    """In-memory only. Used for containment; never returned or written."""
-    return {t.transaction_id for t in transactions if getattr(t, "transaction_id", None)}
-
 
 class MidnightCrossing(RuntimeError):
     """An observation could not be taken within a single calendar date.
@@ -416,25 +243,6 @@ def _observe(service: Any, case: Case, *,
         f"the query that was actually run.",
         retries=retries,
     )
-
-
-def _warning_classes(warnings: tuple[str, ...]) -> list[str]:
-    """The Definition's classes, matched by their published predicates."""
-    found = []
-    for w in warnings:
-        if "beyond snapshot coverage" in w and "are not included" in w:
-            found.append("coverage_clamp")
-        if "narrowed to" in w and "coverage" in w:
-            found.append("coverage_floor_narrowing")
-        if "days behind its coverage end" in w:
-            found.append("freshness")
-        if w.startswith("auto-escalation not applied:"):
-            found.append("escalation_containment")
-        if "the upstream window was not exhausted" in w:
-            found.append("live_incompleteness")
-        if "removed by geography containment" in w:
-            found.append("geography_containment")
-    return sorted(set(found))
 
 
 def run_rehearsal(*, instance: RehearsalInstance, dist_dir: Path,
@@ -657,10 +465,6 @@ def _invariants(case: Case, response: Any, provenance: Any,
         inv["expected_empty"] = response.count == 0
     return inv
 
-
-#: The page size every case is frozen at. A result of exactly this length was
-#: truncated, and a truncated page cannot answer a containment question.
-LIMIT = 50
 
 _SATURATED = (
     "not evaluable: {a} returned {na} rows and {b} returned {nb}, and a page "

--- a/tools/ppd_snapshot/stage1_shadow.py
+++ b/tools/ppd_snapshot/stage1_shadow.py
@@ -305,6 +305,100 @@ class Stage1Instance:
     substitutions: dict[str, str]
 
 
+def _required_number(entry: dict[str, Any], key: str, where: str) -> float:
+    value = entry.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise InstanceRefused(
+            f"qualification[{where}].{key} is {value!r}, not a number; the "
+            f"baselines cannot be checked against a measurement that is not "
+            f"recorded")
+    return value
+
+
+def _cross_check_measurements(qualification: dict[str, Any],
+                              baselines: dict[str, int],
+                              effective: dict[str, str]) -> None:
+    """Every recorded definitional measurement and derived field must agree.
+
+    Checked against the aggregate baselines and the effective geographies, so
+    the three sets of numbers in an Instance cannot disagree with each other.
+    Each mismatch below has the same shape: a document that looks internally
+    complete while one figure came from somewhere the run will not go.
+    """
+    s1_entry = qualification["S1_district"]
+    s2_entry = qualification["S2_district"]
+    s3_entry = qualification["S3_sector"]
+
+    s1_rows = _required_number(s1_entry, "measured_rows", "S1_district")
+    if s1_rows != baselines["S1_full"]:
+        raise InstanceRefused(
+            f"qualification[S1_district].measured_rows is {s1_rows}, but "
+            f"aggregate_baselines.S1_full is {baselines['S1_full']}; the same "
+            f"count over the same geography cannot be two numbers")
+
+    s3_rows = _required_number(s3_entry, "measured_rows", "S3_sector")
+    if s3_rows != baselines["S3_full"]:
+        raise InstanceRefused(
+            f"qualification[S3_sector].measured_rows is {s3_rows}, but "
+            f"aggregate_baselines.S3_full is {baselines['S3_full']}")
+    s9_rows = _required_number(s3_entry, "measured_rows_category_all", "S3_sector")
+    if s9_rows != baselines["S9_full"]:
+        raise InstanceRefused(
+            f"qualification[S3_sector].measured_rows_category_all is {s9_rows}, "
+            f"but aggregate_baselines.S9_full is {baselines['S9_full']}")
+
+    # The neighbour count appears twice -- once as S2's own measurement, once
+    # as the input to S1's ratio. They are the same query.
+    s2_rows = _required_number(s2_entry, "measured_rows", "S2_district")
+    neighbour_rows = _required_number(
+        s1_entry, "measured_neighbour_rows", "S1_district")
+    if s2_rows != neighbour_rows:
+        raise InstanceRefused(
+            f"qualification[S2_district].measured_rows is {s2_rows} but "
+            f"qualification[S1_district].measured_neighbour_rows is "
+            f"{neighbour_rows}; they are the same count over the same "
+            f"geography")
+
+    neighbour_geography = str(s1_entry.get("neighbour_geography", "")).strip().upper()
+    if neighbour_geography != effective["S2_neighbour_district"]:
+        raise InstanceRefused(
+            f"qualification[S1_district].neighbour_geography is "
+            f"{neighbour_geography!r}, but this Instance's neighbour is "
+            f"{effective['S2_neighbour_district']!r}; the ratio would describe "
+            f"a district the run does not use")
+
+    # Derived, so recomputed rather than trusted. A ratio edited to clear the
+    # literal rule while the counts stayed put is exactly what this catches.
+    expected_ratio = round((neighbour_rows / s1_rows) if s1_rows else 0.0, 4)
+    recorded_ratio = round(
+        _required_number(s1_entry, "measured_neighbour_ratio", "S1_district"), 4)
+    if recorded_ratio != expected_ratio:
+        raise InstanceRefused(
+            f"qualification[S1_district].measured_neighbour_ratio is "
+            f"{recorded_ratio}, but {neighbour_rows} / {s1_rows} is "
+            f"{expected_ratio}; a derived field must follow from the counts "
+            f"recorded beside it")
+
+    expected_comparable = bool(s1_rows > 0
+                               and expected_ratio >= NEIGHBOUR_COMPARABLE_RATIO)
+    if s1_entry.get("comparable_or_greater") is not expected_comparable:
+        raise InstanceRefused(
+            f"qualification[S1_district].comparable_or_greater is "
+            f"{s1_entry.get('comparable_or_greater')!r}, but a ratio of "
+            f"{expected_ratio} against the literal rule "
+            f"({NEIGHBOUR_COMPARABLE_RATIO}) gives {expected_comparable}. This "
+            f"field decides whether an owner decision is required, so it may "
+            f"not be asserted independently of the measurement")
+
+    inside = s3_entry.get("inside_s1_district")
+    expected_inside = effective["S3_sector"].split()[0] == effective["S1_district"]
+    if inside is not expected_inside:
+        raise InstanceRefused(
+            f"qualification[S3_sector].inside_s1_district is {inside!r}, but "
+            f"{effective['S3_sector']!r} inside {effective['S1_district']!r} is "
+            f"{expected_inside}")
+
+
 def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
     """Validate the Instance and bind it to the artifact actually on this Machine.
 
@@ -426,8 +520,16 @@ def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
                 f"artifact -- evidence for one geography cannot be attached to "
                 f"a run over another.")
 
-    # The S1/S3/S9 baselines are counts over exactly those three geographies,
-    # so binding the qualification entries above binds the baselines with them.
+    # -- the measurements and the baselines must be the same numbers --------
+    #
+    # Binding the geographies is half of it. The other half is that the counts
+    # recorded beside them agree with the baselines the corpus is qualified on,
+    # and that every derived field follows from those counts. Otherwise an
+    # Instance can name the right places and carry figures from somewhere else
+    # -- a re-qualification where one number was pasted from the previous run,
+    # or a ratio edited to clear the literal rule without the counts moving.
+    _cross_check_measurements(qualification, baselines, effective)
+
 
     # -- the neighbour rule: an explicit decision, or a refusal --------------
     #
@@ -436,14 +538,11 @@ def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
     # substitute-with-recorded-justification, and `qualify` deliberately refers
     # rather than settles it. An Instance that simply carries the shortfall and
     # says nothing about it is that referral going unanswered.
+    # `comparable_or_greater` has already been recomputed from the counts by
+    # `_cross_check_measurements`, which refuses a missing or dishonest value,
+    # so it can be read here as an established fact rather than re-guarded.
     s1_entry = qualification["S1_district"]
-    comparable = s1_entry.get("comparable_or_greater")
-    if not isinstance(comparable, bool):
-        raise InstanceRefused(
-            "qualification[S1_district] does not record comparable_or_greater; "
-            "whether the neighbour satisfied the literal rule is the fact an "
-            "adjudication would be answering")
-    if comparable is False:
+    if s1_entry["comparable_or_greater"] is False:
         decision = s1_entry.get("owner_decision")
         if not isinstance(decision, dict):
             raise InstanceRefused(
@@ -611,7 +710,7 @@ def _type_mix(m: Materialized, sector: str, *, months: int,
 
 
 def qualify(m: Materialized, *, today: Optional[date] = None,
-            definitional: Optional[dict[str, str]] = None) -> dict[str, Any]:
+            substitutions: Optional[dict[str, Any]] = None) -> dict[str, Any]:
     """Select the seven placeholders and measure the three baselines.
 
     Read-only throughout: aggregate COUNT and GROUP BY only, no download, no
@@ -619,7 +718,15 @@ def qualify(m: Materialized, *, today: Optional[date] = None,
     **candidate** Instance for review, never a runtime input.
     """
     today = today or date.today()
-    definitional = {**DEFINITIONAL_GEOGRAPHIES, **(definitional or {})}
+    # The block is carried through whole, justifications included, so the
+    # candidate this emits is a document the loader accepts. Passing only the
+    # resolved geographies dropped the justifications, and the candidate then
+    # described substituted geographies while carrying no `substitutions` key
+    # to declare them -- which the loader refuses, correctly, as evidence
+    # attached to the wrong run.
+    block = dict(substitutions or {})
+    resolved = validate_substitutions(block) if block else {}
+    definitional = {**DEFINITIONAL_GEOGRAPHIES, **resolved}
     qualification: dict[str, Any] = {}
     geo: dict[str, str] = {}
 
@@ -800,6 +907,12 @@ def qualify(m: Materialized, *, today: Optional[date] = None,
         "staleness_bound_days": 45,
         "governs_run": GOVERNS_RUN_PLACEHOLDER,
     }
+    if block:
+        # Verbatim, justifications and all. An operator must be able to take
+        # this candidate, fill in `governs_run` (and any owner decision), and
+        # have it load -- without reconstructing by hand a block the tool
+        # already validated.
+        candidate["substitutions"] = block
     return {
         "kind": "stage1_qualification_candidate",
         "is_instance": False,
@@ -1767,20 +1880,32 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     try:
         if args.mode == "qualify":
-            substitutions: dict[str, str] = {}
+            substitutions: dict[str, Any] = {}
             if args.substitutions is not None:
                 try:
                     raw = json.loads(args.substitutions.read_text())
                 except (OSError, ValueError) as exc:
                     print(f"refused: substitutions file unreadable: {exc}")
                     return 2
+                if not isinstance(raw, dict):
+                    # A list, a string or a bare number. `.get` on it raises
+                    # AttributeError, which reached the operator as a traceback
+                    # rather than a refusal.
+                    print(f"refused: substitutions file must contain a JSON "
+                          f"object, got {type(raw).__name__}")
+                    return 2
+                # A non-dict `substitutions` value needs no guard here:
+                # `validate_substitutions` refuses anything that is not an
+                # object, with a message naming the problem, and the refusal is
+                # caught below. A second isinstance check would be unreachable.
+                candidate_block = raw.get("substitutions", raw)
                 try:
-                    substitutions = validate_substitutions(
-                        raw.get("substitutions", raw))
+                    validate_substitutions(candidate_block)
                 except InstanceRefused as exc:
                     print(f"refused: {exc}")
                     return 2
-            out = qualify(materialized, definitional=substitutions or None)
+                substitutions = candidate_block
+            out = qualify(materialized, substitutions=substitutions or None)
             args.out.parent.mkdir(parents=True, exist_ok=True)
             args.out.write_text(json.dumps(out, indent=2, sort_keys=False))
             print(f"candidate instance written to {args.out}")

--- a/tools/ppd_snapshot/stage1_shadow.py
+++ b/tools/ppd_snapshot/stage1_shadow.py
@@ -369,23 +369,33 @@ def _cross_check_measurements(qualification: dict[str, Any],
 
     # Derived, so recomputed rather than trusted. A ratio edited to clear the
     # literal rule while the counts stayed put is exactly what this catches.
-    expected_ratio = round((neighbour_rows / s1_rows) if s1_rows else 0.0, 4)
+    #
+    # Two ratios, deliberately. The EXACT one decides comparability; the
+    # rounded one exists only to validate the four-decimal field the candidate
+    # records for a human to read. Deciding from the rounded value puts a
+    # rounding boundary inside a deployment gate: 20,000 rows against 20,001 is
+    # 0.99995, which is not "comparable or greater" -- and rounds to 1.0. The
+    # gate would then disagree with `qualify`, refusing a candidate that
+    # correctly said `false` and accepting a hand-edited `true` that skips the
+    # owner decision entirely.
+    exact_ratio = (neighbour_rows / s1_rows) if s1_rows else 0.0
+    expected_display_ratio = round(exact_ratio, 4)
     recorded_ratio = round(
         _required_number(s1_entry, "measured_neighbour_ratio", "S1_district"), 4)
-    if recorded_ratio != expected_ratio:
+    if recorded_ratio != expected_display_ratio:
         raise InstanceRefused(
             f"qualification[S1_district].measured_neighbour_ratio is "
             f"{recorded_ratio}, but {neighbour_rows} / {s1_rows} is "
-            f"{expected_ratio}; a derived field must follow from the counts "
-            f"recorded beside it")
+            f"{expected_display_ratio}; a derived field must follow from the "
+            f"counts recorded beside it")
 
     expected_comparable = bool(s1_rows > 0
-                               and expected_ratio >= NEIGHBOUR_COMPARABLE_RATIO)
+                               and exact_ratio >= NEIGHBOUR_COMPARABLE_RATIO)
     if s1_entry.get("comparable_or_greater") is not expected_comparable:
         raise InstanceRefused(
             f"qualification[S1_district].comparable_or_greater is "
             f"{s1_entry.get('comparable_or_greater')!r}, but a ratio of "
-            f"{expected_ratio} against the literal rule "
+            f"{exact_ratio!r} against the literal rule "
             f"({NEIGHBOUR_COMPARABLE_RATIO}) gives {expected_comparable}. This "
             f"field decides whether an owner decision is required, so it may "
             f"not be asserted independently of the measurement")
@@ -929,11 +939,11 @@ def qualify(m: Materialized, *, today: Optional[date] = None,
         "baselines_satisfy_their_relations": baselines_refusal is None,
         "baselines_refusal": baselines_refusal,
         "baselines_note": (
-            "S1/S3/S9 are measured over the definitional B5 / B5 4 geographies. "
-            "If they do not satisfy the strict-subset and category-B relations, "
-            "the Definition allows a substituted geography with recorded "
-            "justification -- which is an authoring decision, not something "
-            "this tool may make."),
+            f"S1 is measured over {definitional['S1_district']}, and S3/S9 over "
+            f"{definitional['S3_sector']}. If they do not satisfy the "
+            f"strict-subset and category-B relations, the Definition allows a "
+            f"substituted geography with recorded justification -- which is an "
+            f"authoring decision, not something this tool may make."),
         # Definitional cases that failed their own qualification rule. Kept
         # separate from the placeholders because they cannot be substituted by
         # choosing a different geography -- B5/B50 IS the contamination

--- a/tools/ppd_snapshot/stage1_shadow.py
+++ b/tools/ppd_snapshot/stage1_shadow.py
@@ -59,7 +59,9 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from tools.ppd_snapshot.corpus import (
+    DEFINITIONAL_GEOGRAPHIES,
     LIMIT,
+    REQUIRED_GEOGRAPHIES,
     Case,
     InstanceRefused,
     cases,
@@ -74,6 +76,7 @@ from tools.ppd_snapshot.corpus import (
     validate_artifact_identity,
     validate_baselines,
     validate_geographies,
+    validate_substitutions,
     warning_classes as _warning_classes,
 )
 
@@ -122,15 +125,19 @@ REQUIRED_CASES = 13
 REQUIRED_LATENCY_REPEATS = 30
 REQUIRED_LATENCY_OBSERVATIONS = REQUIRED_CASES * REQUIRED_LATENCY_REPEATS
 
-#: How "the longer neighbouring outcode holds comparable or greater volume"
-#: (Definition section 4, S1) is made executable. The Definition states the rule
-#: qualitatively; some threshold has to exist for a tool to check it, so this
-#: one is named here rather than buried, and the measured ratio is recorded
-#: alongside it so a reviewer can judge the operationalisation rather than
-#: trust it. The point of the rule is that B50 must carry enough volume for
-#: B50-in-B5 contamination to be visible at all: against a near-empty
-#: neighbour, a clean S1 result would prove nothing.
-MIN_NEIGHBOUR_VOLUME_RATIO = 0.10
+#: The literal reading of the Definition's S1 rule: "the longer neighbouring
+#: outcode holds **comparable or greater** volume".
+#:
+#: An earlier version of this tool operationalised that as "at least 10% of the
+#: district's rows" and auto-qualified on it. That was wrong: a tenth is not
+#: comparable, and quietly redefining a frozen qualification rule downwards is
+#: exactly the kind of change that must not happen inside an implementation.
+#: The threshold here is the one the words say. Anything below it is **not
+#: refused and not passed** -- it is referred to the owner, with the measurement
+#: attached, because "is 0.6 comparable for this artifact?" is a judgement about
+#: the corpus, and the Definition already provides the two ways to settle it:
+#: accept it, or substitute a geography with recorded justification.
+NEIGHBOUR_COMPARABLE_RATIO = 1.0
 
 #: The placeholder `qualify` writes into a candidate Instance. An Instance still
 #: carrying it has not been through the review the field exists to record.
@@ -261,6 +268,16 @@ REQUIRED_INSTANCE_KEYS = frozenset({
     "governs_run",
 })
 
+#: Optional, and absent in the normal case: the Definition's substitution route
+#: for the section 4 geographies.
+OPTIONAL_INSTANCE_KEYS = frozenset({"substitutions"})
+
+#: Every case whose geography an Instance fixes must say how it qualified --
+#: the seven placeholders plus the two definitional cases. A block covering
+#: some of them is silent about the rest while looking complete.
+REQUIRED_QUALIFICATION_KEYS = frozenset(
+    REQUIRED_GEOGRAPHIES | {"S1_district", "S2_district"})
+
 
 @dataclass(frozen=True)
 class Stage1Instance:
@@ -273,6 +290,8 @@ class Stage1Instance:
     qualification: dict[str, Any]
     staleness_bound_days: int
     governs_run: str
+    #: Empty in the normal case. The Definition's section 4 substitution route.
+    substitutions: dict[str, str]
 
 
 def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
@@ -294,7 +313,7 @@ def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
     keys = set(raw)
     if missing := REQUIRED_INSTANCE_KEYS - keys:
         raise InstanceRefused(f"instance is missing required key(s): {sorted(missing)}")
-    if unknown := keys - REQUIRED_INSTANCE_KEYS:
+    if unknown := keys - REQUIRED_INSTANCE_KEYS - OPTIONAL_INSTANCE_KEYS:
         raise InstanceRefused(f"instance carries unknown key(s): {sorted(unknown)}")
 
     if raw["instance_kind"] != INSTANCE_KIND:
@@ -308,6 +327,7 @@ def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
         raw["snapshot_version"], raw["bundle_sha256"])
     geographies = validate_geographies(raw["geographies"])
     baselines = validate_baselines(raw["aggregate_baselines"])
+    substitutions = validate_substitutions(raw.get("substitutions"))
 
     bound = raw["staleness_bound_days"]
     if isinstance(bound, bool) or not isinstance(bound, int) or bound <= 0:
@@ -348,10 +368,27 @@ def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
             f"staleness_bound_days of {bound}. Its aggregate counts and selected "
             f"geographies were measured over a window that has since moved; "
             f"re-run qualify against the artifact rather than reusing them")
-    if not isinstance(raw["qualification"], dict) or not raw["qualification"]:
+    qualification = raw["qualification"]
+    if not isinstance(qualification, dict):
+        raise InstanceRefused("qualification must be a JSON object")
+    supplied = set(qualification)
+    if missing := REQUIRED_QUALIFICATION_KEYS - supplied:
         raise InstanceRefused(
-            "qualification must record, per placeholder, the rule it satisfied; "
-            "an Instance that does not say how it qualified qualifies nothing")
+            f"qualification is missing {sorted(missing)}; an Instance must "
+            f"record, for EVERY case whose geography it fixes, the rule that "
+            f"geography satisfied. A partial block says some cases qualified "
+            f"and is silent about the rest, which qualifies nothing")
+    if unknown := supplied - REQUIRED_QUALIFICATION_KEYS:
+        raise InstanceRefused(
+            f"qualification carries unknown key(s): {sorted(unknown)}; a typo "
+            f"here would leave the case it was meant to qualify unqualified "
+            f"while the block looked complete")
+    for key in sorted(REQUIRED_QUALIFICATION_KEYS):
+        entry = qualification[key]
+        if not isinstance(entry, dict) or not str(entry.get("rule", "")).strip():
+            raise InstanceRefused(
+                f"qualification[{key}] records no rule; naming a geography is "
+                f"not qualifying it")
 
     # `governs_run` is what ties this Instance to one Stage 1 run. Left blank or
     # left as the placeholder `qualify` wrote, it ties it to nothing -- and an
@@ -389,6 +426,7 @@ def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
         qualification=dict(raw["qualification"]),
         staleness_bound_days=int(bound),
         governs_run=str(raw["governs_run"]),
+        substitutions=dict(substitutions),
     )
 
 
@@ -497,7 +535,8 @@ def _type_mix(m: Materialized, sector: str, *, months: int,
     return {str(r[0]): int(r[1]) for r in rows}
 
 
-def qualify(m: Materialized, *, today: Optional[date] = None) -> dict[str, Any]:
+def qualify(m: Materialized, *, today: Optional[date] = None,
+            definitional: Optional[dict[str, str]] = None) -> dict[str, Any]:
     """Select the seven placeholders and measure the three baselines.
 
     Read-only throughout: aggregate COUNT and GROUP BY only, no download, no
@@ -505,15 +544,19 @@ def qualify(m: Materialized, *, today: Optional[date] = None) -> dict[str, Any]:
     **candidate** Instance for review, never a runtime input.
     """
     today = today or date.today()
+    definitional = {**DEFINITIONAL_GEOGRAPHIES, **(definitional or {})}
     qualification: dict[str, Any] = {}
     geo: dict[str, str] = {}
 
     # -- the three declared baselines, over the whole artifact ---------------
-    s1 = _aggregate(m, geography_sql="outcode = ?", geo_params=["B5"],
+    s1 = _aggregate(m, geography_sql="outcode = ?",
+                    geo_params=[definitional["S1_district"]],
                     months=24, today=today)
-    s3 = _aggregate(m, geography_sql="sector = ?", geo_params=["B5 4"],
+    s3 = _aggregate(m, geography_sql="sector = ?",
+                    geo_params=[definitional["S3_sector"]],
                     months=24, today=today)
-    s9 = _aggregate(m, geography_sql="sector = ?", geo_params=["B5 4"],
+    s9 = _aggregate(m, geography_sql="sector = ?",
+                    geo_params=[definitional["S3_sector"]],
                     months=24, today=today, category=None)
     baselines = {"S1_full": s1, "S3_full": s3, "S9_full": s9}
 
@@ -524,22 +567,39 @@ def qualify(m: Materialized, *, today: Optional[date] = None) -> dict[str, Any]:
     # never checking the neighbour was qualifying neither: a B50 with no rows
     # makes S1 a test that cannot fail and S2 a case with nothing in it.
     unqualified_definitional: list[str] = []
-    s2_full = _aggregate(m, geography_sql="outcode = ?", geo_params=["B50"],
+    requires_adjudication: list[str] = []
+    s2_full = _aggregate(m, geography_sql="outcode = ?",
+                         geo_params=[definitional["S2_neighbour_district"]],
                          months=24, today=today)
     ratio = (s2_full / s1) if s1 else 0.0
     qualification["S1_district"] = {
         "rule": ("the longer neighbouring outcode holds comparable or greater "
-                 f"volume, operationalised as at least "
-                 f"{MIN_NEIGHBOUR_VOLUME_RATIO:.0%} of this district's rows"),
+                 "volume (Definition section 4)"),
+        "geography": definitional["S1_district"],
         "measured_rows": s1,
+        "neighbour_geography": definitional["S2_neighbour_district"],
         "measured_neighbour_rows": s2_full,
         "measured_neighbour_ratio": round(ratio, 4),
-        "threshold_is_an_operationalisation": True,
+        "comparable_or_greater": bool(s1 > 0 and ratio >= NEIGHBOUR_COMPARABLE_RATIO),
     }
-    if s1 <= 0 or ratio < MIN_NEIGHBOUR_VOLUME_RATIO:
+    if s1 <= 0:
+        # No rows in the district at all: nothing to qualify, and no judgement
+        # to refer.
         unqualified_definitional.append("S1_district")
+    elif ratio < NEIGHBOUR_COMPARABLE_RATIO:
+        # Below the literal rule. NOT auto-failed and NOT auto-passed: whether
+        # this artifact's neighbour volume is "comparable" is the owner's
+        # judgement, and the Definition offers accept-or-substitute. This tool
+        # supplies the measurement and stops there.
+        requires_adjudication.append("S1_district")
+        qualification["S1_district"]["adjudication"] = (
+            f"the neighbour holds {ratio:.1%} of the district's rows, which is "
+            f"below the literal 'comparable or greater'. Accept it for this "
+            f"artifact, or substitute a geography with recorded justification "
+            f"(Definition section 4). This tool does not decide.")
     qualification["S2_district"] = {
         "rule": "non-empty under frozen parameters",
+        "geography": definitional["S2_neighbour_district"],
         "measured_rows": s2_full,
     }
     if s2_full <= 0:
@@ -675,6 +735,14 @@ def qualify(m: Materialized, *, today: Optional[date] = None) -> dict[str, Any]:
         # choosing a different geography -- B5/B50 IS the contamination
         # boundary the corpus is built around.
         "unqualified_definitional_cases": sorted(unqualified_definitional),
+        # Measured, not decided. A judgement the Definition reserves to the
+        # owner, with the figures needed to make it.
+        "requires_owner_adjudication": sorted(requires_adjudication),
+        "substitution_route": (
+            "Definition section 4 permits substituting a definitional geography "
+            "with recorded justification. Supply all of "
+            f"{sorted(DEFINITIONAL_GEOGRAPHIES)} under the Instance's "
+            "`substitutions` key, each with a `geography` and a `justification`."),
         "unqualified_placeholders": sorted(
             {"S4_thin", "S5_dense", "S6_unit", "S7_type_weak", "S8_type_strong",
              "S11_provisional_empty", "S13_empty_unit"} - set(geo)),
@@ -1127,7 +1195,7 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
 
     identity = materialized.identity()
     started_at = time.monotonic()
-    corpus = cases(instance.geographies)
+    corpus = cases(instance.geographies, instance.substitutions)
 
     results: list[dict[str, Any]] = []
     snapshot_errors: list[dict[str, Any]] = []
@@ -1183,10 +1251,22 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
                 midnight["unrecoverable"] = True
                 results.append(record)
                 raise
-            except Exception as exc:  # noqa: BLE001 -- recorded, never propagated
+            except Exception as exc:  # noqa: BLE001 -- recorded, then stops the run
+                # Recorded and then fatal. "Zero snapshot errors on the frozen
+                # corpus" is already unreachable at this point, so every later
+                # case is work whose result cannot change the verdict -- and
+                # the live call this case would otherwise make is a request to
+                # HM Land Registry for a comparison that can no longer happen.
+                # The partial report is still written; a run that stopped for a
+                # reason is evidence about that reason.
                 snapshot_errors.append({"shape": case.shape,
                                         "error": f"{type(exc).__name__}: {exc}"})
                 record["snapshot_error"] = f"{type(exc).__name__}: {exc}"
+                results.append(record)
+                raise RunAborted(
+                    f"{case.shape}: the snapshot arm failed "
+                    f"({type(exc).__name__}: {exc}); no live call is made for "
+                    f"this case and no later case runs")
 
             live_response = None
             check_live_budget(live_calls, limits, len(corpus), case.shape)
@@ -1203,10 +1283,15 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
                     midnight["unrecoverable"] = True
                     results.append(record)
                     raise
-                except Exception as exc:  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001 -- recorded, then stops
                     live_errors.append({"shape": case.shape,
                                         "error": f"{type(exc).__name__}: {exc}"})
                     record["live_error"] = f"{type(exc).__name__}: {exc}"
+                    results.append(record)
+                    raise RunAborted(
+                        f"{case.shape}: the live arm failed "
+                        f"({type(exc).__name__}: {exc}); completeness is already "
+                        f"lost, so no later case runs")
             time.sleep(limits.live_delay_seconds)
 
             if snap_response is not None and live_response is not None:
@@ -1593,6 +1678,13 @@ def main(argv: Optional[list[str]] = None) -> int:
                 failed = True
             if not out["baselines_satisfy_their_relations"]:
                 print(f"BASELINES UNUSABLE: {out['baselines_refusal']}")
+                failed = True
+            if out["requires_owner_adjudication"]:
+                # Not a failure of the artifact, and not something this tool may
+                # settle. Non-zero all the same: a candidate awaiting a
+                # judgement is not a candidate ready to run.
+                print("REQUIRES OWNER ADJUDICATION: "
+                      f"{out['requires_owner_adjudication']}")
                 failed = True
             return 1 if failed else 0
 

--- a/tools/ppd_snapshot/stage1_shadow.py
+++ b/tools/ppd_snapshot/stage1_shadow.py
@@ -872,7 +872,7 @@ class RunLimits:
     """
 
     live_delay_seconds: float = 2.0
-    latency_repeats: int = 30
+    latency_repeats: int = REQUIRED_LATENCY_REPEATS
     max_live_per_case: int = 1
     deadline_seconds: float = 3600.0
     min_available_memory_bytes: int = 256 * 1024 * 1024
@@ -1428,7 +1428,8 @@ def build_parser() -> argparse.ArgumentParser:
     c.add_argument("--cache-dir", default=None)
     c.add_argument("--instance", required=True, type=Path)
     c.add_argument("--report", required=True, type=Path)
-    c.add_argument("--latency-repeats", type=int, default=30)
+    c.add_argument("--latency-repeats", type=int,
+                   default=REQUIRED_LATENCY_REPEATS)
     c.add_argument("--max-live-per-case", type=int, default=1)
     c.add_argument("--live-delay-seconds", type=float, default=2.0)
     c.add_argument("--deadline-seconds", type=float, default=3600.0)

--- a/tools/ppd_snapshot/stage1_shadow.py
+++ b/tools/ppd_snapshot/stage1_shadow.py
@@ -64,7 +64,9 @@ from tools.ppd_snapshot.corpus import (
     InstanceRefused,
     cases,
     derived_from_date,
+    geography_violations,
     ids as _ids,
+    is_contaminated,
     outcodes as _outcodes,
     returned_date_bounds,
     snapshot_invariants,
@@ -119,6 +121,16 @@ REQUIRED_CASES = 13
 #: it is measured against by passing a smaller number.
 REQUIRED_LATENCY_REPEATS = 30
 REQUIRED_LATENCY_OBSERVATIONS = REQUIRED_CASES * REQUIRED_LATENCY_REPEATS
+
+#: How "the longer neighbouring outcode holds comparable or greater volume"
+#: (Definition section 4, S1) is made executable. The Definition states the rule
+#: qualitatively; some threshold has to exist for a tool to check it, so this
+#: one is named here rather than buried, and the measured ratio is recorded
+#: alongside it so a reviewer can judge the operationalisation rather than
+#: trust it. The point of the rule is that B50 must carry enough volume for
+#: B50-in-B5 contamination to be visible at all: against a near-empty
+#: neighbour, a clean S1 result would prove nothing.
+MIN_NEIGHBOUR_VOLUME_RATIO = 0.10
 
 #: The placeholder `qualify` writes into a candidate Instance. An Instance still
 #: carrying it has not been through the review the field exists to record.
@@ -301,6 +313,41 @@ def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
     if isinstance(bound, bool) or not isinstance(bound, int) or bound <= 0:
         raise InstanceRefused(
             f"staleness_bound_days is {bound!r}, not a positive number of days")
+
+    # The bound is enforced, not merely recorded. An Instance carries measured
+    # aggregate counts and selected geographies; the artifact is fixed, but the
+    # frozen window moves forward every day, so counts qualified months ago
+    # describe a query nobody now runs. Validating the field and never checking
+    # it against the calendar would let a stale Instance qualify a Stage 1 run
+    # while looking entirely well-formed.
+    raw_qualified_at = raw["qualified_at"]
+    # The round-trip is the load-bearing check, and it is the same rule
+    # `validate_date_range` applies on the routing path. `fromisoformat` already
+    # rejects a non-string, but it ACCEPTS spellings that are not the one the
+    # Instance claims to carry: "20260901" parses, and so does the ISO week date
+    # "2026-W36-2", which resolves silently to a real and quite different-looking
+    # day. Requiring the value to round-trip is what keeps one spelling in the
+    # field an operator reads.
+    try:
+        qualified_on = date.fromisoformat(raw_qualified_at)
+        if qualified_on.isoformat() != raw_qualified_at:
+            raise ValueError("not canonical")
+    except (TypeError, ValueError) as exc:
+        raise InstanceRefused(
+            f"qualified_at {raw_qualified_at!r} is not a canonical ISO date "
+            f"(YYYY-MM-DD); an Instance whose age cannot be established cannot "
+            f"be checked against its own staleness bound") from exc
+    age_days = (date.today() - qualified_on).days
+    if age_days < 0:
+        raise InstanceRefused(
+            f"qualified_at {qualified_on.isoformat()} is in the future; the "
+            f"Instance cannot have been qualified against this artifact yet")
+    if age_days > bound:
+        raise InstanceRefused(
+            f"the Instance was qualified {age_days} days ago, beyond its own "
+            f"staleness_bound_days of {bound}. Its aggregate counts and selected "
+            f"geographies were measured over a window that has since moved; "
+            f"re-run qualify against the artifact rather than reusing them")
     if not isinstance(raw["qualification"], dict) or not raw["qualification"]:
         raise InstanceRefused(
             "qualification must record, per placeholder, the rule it satisfied; "
@@ -470,6 +517,34 @@ def qualify(m: Materialized, *, today: Optional[date] = None) -> dict[str, Any]:
                     months=24, today=today, category=None)
     baselines = {"S1_full": s1, "S3_full": s3, "S9_full": s9}
 
+    # -- S1 and S2: definitional, but still qualified ------------------------
+    # `B5` and `B50` are named in the Definition because the boundary is a
+    # definitional choice rather than an artifact property -- but section 4 is
+    # explicit that "an Instance must still qualify them". Measuring S1_full and
+    # never checking the neighbour was qualifying neither: a B50 with no rows
+    # makes S1 a test that cannot fail and S2 a case with nothing in it.
+    unqualified_definitional: list[str] = []
+    s2_full = _aggregate(m, geography_sql="outcode = ?", geo_params=["B50"],
+                         months=24, today=today)
+    ratio = (s2_full / s1) if s1 else 0.0
+    qualification["S1_district"] = {
+        "rule": ("the longer neighbouring outcode holds comparable or greater "
+                 f"volume, operationalised as at least "
+                 f"{MIN_NEIGHBOUR_VOLUME_RATIO:.0%} of this district's rows"),
+        "measured_rows": s1,
+        "measured_neighbour_rows": s2_full,
+        "measured_neighbour_ratio": round(ratio, 4),
+        "threshold_is_an_operationalisation": True,
+    }
+    if s1 <= 0 or ratio < MIN_NEIGHBOUR_VOLUME_RATIO:
+        unqualified_definitional.append("S1_district")
+    qualification["S2_district"] = {
+        "rule": "non-empty under frozen parameters",
+        "measured_rows": s2_full,
+    }
+    if s2_full <= 0:
+        unqualified_definitional.append("S2_district")
+
     # -- S4: thin market, strictly below the threshold ----------------------
     sectors_ranked = _rank(m, "sector", months=24, today=today)
     thin = [(s, n) for s, n in sectors_ranked if 0 < n < THIN_MARKET_THRESHOLD]
@@ -595,6 +670,11 @@ def qualify(m: Materialized, *, today: Optional[date] = None) -> dict[str, Any]:
             "the Definition allows a substituted geography with recorded "
             "justification -- which is an authoring decision, not something "
             "this tool may make."),
+        # Definitional cases that failed their own qualification rule. Kept
+        # separate from the placeholders because they cannot be substituted by
+        # choosing a different geography -- B5/B50 IS the contamination
+        # boundary the corpus is built around.
+        "unqualified_definitional_cases": sorted(unqualified_definitional),
         "unqualified_placeholders": sorted(
             {"S4_thin", "S5_dense", "S6_unit", "S7_type_weak", "S8_type_strong",
              "S11_provisional_empty", "S13_empty_unit"} - set(geo)),
@@ -873,6 +953,11 @@ class RunLimits:
 
     live_delay_seconds: float = 2.0
     latency_repeats: int = REQUIRED_LATENCY_REPEATS
+    #: Enforced, not advisory. The correctness pass takes one live observation
+    #: per case; a value below 1 is refused outright, because a comparison with
+    #: no live arm is not a comparison, and the budget is checked before every
+    #: live call so the bound cannot be exceeded by a later code change without
+    #: the run stopping.
     max_live_per_case: int = 1
     deadline_seconds: float = 3600.0
     min_available_memory_bytes: int = 256 * 1024 * 1024
@@ -885,6 +970,23 @@ class RunLimits:
 #: boundary. A crossing is possible once a day at most; three attempts either
 #: clear it or prove something else is wrong.
 MIDNIGHT_ATTEMPTS = 3
+
+
+def check_live_budget(live_calls: int, limits: "RunLimits", corpus_size: int,
+                      shape: str) -> None:
+    """Refuse a live call that would exceed the run's declared budget.
+
+    Checked before every live observation rather than assumed from the shape of
+    the loop. The loop takes one per case today; this is what makes the bound
+    survive a change that adds another, instead of quietly making more requests
+    to HM Land Registry than the run declared.
+    """
+    budget = limits.max_live_per_case * corpus_size
+    if live_calls >= budget:
+        raise RunAborted(
+            f"the live-call budget of {budget} ({limits.max_live_per_case} per "
+            f"case x {corpus_size} cases) is exhausted at {shape}; a further "
+            f"live observation needs separate authorisation")
 
 
 def _observe(service: Any, case: Case, *,
@@ -975,10 +1077,15 @@ def _arm_record(response: Any, case: Case, observed: str,
     }
 
 
-def _geography_contamination(response: Any, case: Case) -> list[str]:
-    """Outcodes returned that are not the one the case asked for."""
-    requested = case.postcode.split()[0].upper()
-    return [o for o in _outcodes(response.transactions) if o != requested]
+def _geography_contamination(response: Any, case: Case) -> Optional[dict[str, Any]]:
+    """Rows outside the requested geography, judged at the requested level.
+
+    Returns `None` when clean. An outcode-only test would pass a `sector` case
+    handed a neighbouring sector in the same outcode -- which is the sector
+    isolation trap the Definition names in its own right.
+    """
+    violations = geography_violations(case, response.transactions)
+    return violations if is_contaminated(violations) else None
 
 
 def run_compare(*, instance: Stage1Instance, materialized: Materialized,
@@ -1000,6 +1107,20 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
     anomaly, and the partial report is still written.
     """
     from property_core.ppd_service import PPDService
+
+    # Fail fast, before an adapter is used or a single request is made. An
+    # option that silently does nothing is worse than no option: it tells an
+    # operator they have a control they do not have.
+    if limits.max_live_per_case < 1:
+        raise ComparisonRefused(
+            f"max_live_per_case is {limits.max_live_per_case}; the correctness "
+            f"pass needs one live observation per case, and a comparison with "
+            f"no live arm is not a comparison")
+    if limits.latency_repeats < 1:
+        raise ComparisonRefused(
+            f"latency_repeats is {limits.latency_repeats}; a run that takes no "
+            f"latency observation cannot produce the sample the gate is "
+            f"defined over")
 
     live_service = live_service or PPDService()
     snapshot_service = snapshot_service or PPDService(adapter=materialized.adapter)
@@ -1068,6 +1189,7 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
                 record["snapshot_error"] = f"{type(exc).__name__}: {exc}"
 
             live_response = None
+            check_live_budget(live_calls, limits, len(corpus), case.shape)
             with LiveEvidenceCapture() as capture:
                 try:
                     live_calls += 1
@@ -1107,12 +1229,15 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
                     provisional_from=materialized.provisional_from,
                     live_truncation_evidenced=bool(
                         record.get("live_truncation_evidenced"))))
+                # Both arms. Contamination is a defect in whichever source
+                # produced it (Definition section 7), so neither arm is assumed
+                # clean because the other is.
                 for arm, response in (("live", live_response),
                                       ("snapshot", snap_response)):
                     stray = _geography_contamination(response, case)
                     if stray:
                         contamination.append({"shape": case.shape, "arm": arm,
-                                              "unexpected_outcodes": stray})
+                                              **stray})
                 if (limits.stop_on_unclassified
                         and record.get("classification", {}).get("unclassified")):
                     results.append(record)
@@ -1461,6 +1586,10 @@ def main(argv: Optional[list[str]] = None) -> int:
             failed = False
             if out["unqualified_placeholders"]:
                 print(f"UNQUALIFIED placeholders: {out['unqualified_placeholders']}")
+                failed = True
+            if out["unqualified_definitional_cases"]:
+                print("UNQUALIFIED definitional cases: "
+                      f"{out['unqualified_definitional_cases']}")
                 failed = True
             if not out["baselines_satisfy_their_relations"]:
                 print(f"BASELINES UNUSABLE: {out['baselines_refusal']}")

--- a/tools/ppd_snapshot/stage1_shadow.py
+++ b/tools/ppd_snapshot/stage1_shadow.py
@@ -66,6 +66,8 @@ from tools.ppd_snapshot.corpus import (
     derived_from_date,
     ids as _ids,
     outcodes as _outcodes,
+    returned_date_bounds,
+    snapshot_invariants,
     sectors as _sectors,
     validate_artifact_identity,
     validate_baselines,
@@ -107,6 +109,20 @@ THIN_MARKET_THRESHOLD = 5
 
 #: The residential default the corpus selects by omitting `property_type`.
 RESIDENTIAL_TYPES = ("F", "D", "S", "T")
+
+#: The frozen corpus is thirteen cases. A report covering fewer is not a
+#: smaller Stage 1 result; it is not a Stage 1 result.
+REQUIRED_CASES = 13
+
+#: The latency sample the gate is defined over: every case repeated this many
+#: times. Fixed rather than taken from the CLI, so a run cannot lower the bar
+#: it is measured against by passing a smaller number.
+REQUIRED_LATENCY_REPEATS = 30
+REQUIRED_LATENCY_OBSERVATIONS = REQUIRED_CASES * REQUIRED_LATENCY_REPEATS
+
+#: The placeholder `qualify` writes into a candidate Instance. An Instance still
+#: carrying it has not been through the review the field exists to record.
+GOVERNS_RUN_PLACEHOLDER = "<fill in: the Stage 1 run this Instance governs>"
 
 
 class ComparisonRefused(RuntimeError):
@@ -289,6 +305,20 @@ def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
         raise InstanceRefused(
             "qualification must record, per placeholder, the rule it satisfied; "
             "an Instance that does not say how it qualified qualifies nothing")
+
+    # `governs_run` is what ties this Instance to one Stage 1 run. Left blank or
+    # left as the placeholder `qualify` wrote, it ties it to nothing -- and an
+    # Instance nobody named a run for has not been through the review that field
+    # exists to record.
+    governs = raw["governs_run"]
+    if not isinstance(governs, str) or not governs.strip():
+        raise InstanceRefused(
+            "governs_run is blank; an Instance must name the Stage 1 run it "
+            "governs")
+    if governs.strip() == GOVERNS_RUN_PLACEHOLDER or governs.strip().startswith("<"):
+        raise InstanceRefused(
+            f"governs_run is still the placeholder {governs.strip()!r}; the "
+            f"candidate Instance has not been reviewed and named")
 
     # Binding. An Instance that is internally valid but describes a different
     # artifact would produce a report whose provenance is a fiction.
@@ -544,7 +574,7 @@ def qualify(m: Materialized, *, today: Optional[date] = None) -> dict[str, Any]:
         "qualified_at": today.isoformat(),
         "qualification": qualification,
         "staleness_bound_days": 45,
-        "governs_run": "<fill in: the Stage 1 run this Instance governs>",
+        "governs_run": GOVERNS_RUN_PLACEHOLDER,
     }
     return {
         "kind": "stage1_qualification_candidate",
@@ -663,10 +693,17 @@ def classify(*, only_live_months: dict[str, int], only_snapshot_months: dict[str
              live_truncation_evidenced: bool) -> dict[str, Any]:
     """Definition section 7's four classes, and nothing else.
 
-    Class 3 (**live truncation or ordering**) is only ever assigned on
-    evidence -- `raw_bindings_returned == fetch_limit`, or a page saturated at
-    `limit`. The Definition says so explicitly, because "the snapshot returned
-    more, so live must have truncated" is an assumption dressed as a finding.
+    Class 3 (**live truncation or ordering**) is assigned **only** from
+    captured live transport evidence -- `raw_bindings_returned` against
+    `fetch_limit`, which is a fact about what the upstream window returned.
+
+    Page saturation is deliberately NOT evidence, on either side. A live page
+    at `limit` says our own presentation limit was reached, not that the
+    upstream window was; a saturated *snapshot* page says nothing whatever
+    about live. Treating either as evidence is the "the snapshot returned more,
+    so live must have truncated" assumption wearing a taxonomy label, which is
+    exactly what the Definition forbids. Saturation is still recorded, as
+    context an operator may weigh -- but it cannot classify anything.
 
     Class 2 (**later A/C/D revision**) cannot be evidenced from these two
     sources at all: confirming it needs the monthly change records published
@@ -674,7 +711,10 @@ def classify(*, only_live_months: dict[str, int], only_snapshot_months: dict[str
     `operator_confirmation_required`.
     """
     prov = provisional_from or ""
-    truncation = live_truncation_evidenced or live_saturated or snapshot_saturated
+    # Captured transport evidence, and nothing else. With no evidence the
+    # divergence stays unclassified and blocks exit -- which is the fail-closed
+    # direction: an unexplained difference is a question, not a pass.
+    truncation = live_truncation_evidenced
 
     provisional_tail_lag = 0
     unclassified = 0
@@ -711,9 +751,14 @@ def classify(*, only_live_months: dict[str, int], only_snapshot_months: dict[str
         "unclassified": unclassified,
         "operator_confirmation_required": later_acd,
         "truncation_evidence": {
-            "live_raw_bindings_equals_fetch_limit": live_truncation_evidenced,
-            "live_page_saturated": live_saturated,
-            "snapshot_page_saturated": snapshot_saturated,
+            # The only thing that may classify class 3.
+            "live_raw_bindings_reached_fetch_limit": live_truncation_evidenced,
+            # Context for an operator, explicitly not evidence. Recorded so a
+            # reader can see saturation was considered and rejected as a basis.
+            "context_not_evidence": {
+                "live_page_saturated": live_saturated,
+                "snapshot_page_saturated": snapshot_saturated,
+            },
         },
     }
 
@@ -835,34 +880,66 @@ class RunLimits:
     stop_on_unclassified: bool = True
 
 
-def _observe(service: Any, case: Case) -> tuple[Any, str, float]:
-    """One comps call, with the calendar date it was taken on and its latency.
+#: Bounded retry for an observation that straddles midnight. Three, matching
+#: the local rehearsal, so the two tools behave the same way at the same
+#: boundary. A crossing is possible once a day at most; three attempts either
+#: clear it or prove something else is wrong.
+MIDNIGHT_ATTEMPTS = 3
 
-    The date is captured either side and compared by the caller: `comps`
-    derives its window from `date.today()`, so an observation straddling
-    midnight describes a different window from the one recorded.
+
+def _observe(service: Any, case: Case, *,
+             attempts: int = 1) -> tuple[Any, str, int, float]:
+    """One comps call, guaranteed to lie inside a single calendar date.
+
+    `comps` derives its window from `date.today()`, so an observation that
+    straddles midnight silently describes a different window from the one
+    recorded. Such an observation is **never skipped**: skipping it would leave
+    a report claiming thirteen cases while holding twelve, and a latency sample
+    short of its declared size. It is retried where retrying is free, and
+    otherwise it aborts the run.
+
+    `attempts` is 1 by default -- the caller decides whether a retry is
+    affordable. The snapshot arm can retry for nothing; the live arm cannot,
+    because a retry there is another request to HM Land Registry and the
+    correctness pass is budgeted at one per case.
     """
-    before = date.today()
-    started = time.monotonic()
-    response = service.comps(
-        postcode=case.postcode,
-        search_level=case.search_level,
-        months=case.months,
-        property_type=case.property_type,
-        transaction_category=case.transaction_category,
-        filter_outliers=False,
-        limit=LIMIT,
-        auto_escalate=True,
-    )
-    elapsed_ms = (time.monotonic() - started) * 1000.0
-    after = date.today()
-    if before != after:
-        raise MidnightCrossed(f"{case.shape}: observation straddled midnight")
-    return response, before.isoformat(), elapsed_ms
+    retries = 0
+    for _ in range(max(1, attempts)):
+        before = date.today()
+        started = time.monotonic()
+        response = service.comps(
+            postcode=case.postcode,
+            search_level=case.search_level,
+            months=case.months,
+            property_type=case.property_type,
+            transaction_category=case.transaction_category,
+            filter_outliers=False,
+            limit=LIMIT,
+            auto_escalate=True,
+        )
+        elapsed_ms = (time.monotonic() - started) * 1000.0
+        after = date.today()
+        if before == after:
+            return response, before.isoformat(), retries, elapsed_ms
+        retries += 1
+    raise MidnightCrossed(
+        f"{case.shape}: no same-date observation in {attempts} attempt(s); the "
+        f"window recorded for this case would not describe the query that ran",
+        retries=retries)
 
 
-class MidnightCrossed(RuntimeError):
-    """An observation could not be taken within one calendar date."""
+class MidnightCrossed(RunAborted):
+    """An observation could not be taken within one calendar date.
+
+    A subclass of `RunAborted`, deliberately: a crossing that survives its
+    retries stops the run and writes a failed report. It is never absorbed as
+    an exclusion, because a report that quietly dropped an observation is a
+    report whose totals do not mean what they say.
+    """
+
+    def __init__(self, message: str, *, retries: int = 0) -> None:
+        super().__init__(message)
+        self.retries = retries
 
 
 def _provenance_source(response: Any) -> Optional[str]:
@@ -885,6 +962,8 @@ def _arm_record(response: Any, case: Case, observed: str,
         "sectors_returned": _sectors(response.transactions),
         "warning_classes": _warning_classes(tuple(response.warnings or ())),
         "saturated_at_limit": response.count == LIMIT,
+        "returned_date_from": returned_date_bounds(response.transactions)[0],
+        "returned_date_to": returned_date_bounds(response.transactions)[1],
         "source": _provenance_source(response),
         "observed_at": observed,
         "derived_from_date": derived_from_date(date.fromisoformat(observed),
@@ -933,7 +1012,8 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
     snapshot_errors: list[dict[str, Any]] = []
     live_errors: list[dict[str, Any]] = []
     contamination: list[dict[str, Any]] = []
-    excluded = {"midnight": 0, "health": 0, "memory": 0}
+    excluded = {"health": 0, "memory": 0}
+    midnight = {"retries": 0, "unrecoverable": False, "pair_date_mismatches": 0}
     aborted: Optional[str] = None
     live_calls = 0
 
@@ -963,40 +1043,65 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
                 "artifact": dict(identity),
             }
 
+            # The snapshot arm may retry a midnight crossing: it costs nothing
+            # but a local query. The live arm may not -- a retry there is
+            # another request to HM Land Registry, and the correctness pass is
+            # budgeted at one per case. Either way a surviving crossing aborts.
             snap_response = None
             try:
-                snap_response, snap_observed, snap_ms = _observe(snapshot_service, case)
+                snap_response, snap_observed, retries, snap_ms = _observe(
+                    snapshot_service, case, attempts=MIDNIGHT_ATTEMPTS)
+                midnight["retries"] += retries
                 record["snapshot"] = _arm_record(snap_response, case,
                                                  snap_observed, snap_ms)
+                record["snapshot_invariants"] = snapshot_invariants(
+                    case, snap_response, getattr(snap_response, "provenance", None),
+                    record["snapshot"]["warning_classes"])
             except MidnightCrossed as exc:
-                excluded["midnight"] += 1
-                record["excluded"] = str(exc)
+                midnight["retries"] += exc.retries
+                midnight["unrecoverable"] = True
+                results.append(record)
+                raise
             except Exception as exc:  # noqa: BLE001 -- recorded, never propagated
                 snapshot_errors.append({"shape": case.shape,
                                         "error": f"{type(exc).__name__}: {exc}"})
                 record["snapshot_error"] = f"{type(exc).__name__}: {exc}"
 
             live_response = None
-            if live_calls < limits.max_live_per_case * len(corpus):
-                with LiveEvidenceCapture() as capture:
-                    try:
-                        live_calls += 1
-                        live_response, live_observed, live_ms = _observe(
-                            live_service, case)
-                        record["live"] = _arm_record(live_response, case,
-                                                     live_observed, live_ms)
-                        record["live"]["transport_evidence"] = dict(capture.last)
-                        record["live_truncation_evidenced"] = capture.truncation_evidenced
-                    except MidnightCrossed as exc:
-                        excluded["midnight"] += 1
-                        record["excluded"] = str(exc)
-                    except Exception as exc:  # noqa: BLE001
-                        live_errors.append({"shape": case.shape,
-                                            "error": f"{type(exc).__name__}: {exc}"})
-                        record["live_error"] = f"{type(exc).__name__}: {exc}"
-                time.sleep(limits.live_delay_seconds)
+            with LiveEvidenceCapture() as capture:
+                try:
+                    live_calls += 1
+                    live_response, live_observed, _, live_ms = _observe(
+                        live_service, case)
+                    record["live"] = _arm_record(live_response, case,
+                                                 live_observed, live_ms)
+                    record["live"]["transport_evidence"] = dict(capture.last)
+                    record["live_truncation_evidenced"] = capture.truncation_evidenced
+                except MidnightCrossed:
+                    midnight["unrecoverable"] = True
+                    results.append(record)
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    live_errors.append({"shape": case.shape,
+                                        "error": f"{type(exc).__name__}: {exc}"})
+                    record["live_error"] = f"{type(exc).__name__}: {exc}"
+            time.sleep(limits.live_delay_seconds)
 
             if snap_response is not None and live_response is not None:
+                # Both arms must describe the same day. `comps` derives its
+                # window from `date.today()`, so a pair straddling midnight is
+                # two different questions being compared as though they were
+                # one -- which no amount of downstream analysis can detect.
+                if record["snapshot"]["observed_at"] != record["live"]["observed_at"]:
+                    midnight["pair_date_mismatches"] += 1
+                    midnight["unrecoverable"] = True
+                    results.append(record)
+                    raise RunAborted(
+                        f"{case.shape}: the snapshot arm was observed on "
+                        f"{record['snapshot']['observed_at']} and the live arm on "
+                        f"{record['live']['observed_at']}; the pair straddles "
+                        f"midnight and compares two different windows")
+
                 record.update(_compare_arms(
                     case=case, live=live_response, snap=snap_response,
                     provisional_from=materialized.provisional_from,
@@ -1024,16 +1129,25 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
             _guard(f"latency/{repeat + 1}")
             for case in corpus:
                 try:
-                    _, _, elapsed = _observe(snapshot_service, case)
-                except MidnightCrossed:
-                    excluded["midnight"] += 1
-                    continue
+                    _, _, retries, elapsed = _observe(
+                        snapshot_service, case, attempts=MIDNIGHT_ATTEMPTS)
+                    midnight["retries"] += retries
+                except MidnightCrossed as exc:
+                    midnight["retries"] += exc.retries
+                    midnight["unrecoverable"] = True
+                    raise
                 except Exception as exc:  # noqa: BLE001
                     snapshot_errors.append({"shape": case.shape,
                                             "error": f"{type(exc).__name__}: {exc}"})
                     continue
                 latency_ms.append(elapsed)
                 per_case.setdefault(case.shape, []).append(elapsed)
+
+        # One last guard AFTER the final observation. Without it the run could
+        # complete its last case on a Machine that had already gone unhealthy
+        # or run out of memory, and report a clean pass measured under
+        # conditions nobody checked.
+        _guard("final")
     except RunAborted as exc:
         aborted = str(exc)
         latency_ms = locals().get("latency_ms", [])  # type: ignore[assignment]
@@ -1043,7 +1157,7 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
         instance=instance, identity=identity, limits=limits, results=results,
         latency_ms=latency_ms, per_case=per_case, snapshot_errors=snapshot_errors,
         live_errors=live_errors, contamination=contamination, excluded=excluded,
-        aborted=aborted, live_calls=live_calls)
+        midnight=midnight, corpus=corpus, aborted=aborted, live_calls=live_calls)
     report_path.parent.mkdir(parents=True, exist_ok=True)
     report_path.write_text(json.dumps(report, indent=2, sort_keys=False))
     return report
@@ -1102,9 +1216,16 @@ def _build_report(*, instance: Stage1Instance, identity: dict[str, Any],
                   snapshot_errors: list[dict[str, Any]],
                   live_errors: list[dict[str, Any]],
                   contamination: list[dict[str, Any]],
-                  excluded: dict[str, int], aborted: Optional[str],
+                  excluded: dict[str, int], midnight: dict[str, Any],
+                  corpus: list[Case], aborted: Optional[str],
                   live_calls: int) -> dict[str, Any]:
-    """The Stage 1 report, and its verdict against each exit criterion."""
+    """The Stage 1 report, and its verdict against each exit criterion.
+
+    Every criterion here can only move the verdict towards failure. There is no
+    path by which a missing observation, an absent arm, a short latency sample
+    or an unconfirmed classification produces a pass -- absence is never
+    evidence of compliance.
+    """
     unclassified = sum(r.get("classification", {}).get("unclassified", 0)
                        for r in results)
     confirmation = sum(
@@ -1117,20 +1238,76 @@ def _build_report(*, instance: Stage1Instance, identity: dict[str, Any],
                         for r in results)
     compared = [r for r in results if "diff" in r]
 
+    # -- completeness ---------------------------------------------------
+    expected = [c.shape for c in corpus]
+    missing_snapshot = [r["shape"] for r in results if "snapshot" not in r]
+    missing_live = [r["shape"] for r in results if "live" not in r]
+    never_reached = sorted(set(expected) - {r["shape"] for r in results})
+    complete = (len(compared) == REQUIRED_CASES
+                and len(results) == REQUIRED_CASES
+                and not missing_snapshot and not missing_live
+                and not never_reached and not live_errors and not snapshot_errors
+                and not midnight["unrecoverable"]
+                and not midnight["pair_date_mismatches"])
+
+    # -- corpus invariants (Definition section 3 and the case intents) ---
+    invariant_failures = [
+        {"shape": r["shape"],
+         "failed": sorted(k for k, v in r["snapshot_invariants"].items() if not v)}
+        for r in results
+        if r.get("snapshot_invariants")
+        and not all(r["snapshot_invariants"].values())]
+    invariants_checked = sum(len(r.get("snapshot_invariants", {})) for r in results)
+
+    # -- latency --------------------------------------------------------
     latency = latency_summary(latency_ms)
     p95 = latency["p95_ms"]
+    short_cases = sorted(
+        {shape for shape in expected
+         if len(per_case.get(shape, [])) != REQUIRED_LATENCY_REPEATS})
+    sample_complete = (latency["n"] == REQUIRED_LATENCY_OBSERVATIONS
+                       and not short_cases)
+    if not sample_complete:
+        latency_verdict = "insufficient_evidence"
+    elif p95 is not None and p95 < 1000.0:
+        latency_verdict = "pass"
+    else:
+        latency_verdict = "fail"
 
     criteria = {
+        "all_thirteen_cases_compared": {
+            "passed": complete,
+            "cases_recorded": len(results),
+            "cases_compared": len(compared),
+            "required": REQUIRED_CASES,
+            "cases_missing_snapshot_arm": missing_snapshot,
+            "cases_missing_live_arm": missing_live,
+            "cases_never_reached": never_reached,
+            "live_errors": len(live_errors),
+            "snapshot_errors": len(snapshot_errors),
+            "note": ("the frozen corpus is thirteen cases with two arms each; a "
+                     "report covering fewer is not a smaller Stage 1 result, it "
+                     "is not a Stage 1 result"),
+        },
+        "corpus_invariants_hold": {
+            "passed": not invariant_failures and complete,
+            "assertions_checked": invariants_checked,
+            "failures": invariant_failures,
+            "note": ("Definition section 3's universal invariants and each "
+                     "shape's intent, asserted on the snapshot arm; a case "
+                     "reporting sample_complete true is a defect, not a "
+                     "divergence"),
+        },
         "zero_unexplained_false_empties": {
-            "passed": not false_empties or unclassified == 0,
+            "passed": (not false_empties or unclassified == 0) and complete,
             "false_empty_shapes": false_empties,
             "note": ("a false empty is only a failure when it is unexplained; "
                      "these are checked against the classification below"),
         },
         "zero_geography_contamination": {
-            "passed": not contamination, "findings": contamination},
+            "passed": not contamination and complete, "findings": contamination},
         "field_equality_on_shared_ids": {
-            "passed": mismatch_rows == 0 and not vacuous,
+            "passed": mismatch_rows == 0 and not vacuous and complete,
             "mismatch_rows": mismatch_rows,
             "vacuous_comparison_shapes": vacuous,
             "note": ("a shape listed under vacuous_comparison_shapes shared no "
@@ -1139,20 +1316,37 @@ def _build_report(*, instance: Stage1Instance, identity: dict[str, Any],
                      "reported as a failure, not a pass"),
         },
         "every_divergence_classified": {
-            "passed": unclassified == 0, "unclassified": unclassified,
+            "passed": unclassified == 0 and complete, "unclassified": unclassified,
+            "note": "an unclassified divergence blocks exit",
+        },
+        "no_unconfirmed_classifications": {
+            # Blocking, not advisory. "Later A/C/D revision" is a PROPOSED
+            # class: confirming one needs the monthly change records published
+            # after the build, which this comparison cannot see. A verdict that
+            # passed while carrying proposals would be recording a guess as a
+            # result.
+            "passed": confirmation == 0,
             "operator_confirmation_required": confirmation,
             "note": ("later A/C/D revision cannot be evidenced from these two "
-                     "sources; it is proposed, not asserted, and the count "
-                     "above is what an operator must confirm"),
+                     "sources; while any remain proposed, Stage 1 cannot exit "
+                     "on this report alone -- external confirmation is a "
+                     "separately authorised step"),
         },
         "zero_snapshot_errors": {
             "passed": not snapshot_errors, "errors": snapshot_errors},
         "p95_under_one_second": {
-            "passed": p95 is not None and p95 < 1000.0,
+            "passed": latency_verdict == "pass",
+            "verdict": latency_verdict,
             "p95_ms": p95, "n": latency["n"],
+            "required_observations": REQUIRED_LATENCY_OBSERVATIONS,
+            "required_repeats_per_case": REQUIRED_LATENCY_REPEATS,
+            "cases_short_of_the_required_repeats": short_cases,
             "criterion": ("p95 < 1 second on the deployed production Machine "
                           "and selected artifact, measured across the frozen "
                           "corpus request mix (governing spec rev 10)"),
+            "note": ("a partial sample is insufficient_evidence, never a pass: "
+                     "a percentile over fewer observations than the gate is "
+                     "defined over is a different measurement"),
         },
     }
 
@@ -1190,6 +1384,7 @@ def _build_report(*, instance: Stage1Instance, identity: dict[str, Any],
             "live_calls_made": live_calls,
         },
         "excluded": dict(excluded),
+        "midnight": dict(midnight),
         "aborted": aborted,
         "cases_total": len(results),
         "cases_compared": len(compared),
@@ -1256,12 +1451,20 @@ def main(argv: Optional[list[str]] = None) -> int:
             out = qualify(materialized)
             args.out.parent.mkdir(parents=True, exist_ok=True)
             args.out.write_text(json.dumps(out, indent=2, sort_keys=False))
-            unqualified = out["unqualified_placeholders"]
             print(f"candidate instance written to {args.out}")
-            if unqualified:
-                print(f"UNQUALIFIED placeholders: {unqualified}")
-                return 1
-            return 0
+            # Non-zero on an unusable candidate. Printing a warning and exiting
+            # 0 would let a scripted run treat "these baselines contradict the
+            # relation they exist to establish" as success, and the refusal
+            # would then surface much later, at load, after the Instance had
+            # been authored and reviewed.
+            failed = False
+            if out["unqualified_placeholders"]:
+                print(f"UNQUALIFIED placeholders: {out['unqualified_placeholders']}")
+                failed = True
+            if not out["baselines_satisfy_their_relations"]:
+                print(f"BASELINES UNUSABLE: {out['baselines_refusal']}")
+                failed = True
+            return 1 if failed else 0
 
         try:
             instance = load_instance(args.instance, materialized)

--- a/tools/ppd_snapshot/stage1_shadow.py
+++ b/tools/ppd_snapshot/stage1_shadow.py
@@ -1,0 +1,1289 @@
+"""Stage 1 production shadow comparison, run out of band on the Machine.
+
+    fly ssh console -a property-shared
+    cd /app
+    PPD_SHADOW_COMPARE_ENABLED=1 python -m tools.ppd_snapshot.stage1_shadow \\
+        qualify --out /tmp/stage1-candidate-instance.json
+    PPD_SHADOW_COMPARE_ENABLED=1 python -m tools.ppd_snapshot.stage1_shadow \\
+        compare --instance /tmp/stage1-instance.json --report /tmp/stage1.json
+
+Two modes, in the order the runbook uses them.
+
+* **`qualify`** -- read-only, snapshot-only. Runs the full aggregate COUNT
+  queries the frozen Definition needs, selects the seven placeholder
+  geographies against their published qualification rules, and emits a
+  *candidate* Instance bound to the artifact's version and full bundle digest.
+  It makes no live call, downloads nothing, and writes nothing into the
+  snapshot. Its output is reviewed and committed as its own change; nothing
+  artifact-specific is ever hard-coded here.
+
+* **`compare`** -- the Stage 1 run. Executes the thirteen frozen cases against
+  **both** the existing live source and the already-materialized snapshot,
+  then repeats the snapshot arm alone for the latency sample.
+
+**Why out of band rather than in the request path.** Stage 1 needs evidence, not
+a permanent feature. A sampling hook inside the serving application would mean a
+queue, a worker thread, sampling configuration and a telemetry stream living in
+the request path of a live service, outliving the gate they were built for. As a
+separate process this tool is in no request path at all, so *"shadow comparison
+never makes a live request fail"* holds by construction rather than by careful
+coding. The governing specification's rev 10 records that decision and the
+matching p95 revision.
+
+**Isolation from the running server.** This module never installs into
+`property_core.snapshot.state`, never sets or reads `PPD_SNAPSHOT_ENABLED`,
+never downloads an artifact and never writes inside the snapshot directory. It
+opens **its own** adapter over the parquet files the server already
+materialized; `SnapshotAdapter` connects to an in-memory DuckDB and reads
+Parquet, so there is no database file to lock and no contention with the
+process that is serving.
+
+**What is persisted.** Counts, month histograms, field-mismatch tallies,
+geography results, warning classes, source evidence, latency, classification and
+artifact identity. Transaction ids and the values of compared fields exist in
+memory for the length of one comparison and are then discarded: **no id, no
+address, no price and no row ever reaches a report.**
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import time
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from tools.ppd_snapshot.corpus import (
+    LIMIT,
+    Case,
+    InstanceRefused,
+    cases,
+    derived_from_date,
+    ids as _ids,
+    outcodes as _outcodes,
+    sectors as _sectors,
+    validate_artifact_identity,
+    validate_baselines,
+    validate_geographies,
+    warning_classes as _warning_classes,
+)
+
+#: Bound to every observation. A report whose numbers cannot be attributed to a
+#: known comparator is not evidence -- two runs of "the comparator" could have
+#: measured different things.
+COMPARATOR_VERSION = "1"
+
+#: Default off, and separately controlled. The tool refuses to open an adapter,
+#: issue a query or write a report unless this parses true. Passed inline for
+#: one invocation rather than set as a Fly secret: setting a secret restarts the
+#: Machine, which wipes the ephemeral rootfs and destroys the very materialized
+#: snapshot the run is about.
+SHADOW_COMPARE_ENABLED_ENV = "PPD_SHADOW_COMPARE_ENABLED"
+
+#: The comps fields compared on shared transaction ids. `raw` is excluded: it is
+#: the live SPARQL binding dict and has no snapshot counterpart by construction,
+#: so comparing it would report a difference on every row. The EPC fields are
+#: excluded because the corpus freezes `enrich_epc=false`, so they are null on
+#: both sides and would pad the tally with meaningless agreement.
+COMPARED_FIELDS: tuple[str, ...] = (
+    "transaction_id", "price", "date", "postcode", "property_type",
+    "estate_type", "transaction_category", "new_build", "paon", "saon",
+    "street", "town", "county", "locality", "district",
+)
+
+#: A unit postcode is only selectable as a corpus geography when it is
+#: aggregate-dense; the Definition requires S6 to be "aggregate-dense, so not
+#: individually identifying". Made executable here so qualification cannot pick
+#: a postcode that names one household's sale history.
+MIN_UNIT_POSTCODE_ROWS = 10
+
+#: Definition section 2: comps' thin-market threshold under frozen parameters.
+THIN_MARKET_THRESHOLD = 5
+
+#: The residential default the corpus selects by omitting `property_type`.
+RESIDENTIAL_TYPES = ("F", "D", "S", "T")
+
+
+class ComparisonRefused(RuntimeError):
+    """A precondition failed before anything was opened, queried or written.
+
+    Raised before the adapter exists. The CLI maps it to exit 2, distinct from
+    a run that executed and found problems (exit 1).
+    """
+
+
+class RunAborted(RuntimeError):
+    """A health, resource or divergence anomaly stopped the run mid-flight.
+
+    The partial report is still written: a run that stopped for a reason is
+    evidence about that reason, and a traceback with no report leaves nothing
+    to review.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+def require_enabled(env: Optional[dict[str, str]] = None) -> None:
+    """Refuse unless the comparison is explicitly enabled. Fails CLOSED.
+
+    Uses `property_core`'s single flag parser, so an operator typo means "off"
+    here exactly as it does for every other snapshot flag, rather than being
+    truthy because it is a non-empty string.
+    """
+    from property_core.config import parse_bool_flag
+
+    source = os.environ if env is None else env
+    if not parse_bool_flag(source.get(SHADOW_COMPARE_ENABLED_ENV)):
+        raise ComparisonRefused(
+            f"{SHADOW_COMPARE_ENABLED_ENV} is not set to a true value; shadow "
+            f"comparison is off by default and must be enabled deliberately for "
+            f"the invocation that runs it"
+        )
+
+
+@dataclass(frozen=True)
+class Materialized:
+    """The snapshot this Machine already holds, opened read-only."""
+
+    adapter: Any
+    version: str
+    bundle_sha256: str
+    coverage_from: Optional[str]
+    coverage_to: Optional[str]
+    provisional_from: Optional[str]
+    directory: Path
+
+    def identity(self) -> dict[str, Any]:
+        """Artifact identity and coverage, attached to every result."""
+        return {
+            "snapshot_version": self.version,
+            "bundle_sha256": self.bundle_sha256,
+            "coverage_from": self.coverage_from,
+            "coverage_to": self.coverage_to,
+            "provisional_from": self.provisional_from,
+            "comparator_version": COMPARATOR_VERSION,
+        }
+
+
+def open_materialized(cache_dir: Path) -> Materialized:
+    """Open the snapshot the server already materialized. Never create one.
+
+    **Refuses rather than materializing.** Every directory this reads must
+    already exist: the tool's whole premise is that it observes what the
+    deployed application booted, and a tool that would happily build its own
+    snapshot could silently measure a different artifact from the one serving.
+    The existence checks come first so that constructing `SnapshotStore` --
+    which creates its directories -- is provably a no-op rather than a write.
+    """
+    from property_core.snapshot.adapter import SnapshotAdapter
+    from property_core.snapshot.store import SnapshotStore
+
+    cache_dir = Path(cache_dir)
+    if not (cache_dir / "snapshots").is_dir() or not (cache_dir / "CURRENT").is_file():
+        raise ComparisonRefused(
+            f"{cache_dir} holds no materialized snapshot (no CURRENT pointer and "
+            f"snapshots/ directory); this tool observes what the application "
+            f"booted and never materializes one of its own"
+        )
+
+    store = SnapshotStore(cache_dir)
+    version = store.current_version()
+    if not version:
+        raise ComparisonRefused(f"{cache_dir}/CURRENT names no version")
+    record = store.verified_record(version)
+    if record is None:
+        raise ComparisonRefused(
+            f"snapshot {version} has no readable verification record; its "
+            f"artifact identity cannot be established, so nothing measured "
+            f"against it could be attributed")
+
+    directory = store.snapshots_dir / version
+    adapter = SnapshotAdapter.open(directory, record)
+    return Materialized(
+        adapter=adapter,
+        version=record.version,
+        bundle_sha256=record.bundle_sha256,
+        coverage_from=record.coverage_from,
+        coverage_to=record.coverage_to,
+        provisional_from=record.provisional_from,
+        directory=directory,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The Stage 1 Instance
+# ---------------------------------------------------------------------------
+
+INSTANCE_KIND = "stage1"
+
+#: Definition section 10. A Stage 1 Instance is a superset of a rehearsal one:
+#: it additionally records when it was qualified, the rule each geography
+#: satisfied, any substitution and its justification, its staleness bound, and
+#: the run it governs.
+REQUIRED_INSTANCE_KEYS = frozenset({
+    "instance_kind", "snapshot_version", "bundle_sha256", "geographies",
+    "aggregate_baselines", "qualified_at", "qualification", "staleness_bound_days",
+    "governs_run",
+})
+
+
+@dataclass(frozen=True)
+class Stage1Instance:
+    instance_kind: str
+    snapshot_version: str
+    bundle_sha256: str
+    geographies: dict[str, str]
+    aggregate_baselines: dict[str, int]
+    qualified_at: str
+    qualification: dict[str, Any]
+    staleness_bound_days: int
+    governs_run: str
+
+
+def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
+    """Validate the Instance and bind it to the artifact actually on this Machine.
+
+    Structure first, then binding. A `rehearsal` instance is refused by kind, so
+    a correctness exercise cannot be run through the Stage 1 path and filed as
+    Stage 1 evidence -- which is the one substitution the Definition names.
+    """
+    try:
+        raw = json.loads(Path(path).read_text())
+    except FileNotFoundError as exc:
+        raise InstanceRefused(f"instance file not found: {path}") from exc
+    except (OSError, ValueError) as exc:
+        raise InstanceRefused(f"instance is not readable JSON: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise InstanceRefused("instance must be a JSON object")
+    keys = set(raw)
+    if missing := REQUIRED_INSTANCE_KEYS - keys:
+        raise InstanceRefused(f"instance is missing required key(s): {sorted(missing)}")
+    if unknown := keys - REQUIRED_INSTANCE_KEYS:
+        raise InstanceRefused(f"instance carries unknown key(s): {sorted(unknown)}")
+
+    if raw["instance_kind"] != INSTANCE_KIND:
+        raise InstanceRefused(
+            f"instance_kind is {raw['instance_kind']!r}; this tool runs "
+            f"{INSTANCE_KIND!r} instances only. A rehearsal instance is a "
+            f"correctness exercise and must not be run as Stage 1."
+        )
+
+    version, digest = validate_artifact_identity(
+        raw["snapshot_version"], raw["bundle_sha256"])
+    geographies = validate_geographies(raw["geographies"])
+    baselines = validate_baselines(raw["aggregate_baselines"])
+
+    bound = raw["staleness_bound_days"]
+    if isinstance(bound, bool) or not isinstance(bound, int) or bound <= 0:
+        raise InstanceRefused(
+            f"staleness_bound_days is {bound!r}, not a positive number of days")
+    if not isinstance(raw["qualification"], dict) or not raw["qualification"]:
+        raise InstanceRefused(
+            "qualification must record, per placeholder, the rule it satisfied; "
+            "an Instance that does not say how it qualified qualifies nothing")
+
+    # Binding. An Instance that is internally valid but describes a different
+    # artifact would produce a report whose provenance is a fiction.
+    if version != materialized.version:
+        raise InstanceRefused(
+            f"instance names snapshot_version {version}, but this Machine has "
+            f"materialized {materialized.version}")
+    if digest != materialized.bundle_sha256:
+        raise InstanceRefused(
+            "instance bundle_sha256 does not match the digest of the artifact "
+            "materialized on this Machine; the instance describes a different "
+            "artifact")
+
+    return Stage1Instance(
+        instance_kind=raw["instance_kind"],
+        snapshot_version=version,
+        bundle_sha256=digest,
+        geographies=dict(geographies),
+        aggregate_baselines=dict(baselines),
+        qualified_at=str(raw["qualified_at"]),
+        qualification=dict(raw["qualification"]),
+        staleness_bound_days=int(bound),
+        governs_run=str(raw["governs_run"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# qualify -- read-only aggregate counts against the materialized artifact
+# ---------------------------------------------------------------------------
+
+def _clamped_window(m: Materialized, months: int, today: date) -> tuple[str, str]:
+    """The window a frozen case actually queries, as coverage clamps it.
+
+    Comps sends no `to_date`, so routing clamps to `coverage_to` unconditionally
+    and the lower bound is `today - months*30` narrowed up to `coverage_from`.
+    Qualification must count over that same window or its baselines describe a
+    query nobody runs.
+    """
+    lower = derived_from_date(today, months)
+    if m.coverage_from and lower < m.coverage_from:
+        lower = m.coverage_from
+    return lower, (m.coverage_to or today.isoformat())
+
+
+def _count(m: Materialized, where: str, params: list[Any]) -> int:
+    """One aggregate COUNT over the adapter's own validated view.
+
+    Deliberately the adapter's view, not a second one built here. The adapter
+    creates it during `open()` having already validated every partition
+    individually; rebuilding it would mean two definitions of "the snapshot",
+    and the qualification counts would be over whichever one this file happened
+    to describe. `tests/snapshot/test_stage1_shadow.py` pins the two adapter
+    names this relies on, so a rename fails loudly here instead of silently
+    counting something else.
+    """
+    from property_core.snapshot.adapter import VIEW
+
+    sql = f"SELECT count(*) FROM {VIEW} WHERE {where}"
+    return int(m.adapter._execute(sql, params).fetchone()[0])
+
+
+def _frozen_where(*, months_window: tuple[str, str],
+                  geography_sql: str,
+                  property_types: Optional[tuple[str, ...]],
+                  category: Optional[str]) -> tuple[str, list[Any]]:
+    """The frozen parameters of Definition section 2, as a SQL predicate."""
+    lower, upper = months_window
+    where = [f"({geography_sql})", "transfer_date >= ?", "transfer_date <= ?"]
+    params: list[Any] = [lower, upper]
+    if property_types:
+        placeholders = ", ".join("?" for _ in property_types)
+        where.append(f"property_type IN ({placeholders})")
+        params.extend(property_types)
+    if category is not None:
+        where.append("ppd_category = ?")
+        params.append(category)
+    return " AND ".join(where), params
+
+
+def _aggregate(m: Materialized, *, geography_sql: str, geo_params: list[Any],
+               months: int, today: date,
+               property_types: Optional[tuple[str, ...]] = RESIDENTIAL_TYPES,
+               category: Optional[str] = "A") -> int:
+    where, params = _frozen_where(
+        months_window=_clamped_window(m, months, today),
+        geography_sql=geography_sql,
+        property_types=property_types,
+        category=category)
+    return _count(m, where, geo_params + params)
+
+
+def _rank(m: Materialized, column: str, *, months: int, today: date,
+          property_types: Optional[tuple[str, ...]] = RESIDENTIAL_TYPES,
+          category: Optional[str] = "A",
+          having: str = "", limit: int = 200) -> list[tuple[str, int]]:
+    """Candidate geographies by row count under the frozen parameters.
+
+    Ordered by count then value so selection is deterministic: the same
+    artifact must qualify the same geographies on every run, or the Instance
+    is not reproducible.
+    """
+    from property_core.snapshot.adapter import VIEW
+
+    lower, upper = _clamped_window(m, months, today)
+    where = [f"{column} IS NOT NULL", "transfer_date >= ?", "transfer_date <= ?"]
+    params: list[Any] = [lower, upper]
+    if property_types:
+        placeholders = ", ".join("?" for _ in property_types)
+        where.append(f"property_type IN ({placeholders})")
+        params.extend(property_types)
+    if category is not None:
+        where.append("ppd_category = ?")
+        params.append(category)
+    sql = (f"SELECT {column}, count(*) AS n FROM {VIEW} "
+           f"WHERE {' AND '.join(where)} GROUP BY {column} "
+           f"{having} ORDER BY n DESC, {column} ASC LIMIT {int(limit)}")
+    return [(r[0], int(r[1])) for r in m.adapter._execute(sql, params).fetchall()]
+
+
+def _type_mix(m: Materialized, sector: str, *, months: int,
+              today: date) -> dict[str, int]:
+    from property_core.snapshot.adapter import VIEW
+
+    lower, upper = _clamped_window(m, months, today)
+    sql = (f"SELECT property_type, count(*) FROM {VIEW} WHERE sector = ? "
+           f"AND transfer_date >= ? AND transfer_date <= ? AND ppd_category = 'A' "
+           f"AND property_type IN ('F','D','S','T') GROUP BY property_type")
+    rows = m.adapter._execute(sql, [sector, lower, upper]).fetchall()
+    return {str(r[0]): int(r[1]) for r in rows}
+
+
+def qualify(m: Materialized, *, today: Optional[date] = None) -> dict[str, Any]:
+    """Select the seven placeholders and measure the three baselines.
+
+    Read-only throughout: aggregate COUNT and GROUP BY only, no download, no
+    live call, and nothing written into the snapshot. The output is a
+    **candidate** Instance for review, never a runtime input.
+    """
+    today = today or date.today()
+    qualification: dict[str, Any] = {}
+    geo: dict[str, str] = {}
+
+    # -- the three declared baselines, over the whole artifact ---------------
+    s1 = _aggregate(m, geography_sql="outcode = ?", geo_params=["B5"],
+                    months=24, today=today)
+    s3 = _aggregate(m, geography_sql="sector = ?", geo_params=["B5 4"],
+                    months=24, today=today)
+    s9 = _aggregate(m, geography_sql="sector = ?", geo_params=["B5 4"],
+                    months=24, today=today, category=None)
+    baselines = {"S1_full": s1, "S3_full": s3, "S9_full": s9}
+
+    # -- S4: thin market, strictly below the threshold ----------------------
+    sectors_ranked = _rank(m, "sector", months=24, today=today)
+    thin = [(s, n) for s, n in sectors_ranked if 0 < n < THIN_MARKET_THRESHOLD]
+    if thin:
+        geo["S4_thin"] = thin[0][0]
+        qualification["S4_thin"] = {
+            "rule": (f"non-empty and strictly below thin_market_threshold "
+                     f"({THIN_MARKET_THRESHOLD}) under frozen parameters"),
+            "measured_rows": thin[0][1]}
+
+    # -- S5: dense, matching rows greatly exceed `limit` --------------------
+    dense = [(s, n) for s, n in sectors_ranked if n > LIMIT * 4]
+    if dense:
+        geo["S5_dense"] = dense[0][0]
+        qualification["S5_dense"] = {
+            "rule": f"matching rows greatly exceed limit ({LIMIT})",
+            "measured_rows": dense[0][1]}
+
+    # -- S6: exact postcode, aggregate-dense so not individually identifying -
+    units = _rank(m, "postcode", months=24, today=today)
+    dense_units = [(p, n) for p, n in units if n >= MIN_UNIT_POSTCODE_ROWS]
+    if dense_units:
+        geo["S6_unit"] = dense_units[0][0]
+        qualification["S6_unit"] = {
+            "rule": (f"aggregate-dense (>= {MIN_UNIT_POSTCODE_ROWS} rows), so "
+                     f"not individually identifying"),
+            "measured_rows": dense_units[0][1]}
+
+    # -- S7 / S8: a type filter that barely bites, and one that genuinely does
+    for sector, total in sectors_ranked:
+        if total < LIMIT:
+            continue
+        mix = _type_mix(m, sector, months=24, today=today)
+        rows = sum(mix.values())
+        if rows == 0:
+            continue
+        share_f = mix.get("F", 0) / rows
+        if "S7_type_weak" not in geo and share_f >= 0.90:
+            geo["S7_type_weak"] = sector
+            qualification["S7_type_weak"] = {
+                "rule": "at least 90% of the base is F",
+                "measured_share_f": round(share_f, 4), "measured_rows": rows}
+        # "A real spread across F/D/S/T": every type present, and F is not
+        # dominant -- otherwise the filter barely bites and this is an S7.
+        if ("S8_type_strong" not in geo
+                and all(mix.get(t, 0) > 0 for t in RESIDENTIAL_TYPES)
+                and share_f <= 0.60):
+            geo["S8_type_strong"] = sector
+            qualification["S8_type_strong"] = {
+                "rule": "a real spread across F/D/S/T, F not dominant",
+                "measured_share_f": round(share_f, 4),
+                "measured_types_present": sorted(mix)}
+        if "S7_type_weak" in geo and "S8_type_strong" in geo:
+            break
+
+    # -- S11: empty over a 6-month window that intersects the provisional tail
+    six = _clamped_window(m, 6, today)
+    provisional_intersects = bool(
+        m.provisional_from and m.coverage_to
+        and not (six[1] < m.provisional_from or six[0] > m.coverage_to))
+    for sector, _ in sectors_ranked:
+        if _aggregate(m, geography_sql="sector = ?", geo_params=[sector],
+                      months=6, today=today) == 0:
+            geo["S11_provisional_empty"] = sector
+            qualification["S11_provisional_empty"] = {
+                "rule": ("returns zero rows over months=6 while the window "
+                         "intersects the provisional period"),
+                "measured_rows": 0,
+                "window_intersects_provisional": provisional_intersects}
+            break
+
+    # -- S13: a unit postcode non-empty under defaults with no `D` rows ------
+    for postcode, total in dense_units:
+        if _aggregate(m, geography_sql="postcode = ?", geo_params=[postcode],
+                      months=24, today=today, property_types=("D",)) == 0:
+            geo["S13_empty_unit"] = postcode
+            qualification["S13_empty_unit"] = {
+                "rule": ("non-empty under the residential default, zero rows "
+                         "once filtered to property_type=D"),
+                "measured_rows_default": total, "measured_rows_type_d": 0}
+            break
+
+    # The measured baselines must satisfy the very relations they exist to
+    # establish, or the Instance built from them will be refused at load. Say so
+    # here, while the operator is still choosing geographies, rather than
+    # letting them find out from a refusal after the Instance is authored and
+    # reviewed. A refusal is not a qualification failure by itself: the
+    # Definition allows a geography to be substituted with recorded
+    # justification, and this is the signal that one is needed.
+    try:
+        validate_baselines(baselines)
+        baselines_refusal = None
+    except InstanceRefused as exc:
+        baselines_refusal = str(exc)
+
+    candidate = {
+        "instance_kind": INSTANCE_KIND,
+        "snapshot_version": m.version,
+        "bundle_sha256": m.bundle_sha256,
+        "geographies": geo,
+        "aggregate_baselines": baselines,
+        "qualified_at": today.isoformat(),
+        "qualification": qualification,
+        "staleness_bound_days": 45,
+        "governs_run": "<fill in: the Stage 1 run this Instance governs>",
+    }
+    return {
+        "kind": "stage1_qualification_candidate",
+        "is_instance": False,
+        "note": (
+            "A CANDIDATE Instance. It is reviewed and committed as its own "
+            "change before Stage 1 runs; it is never read as runtime "
+            "configuration and nothing here is hard-coded into the tool."),
+        "coverage": {"coverage_from": m.coverage_from,
+                     "coverage_to": m.coverage_to,
+                     "provisional_from": m.provisional_from},
+        "comparator_version": COMPARATOR_VERSION,
+        "baselines_satisfy_their_relations": baselines_refusal is None,
+        "baselines_refusal": baselines_refusal,
+        "baselines_note": (
+            "S1/S3/S9 are measured over the definitional B5 / B5 4 geographies. "
+            "If they do not satisfy the strict-subset and category-B relations, "
+            "the Definition allows a substituted geography with recorded "
+            "justification -- which is an authoring decision, not something "
+            "this tool may make."),
+        "unqualified_placeholders": sorted(
+            {"S4_thin", "S5_dense", "S6_unit", "S7_type_weak", "S8_type_strong",
+             "S11_provisional_empty", "S13_empty_unit"} - set(geo)),
+        "candidate_instance": candidate,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Latency -- nearest rank, defined exactly
+# ---------------------------------------------------------------------------
+
+def nearest_rank(values: list[float], percentile: float) -> Optional[float]:
+    """The nearest-rank percentile, spelled out so it cannot drift.
+
+    Sort ascending; take the value at 1-based rank ``ceil(p/100 * N)``. For
+    ``N = 390`` and ``p = 95`` that is rank 371, i.e. index 370 -- a value that
+    was actually observed, never an interpolation between two observations.
+    Interpolating would report a latency no request ever took, which is the
+    wrong kind of number to hang a deployment gate on.
+    """
+    if not values:
+        return None
+    ordered = sorted(values)
+    rank = max(1, math.ceil(percentile / 100.0 * len(ordered)))
+    return ordered[min(rank, len(ordered)) - 1]
+
+
+def latency_summary(values: list[float]) -> dict[str, Any]:
+    return {
+        "n": len(values),
+        "p50_ms": nearest_rank(values, 50),
+        "p95_ms": nearest_rank(values, 95),
+        "p99_ms": nearest_rank(values, 99),
+        "max_ms": max(values) if values else None,
+        "method": "nearest rank: sorted ascending, 1-based rank ceil(p/100*N)",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Diffing -- ids and field values live in memory only
+# ---------------------------------------------------------------------------
+
+def _month(value: Any) -> str:
+    text = str(value or "")
+    return text[:7] if len(text) >= 7 else "unknown"
+
+
+def _by_month(transactions: Any, keep: set[str]) -> dict[str, int]:
+    """A month histogram over the rows whose ids are in `keep`.
+
+    A month is the finest granularity that classification needs -- it answers
+    "is this row in the provisional tail?" -- and is not identifying. The ids
+    themselves are the argument, not the output.
+    """
+    counter: Counter[str] = Counter()
+    for t in transactions:
+        if getattr(t, "transaction_id", None) in keep:
+            counter[_month(getattr(t, "date", None))] += 1
+    return dict(sorted(counter.items()))
+
+
+def _field_mismatches(live: Any, snap: Any, shared: set[str]) -> tuple[
+        dict[str, int], dict[str, int], int]:
+    """Per-field mismatch tallies over shared ids. Values never leave here.
+
+    Returns the tally by field, a month histogram of the rows that disagreed,
+    and how many rows disagreed at all. Comparison is on the values the models
+    produced, with **no normalisation**: a systematic representational
+    difference between the two sources is a finding, not something a harness
+    should quietly paper over.
+    """
+    live_by_id = {t.transaction_id: t for t in live
+                  if getattr(t, "transaction_id", None) in shared}
+    snap_by_id = {t.transaction_id: t for t in snap
+                  if getattr(t, "transaction_id", None) in shared}
+    tally: Counter[str] = Counter()
+    months: Counter[str] = Counter()
+    rows = 0
+    for tid in sorted(shared):
+        a, b = live_by_id.get(tid), snap_by_id.get(tid)
+        if a is None or b is None:
+            continue
+        differing = [f for f in COMPARED_FIELDS
+                     if getattr(a, f, None) != getattr(b, f, None)]
+        if differing:
+            rows += 1
+            months[_month(getattr(a, "date", None))] += 1
+            for f in differing:
+                tally[f] += 1
+    return dict(sorted(tally.items())), dict(sorted(months.items())), rows
+
+
+def classify(*, only_live_months: dict[str, int], only_snapshot_months: dict[str, int],
+             mismatch_months: dict[str, int], provisional_from: Optional[str],
+             live_saturated: bool, snapshot_saturated: bool,
+             live_truncation_evidenced: bool) -> dict[str, Any]:
+    """Definition section 7's four classes, and nothing else.
+
+    Class 3 (**live truncation or ordering**) is only ever assigned on
+    evidence -- `raw_bindings_returned == fetch_limit`, or a page saturated at
+    `limit`. The Definition says so explicitly, because "the snapshot returned
+    more, so live must have truncated" is an assumption dressed as a finding.
+
+    Class 2 (**later A/C/D revision**) cannot be evidenced from these two
+    sources at all: confirming it needs the monthly change records published
+    after the build. It is therefore proposed, never asserted, and carries
+    `operator_confirmation_required`.
+    """
+    prov = provisional_from or ""
+    truncation = live_truncation_evidenced or live_saturated or snapshot_saturated
+
+    provisional_tail_lag = 0
+    unclassified = 0
+    live_truncation = 0
+    for month, n in only_live_months.items():
+        if prov and month >= prov[:7]:
+            provisional_tail_lag += n
+        elif truncation:
+            live_truncation += n
+        else:
+            unclassified += n
+    for month, n in only_snapshot_months.items():
+        if truncation:
+            live_truncation += n
+        elif prov and month >= prov[:7]:
+            # A row the snapshot holds and live does not, inside the
+            # provisional tail, is still the provisional period moving --
+            # revision runs in both directions.
+            provisional_tail_lag += n
+        else:
+            unclassified += n
+
+    later_acd = 0
+    for month, n in mismatch_months.items():
+        if prov and month >= prov[:7]:
+            provisional_tail_lag += n
+        else:
+            later_acd += n
+
+    return {
+        "provisional_tail_lag": provisional_tail_lag,
+        "later_acd_revision": later_acd,
+        "live_truncation_or_ordering": live_truncation,
+        "unclassified": unclassified,
+        "operator_confirmation_required": later_acd,
+        "truncation_evidence": {
+            "live_raw_bindings_equals_fetch_limit": live_truncation_evidenced,
+            "live_page_saturated": live_saturated,
+            "snapshot_page_saturated": snapshot_saturated,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Live transport evidence, captured without touching public models
+# ---------------------------------------------------------------------------
+
+class LiveEvidenceCapture:
+    """Record `raw_bindings_returned` / `fetch_limit` for the live arm.
+
+    Divergence class 3 must be *evidenced*, and those two numbers are the
+    evidence. They are carried up the live path as `TransportEvidence` but are
+    deliberately not exposed on `PPDCompsResponse`, so the only ways to see
+    them are to widen a public response model or to observe the transport call.
+
+    Widening the model would put a rollout-diagnostic field into every
+    consumer's payload permanently, so this observes instead: it wraps the exact
+    method the live path already calls, for the duration of this process only,
+    and changes nothing about what that method does. The wrap is installed and
+    removed around the live arm; the serving application is a different process
+    and is untouched either way.
+    """
+
+    def __init__(self) -> None:
+        self.last: dict[str, Any] = {}
+        self._original: Optional[Callable[..., Any]] = None
+
+    def __enter__(self) -> "LiveEvidenceCapture":
+        from property_core.ppd_client import PricePaidDataClient
+
+        self._original = PricePaidDataClient.search_with_evidence
+
+        def _wrapped(inner_self, **kwargs):
+            page = self._original(inner_self, **kwargs)
+            evidence = getattr(page, "evidence", None)
+            self.last = {
+                "raw_bindings_returned": getattr(
+                    evidence, "raw_bindings_returned", None),
+                "fetch_limit": getattr(evidence, "fetch_limit", None),
+                "source_exhausted": getattr(evidence, "source_exhausted", None),
+            }
+            return page
+
+        PricePaidDataClient.search_with_evidence = _wrapped  # type: ignore[assignment]
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        if self._original is not None:
+            from property_core.ppd_client import PricePaidDataClient
+
+            PricePaidDataClient.search_with_evidence = self._original  # type: ignore[assignment]
+            self._original = None
+
+    @property
+    def truncation_evidenced(self) -> bool:
+        raw = self.last.get("raw_bindings_returned")
+        limit = self.last.get("fetch_limit")
+        return raw is not None and limit is not None and raw >= limit
+
+
+# ---------------------------------------------------------------------------
+# Health and resource monitoring
+# ---------------------------------------------------------------------------
+
+def available_memory_bytes(meminfo: Optional[str] = None) -> Optional[int]:
+    """`MemAvailable` from /proc/meminfo, or None where it cannot be read.
+
+    None means "unknown", never "fine": the caller treats an unreadable value
+    as a reason to keep going only because the floor check is a guard against a
+    Machine under pressure, not the primary safety property.
+    """
+    try:
+        text = meminfo if meminfo is not None else Path("/proc/meminfo").read_text()
+    except OSError:
+        return None
+    for line in text.splitlines():
+        if line.startswith("MemAvailable:"):
+            parts = line.split()
+            if len(parts) >= 2 and parts[1].isdigit():
+                return int(parts[1]) * 1024
+    return None
+
+
+def health_ok(url: str, timeout: float = 5.0) -> tuple[bool, str]:
+    """Ask the serving application on this Machine whether it is still well.
+
+    Localhost only: this is the app sharing the Machine with the run, and the
+    point is to notice if the run is disturbing it.
+    """
+    try:
+        import httpx
+
+        response = httpx.get(url, timeout=timeout)
+        return response.status_code == 200, f"{response.status_code}"
+    except Exception as exc:  # noqa: BLE001 -- a monitor must not raise
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# The Stage 1 run
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RunLimits:
+    """Every bound the run may not exceed, in one place.
+
+    Bounds rather than best effort: this process shares a 2 GB Machine with the
+    application that is serving, so "shadow traffic cannot exhaust the Machine"
+    has to be a refusal, not an intention.
+    """
+
+    live_delay_seconds: float = 2.0
+    latency_repeats: int = 30
+    max_live_per_case: int = 1
+    deadline_seconds: float = 3600.0
+    min_available_memory_bytes: int = 256 * 1024 * 1024
+    health_url: str = "http://127.0.0.1:8080/v1/health"
+    stop_on_unclassified: bool = True
+
+
+def _observe(service: Any, case: Case) -> tuple[Any, str, float]:
+    """One comps call, with the calendar date it was taken on and its latency.
+
+    The date is captured either side and compared by the caller: `comps`
+    derives its window from `date.today()`, so an observation straddling
+    midnight describes a different window from the one recorded.
+    """
+    before = date.today()
+    started = time.monotonic()
+    response = service.comps(
+        postcode=case.postcode,
+        search_level=case.search_level,
+        months=case.months,
+        property_type=case.property_type,
+        transaction_category=case.transaction_category,
+        filter_outliers=False,
+        limit=LIMIT,
+        auto_escalate=True,
+    )
+    elapsed_ms = (time.monotonic() - started) * 1000.0
+    after = date.today()
+    if before != after:
+        raise MidnightCrossed(f"{case.shape}: observation straddled midnight")
+    return response, before.isoformat(), elapsed_ms
+
+
+class MidnightCrossed(RuntimeError):
+    """An observation could not be taken within one calendar date."""
+
+
+def _provenance_source(response: Any) -> Optional[str]:
+    provenance = getattr(response, "provenance", None)
+    if provenance is None:
+        return None
+    source = getattr(provenance, "source", None)
+    return getattr(source, "value", None) or (str(source) if source else None)
+
+
+def _arm_record(response: Any, case: Case, observed: str,
+                latency_ms: float) -> dict[str, Any]:
+    """What one arm produced -- aggregates, geography and provenance only."""
+    provenance = getattr(response, "provenance", None)
+    return {
+        "count": response.count,
+        "latency_ms": round(latency_ms, 2),
+        "thin_market": response.thin_market,
+        "outcodes_returned": _outcodes(response.transactions),
+        "sectors_returned": _sectors(response.transactions),
+        "warning_classes": _warning_classes(tuple(response.warnings or ())),
+        "saturated_at_limit": response.count == LIMIT,
+        "source": _provenance_source(response),
+        "observed_at": observed,
+        "derived_from_date": derived_from_date(date.fromisoformat(observed),
+                                               case.months),
+        "resolved_to_date": getattr(provenance, "coverage_to", None),
+        "recent_period_provisional": getattr(
+            provenance, "recent_period_provisional", None),
+        "sample_complete": getattr(provenance, "sample_complete", None),
+    }
+
+
+def _geography_contamination(response: Any, case: Case) -> list[str]:
+    """Outcodes returned that are not the one the case asked for."""
+    requested = case.postcode.split()[0].upper()
+    return [o for o in _outcodes(response.transactions) if o != requested]
+
+
+def run_compare(*, instance: Stage1Instance, materialized: Materialized,
+                limits: RunLimits, report_path: Path,
+                live_service: Optional[Any] = None,
+                snapshot_service: Optional[Any] = None) -> dict[str, Any]:
+    """Execute the frozen corpus against both arms, then measure latency.
+
+    Two passes, deliberately separate:
+
+    * **correctness** -- every case once through each arm, giving the
+      divergence, geography and error evidence. One rate-limited live
+      observation per case: the live source is HM Land Registry's, and the
+      corpus is a fixed thirteen, so there is no reason to ask it more.
+    * **latency** -- the snapshot arm alone, repeated, giving the p95 sample
+      with **no further live calls at all**.
+
+    The run stops on a health, memory, snapshot-error or unclassified-divergence
+    anomaly, and the partial report is still written.
+    """
+    from property_core.ppd_service import PPDService
+
+    live_service = live_service or PPDService()
+    snapshot_service = snapshot_service or PPDService(adapter=materialized.adapter)
+
+    identity = materialized.identity()
+    started_at = time.monotonic()
+    corpus = cases(instance.geographies)
+
+    results: list[dict[str, Any]] = []
+    snapshot_errors: list[dict[str, Any]] = []
+    live_errors: list[dict[str, Any]] = []
+    contamination: list[dict[str, Any]] = []
+    excluded = {"midnight": 0, "health": 0, "memory": 0}
+    aborted: Optional[str] = None
+    live_calls = 0
+
+    def _guard(stage: str) -> None:
+        """Health, memory and deadline, checked between observations."""
+        if time.monotonic() - started_at > limits.deadline_seconds:
+            raise RunAborted(f"deadline of {limits.deadline_seconds}s exceeded at {stage}")
+        available = available_memory_bytes()
+        if available is not None and available < limits.min_available_memory_bytes:
+            excluded["memory"] += 1
+            raise RunAborted(
+                f"available memory {available} B fell below the floor "
+                f"{limits.min_available_memory_bytes} B at {stage}")
+        ok, detail = health_ok(limits.health_url)
+        if not ok:
+            excluded["health"] += 1
+            raise RunAborted(f"application health check failed at {stage}: {detail}")
+
+    try:
+        # -- pass A: correctness -------------------------------------------
+        for case in corpus:
+            _guard(f"correctness/{case.shape}")
+            record: dict[str, Any] = {
+                "shape": case.shape,
+                "intent": case.intent,
+                "request": {"wire": case.request(), "effective": case.effective()},
+                "artifact": dict(identity),
+            }
+
+            snap_response = None
+            try:
+                snap_response, snap_observed, snap_ms = _observe(snapshot_service, case)
+                record["snapshot"] = _arm_record(snap_response, case,
+                                                 snap_observed, snap_ms)
+            except MidnightCrossed as exc:
+                excluded["midnight"] += 1
+                record["excluded"] = str(exc)
+            except Exception as exc:  # noqa: BLE001 -- recorded, never propagated
+                snapshot_errors.append({"shape": case.shape,
+                                        "error": f"{type(exc).__name__}: {exc}"})
+                record["snapshot_error"] = f"{type(exc).__name__}: {exc}"
+
+            live_response = None
+            if live_calls < limits.max_live_per_case * len(corpus):
+                with LiveEvidenceCapture() as capture:
+                    try:
+                        live_calls += 1
+                        live_response, live_observed, live_ms = _observe(
+                            live_service, case)
+                        record["live"] = _arm_record(live_response, case,
+                                                     live_observed, live_ms)
+                        record["live"]["transport_evidence"] = dict(capture.last)
+                        record["live_truncation_evidenced"] = capture.truncation_evidenced
+                    except MidnightCrossed as exc:
+                        excluded["midnight"] += 1
+                        record["excluded"] = str(exc)
+                    except Exception as exc:  # noqa: BLE001
+                        live_errors.append({"shape": case.shape,
+                                            "error": f"{type(exc).__name__}: {exc}"})
+                        record["live_error"] = f"{type(exc).__name__}: {exc}"
+                time.sleep(limits.live_delay_seconds)
+
+            if snap_response is not None and live_response is not None:
+                record.update(_compare_arms(
+                    case=case, live=live_response, snap=snap_response,
+                    provisional_from=materialized.provisional_from,
+                    live_truncation_evidenced=bool(
+                        record.get("live_truncation_evidenced"))))
+                for arm, response in (("live", live_response),
+                                      ("snapshot", snap_response)):
+                    stray = _geography_contamination(response, case)
+                    if stray:
+                        contamination.append({"shape": case.shape, "arm": arm,
+                                              "unexpected_outcodes": stray})
+                if (limits.stop_on_unclassified
+                        and record.get("classification", {}).get("unclassified")):
+                    results.append(record)
+                    raise RunAborted(
+                        f"{case.shape}: an unclassified divergence blocks Stage 1 "
+                        f"exit and stops the run for investigation")
+
+            results.append(record)
+
+        # -- pass B: latency, snapshot arm only, no further live calls ------
+        latency_ms: list[float] = []
+        per_case: dict[str, list[float]] = {}
+        for repeat in range(limits.latency_repeats):
+            _guard(f"latency/{repeat + 1}")
+            for case in corpus:
+                try:
+                    _, _, elapsed = _observe(snapshot_service, case)
+                except MidnightCrossed:
+                    excluded["midnight"] += 1
+                    continue
+                except Exception as exc:  # noqa: BLE001
+                    snapshot_errors.append({"shape": case.shape,
+                                            "error": f"{type(exc).__name__}: {exc}"})
+                    continue
+                latency_ms.append(elapsed)
+                per_case.setdefault(case.shape, []).append(elapsed)
+    except RunAborted as exc:
+        aborted = str(exc)
+        latency_ms = locals().get("latency_ms", [])  # type: ignore[assignment]
+        per_case = locals().get("per_case", {})  # type: ignore[assignment]
+
+    report = _build_report(
+        instance=instance, identity=identity, limits=limits, results=results,
+        latency_ms=latency_ms, per_case=per_case, snapshot_errors=snapshot_errors,
+        live_errors=live_errors, contamination=contamination, excluded=excluded,
+        aborted=aborted, live_calls=live_calls)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=False))
+    return report
+
+
+def _compare_arms(*, case: Case, live: Any, snap: Any,
+                  provisional_from: Optional[str],
+                  live_truncation_evidenced: bool) -> dict[str, Any]:
+    """One case's structured diff. Ids and values are discarded on return."""
+    live_ids, snap_ids = _ids(live.transactions), _ids(snap.transactions)
+    only_live, only_snapshot = live_ids - snap_ids, snap_ids - live_ids
+    shared = live_ids & snap_ids
+
+    only_live_months = _by_month(live.transactions, only_live)
+    only_snapshot_months = _by_month(snap.transactions, only_snapshot)
+    tally, mismatch_months, mismatch_rows = _field_mismatches(
+        live.transactions, snap.transactions, shared)
+
+    both_returned_rows = bool(live_ids) and bool(snap_ids)
+    return {
+        "diff": {
+            "only_live": {"count": len(only_live), "by_month": only_live_months},
+            "only_snapshot": {"count": len(only_snapshot),
+                              "by_month": only_snapshot_months},
+            "shared": {"count": len(shared)},
+            "count_delta": snap.count - live.count,
+            "field_mismatches": tally,
+            "field_mismatch_rows": mismatch_rows,
+            "field_mismatch_by_month": mismatch_months,
+            "compared_fields": list(COMPARED_FIELDS),
+        },
+        # A snapshot that returns nothing where live returned rows, inside
+        # coverage, is the criterion's "false empty".
+        "snapshot_false_empty": snap.count == 0 and live.count > 0,
+        # The vacuous-pass guard. "100% equality on shared ids" is trivially
+        # true when no id is shared -- which is exactly what a systematic
+        # difference in id spelling between the two sources would produce. An
+        # empty intersection where both arms returned rows is a blocking
+        # finding, never a pass.
+        "empty_id_intersection_with_rows_on_both_sides": (
+            both_returned_rows and not shared),
+        "classification": classify(
+            only_live_months=only_live_months,
+            only_snapshot_months=only_snapshot_months,
+            mismatch_months=mismatch_months,
+            provisional_from=provisional_from,
+            live_saturated=live.count == LIMIT,
+            snapshot_saturated=snap.count == LIMIT,
+            live_truncation_evidenced=live_truncation_evidenced),
+    }
+
+
+def _build_report(*, instance: Stage1Instance, identity: dict[str, Any],
+                  limits: RunLimits, results: list[dict[str, Any]],
+                  latency_ms: list[float], per_case: dict[str, list[float]],
+                  snapshot_errors: list[dict[str, Any]],
+                  live_errors: list[dict[str, Any]],
+                  contamination: list[dict[str, Any]],
+                  excluded: dict[str, int], aborted: Optional[str],
+                  live_calls: int) -> dict[str, Any]:
+    """The Stage 1 report, and its verdict against each exit criterion."""
+    unclassified = sum(r.get("classification", {}).get("unclassified", 0)
+                       for r in results)
+    confirmation = sum(
+        r.get("classification", {}).get("operator_confirmation_required", 0)
+        for r in results)
+    false_empties = [r["shape"] for r in results if r.get("snapshot_false_empty")]
+    vacuous = [r["shape"] for r in results
+               if r.get("empty_id_intersection_with_rows_on_both_sides")]
+    mismatch_rows = sum(r.get("diff", {}).get("field_mismatch_rows", 0)
+                        for r in results)
+    compared = [r for r in results if "diff" in r]
+
+    latency = latency_summary(latency_ms)
+    p95 = latency["p95_ms"]
+
+    criteria = {
+        "zero_unexplained_false_empties": {
+            "passed": not false_empties or unclassified == 0,
+            "false_empty_shapes": false_empties,
+            "note": ("a false empty is only a failure when it is unexplained; "
+                     "these are checked against the classification below"),
+        },
+        "zero_geography_contamination": {
+            "passed": not contamination, "findings": contamination},
+        "field_equality_on_shared_ids": {
+            "passed": mismatch_rows == 0 and not vacuous,
+            "mismatch_rows": mismatch_rows,
+            "vacuous_comparison_shapes": vacuous,
+            "note": ("a shape listed under vacuous_comparison_shapes shared no "
+                     "transaction id while both arms returned rows; equality "
+                     "over an empty intersection proves nothing and is "
+                     "reported as a failure, not a pass"),
+        },
+        "every_divergence_classified": {
+            "passed": unclassified == 0, "unclassified": unclassified,
+            "operator_confirmation_required": confirmation,
+            "note": ("later A/C/D revision cannot be evidenced from these two "
+                     "sources; it is proposed, not asserted, and the count "
+                     "above is what an operator must confirm"),
+        },
+        "zero_snapshot_errors": {
+            "passed": not snapshot_errors, "errors": snapshot_errors},
+        "p95_under_one_second": {
+            "passed": p95 is not None and p95 < 1000.0,
+            "p95_ms": p95, "n": latency["n"],
+            "criterion": ("p95 < 1 second on the deployed production Machine "
+                          "and selected artifact, measured across the frozen "
+                          "corpus request mix (governing spec rev 10)"),
+        },
+    }
+
+    return {
+        "kind": "stage1_shadow_comparison",
+        "stage_1_evidence": True,
+        "latency_sample_kind": "deployed_machine_frozen_corpus",
+        "not_organic_traffic": (
+            "The request mix is the frozen thirteen-case corpus, chosen in "
+            "advance, executed on the deployed production Machine against the "
+            "selected artifact. It is not a sample of organic traffic and must "
+            "never be described as one (governing spec rev 10)."),
+        "definition": "docs/design/ppd-shadow-corpus.md",
+        "artifact": dict(identity),
+        "instance": {
+            "instance_kind": instance.instance_kind,
+            "qualified_at": instance.qualified_at,
+            "governs_run": instance.governs_run,
+            "staleness_bound_days": instance.staleness_bound_days,
+            "aggregate_baselines": dict(instance.aggregate_baselines),
+            "baselines_are": "declared during qualification, not measured here",
+        },
+        "isolation": {
+            "installed_into_server_state": False,
+            "snapshot_routing_enabled": False,
+            "artifacts_downloaded": 0,
+            "snapshot_written_to": False,
+        },
+        "limits": {
+            "live_delay_seconds": limits.live_delay_seconds,
+            "latency_repeats": limits.latency_repeats,
+            "max_live_per_case": limits.max_live_per_case,
+            "deadline_seconds": limits.deadline_seconds,
+            "min_available_memory_bytes": limits.min_available_memory_bytes,
+            "live_calls_made": live_calls,
+        },
+        "excluded": dict(excluded),
+        "aborted": aborted,
+        "cases_total": len(results),
+        "cases_compared": len(compared),
+        "live_errors": live_errors,
+        "latency": {
+            "snapshot_arm": latency,
+            "per_case_ms": {k: latency_summary(v) for k, v in
+                            sorted(per_case.items())},
+        },
+        "exit_criteria": criteria,
+        "passed": (aborted is None
+                   and all(c["passed"] for c in criteria.values())),
+        "cases": results,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _default_cache_dir() -> str:
+    from property_core.snapshot.bootstrap import DEFAULT_CACHE_DIR, SNAPSHOT_CACHE_ENV
+
+    return os.getenv(SNAPSHOT_CACHE_ENV, DEFAULT_CACHE_DIR)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="stage1_shadow",
+        description=("Stage 1 shadow comparison, run out of band on the "
+                     "deployed Machine. Off by default."))
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    q = sub.add_parser("qualify", help="read-only aggregate counts; emit a "
+                                       "candidate Stage 1 Instance")
+    q.add_argument("--cache-dir", default=None)
+    q.add_argument("--out", required=True, type=Path)
+
+    c = sub.add_parser("compare", help="execute the frozen corpus against both "
+                                       "arms and write the Stage 1 report")
+    c.add_argument("--cache-dir", default=None)
+    c.add_argument("--instance", required=True, type=Path)
+    c.add_argument("--report", required=True, type=Path)
+    c.add_argument("--latency-repeats", type=int, default=30)
+    c.add_argument("--max-live-per-case", type=int, default=1)
+    c.add_argument("--live-delay-seconds", type=float, default=2.0)
+    c.add_argument("--deadline-seconds", type=float, default=3600.0)
+    c.add_argument("--health-url", default="http://127.0.0.1:8080/v1/health")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        require_enabled()
+        cache_dir = Path(args.cache_dir or _default_cache_dir())
+        materialized = open_materialized(cache_dir)
+    except ComparisonRefused as exc:
+        print(f"refused: {exc}")
+        return 2
+
+    try:
+        if args.mode == "qualify":
+            out = qualify(materialized)
+            args.out.parent.mkdir(parents=True, exist_ok=True)
+            args.out.write_text(json.dumps(out, indent=2, sort_keys=False))
+            unqualified = out["unqualified_placeholders"]
+            print(f"candidate instance written to {args.out}")
+            if unqualified:
+                print(f"UNQUALIFIED placeholders: {unqualified}")
+                return 1
+            return 0
+
+        try:
+            instance = load_instance(args.instance, materialized)
+        except InstanceRefused as exc:
+            print(f"refused: {exc}")
+            return 2
+
+        limits = RunLimits(
+            live_delay_seconds=args.live_delay_seconds,
+            latency_repeats=args.latency_repeats,
+            max_live_per_case=args.max_live_per_case,
+            deadline_seconds=args.deadline_seconds,
+            health_url=args.health_url,
+        )
+        report = run_compare(instance=instance, materialized=materialized,
+                             limits=limits, report_path=args.report)
+        print(f"report written to {args.report}")
+        print(f"passed: {report['passed']}  aborted: {report['aborted']}")
+        return 0 if report["passed"] else 1
+    finally:
+        materialized.adapter.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ppd_snapshot/stage1_shadow.py
+++ b/tools/ppd_snapshot/stage1_shadow.py
@@ -276,7 +276,18 @@ OPTIONAL_INSTANCE_KEYS = frozenset({"substitutions"})
 #: the seven placeholders plus the two definitional cases. A block covering
 #: some of them is silent about the rest while looking complete.
 REQUIRED_QUALIFICATION_KEYS = frozenset(
-    REQUIRED_GEOGRAPHIES | {"S1_district", "S2_district"})
+    REQUIRED_GEOGRAPHIES | {"S1_district", "S2_district", "S3_sector"})
+
+#: Qualification entries that must name the geography they were measured over,
+#: and be checked against the Instance's EFFECTIVE geographies. These three fix
+#: the definitional cases and the S1/S3/S9 baselines, so a substitution that
+#: left them describing `B5`/`B50`/`B5 4` would be evidence about one set of
+#: geographies attached to a run executing another.
+GEOGRAPHY_BOUND_QUALIFICATIONS = {
+    "S1_district": "S1_district",
+    "S2_district": "S2_neighbour_district",
+    "S3_sector": "S3_sector",
+}
 
 
 @dataclass(frozen=True)
@@ -389,6 +400,70 @@ def load_instance(path: Path, materialized: Materialized) -> Stage1Instance:
             raise InstanceRefused(
                 f"qualification[{key}] records no rule; naming a geography is "
                 f"not qualifying it")
+
+    # -- the qualification must describe the geographies actually executed ---
+    #
+    # A substitution changes which geographies the thirteen cases run against.
+    # Evidence measured over `B5`/`B50`/`B5 4` says nothing about a run over
+    # `M3`/`M30`/`M3 7`, and a `substitutions` block bolted onto an otherwise
+    # unchanged Instance would look complete while binding measurements to the
+    # wrong places. Re-qualify against the artifact instead: `qualify
+    # --substitutions` re-measures everything, and this refuses anything else.
+    effective = {**DEFINITIONAL_GEOGRAPHIES, **substitutions}
+    for entry_key, geography_key in sorted(GEOGRAPHY_BOUND_QUALIFICATIONS.items()):
+        measured_over = qualification[entry_key].get("geography")
+        expected = effective[geography_key]
+        if not isinstance(measured_over, str) or not measured_over.strip():
+            raise InstanceRefused(
+                f"qualification[{entry_key}] does not record the geography it "
+                f"was measured over; without it there is no way to tell whether "
+                f"the measurement describes the run this Instance governs")
+        if measured_over.strip().upper() != expected:
+            raise InstanceRefused(
+                f"qualification[{entry_key}] was measured over "
+                f"{measured_over.strip().upper()!r}, but this Instance runs "
+                f"{expected!r}. A substitution must be re-qualified against the "
+                f"artifact -- evidence for one geography cannot be attached to "
+                f"a run over another.")
+
+    # The S1/S3/S9 baselines are counts over exactly those three geographies,
+    # so binding the qualification entries above binds the baselines with them.
+
+    # -- the neighbour rule: an explicit decision, or a refusal --------------
+    #
+    # Where the measurement meets the literal rule there is nothing to decide.
+    # Where it does not, the Definition offers accept-with-recorded-decision or
+    # substitute-with-recorded-justification, and `qualify` deliberately refers
+    # rather than settles it. An Instance that simply carries the shortfall and
+    # says nothing about it is that referral going unanswered.
+    s1_entry = qualification["S1_district"]
+    comparable = s1_entry.get("comparable_or_greater")
+    if not isinstance(comparable, bool):
+        raise InstanceRefused(
+            "qualification[S1_district] does not record comparable_or_greater; "
+            "whether the neighbour satisfied the literal rule is the fact an "
+            "adjudication would be answering")
+    if comparable is False:
+        decision = s1_entry.get("owner_decision")
+        if not isinstance(decision, dict):
+            raise InstanceRefused(
+                f"the neighbour holds "
+                f"{s1_entry.get('measured_neighbour_ratio')!r} of the "
+                f"district's rows, below the literal 'comparable or greater', "
+                f"and qualification[S1_district] records no owner_decision. "
+                f"Adjudication is still pending, and a pending judgement is "
+                f"not a qualification.")
+        if str(decision.get("decision", "")).strip().lower() != "accepted":
+            raise InstanceRefused(
+                f"qualification[S1_district].owner_decision.decision is "
+                f"{decision.get('decision')!r}; only 'accepted' qualifies the "
+                f"case. Anything else leaves the Definition's other route -- "
+                f"substitute with recorded justification -- untaken.")
+        if not str(decision.get("justification", "")).strip():
+            raise InstanceRefused(
+                "qualification[S1_district].owner_decision records no "
+                "justification; an accepted shortfall with no stated reason is "
+                "a decision nobody can review")
 
     # `governs_run` is what ties this Instance to one Stage 1 run. Left blank or
     # left as the placeholder `qualify` wrote, it ties it to nothing -- and an
@@ -604,6 +679,20 @@ def qualify(m: Materialized, *, today: Optional[date] = None,
     }
     if s2_full <= 0:
         unqualified_definitional.append("S2_district")
+    # S3's sector carries the S3/S9 baselines, so it names the geography they
+    # were counted over. Without this the baselines are three numbers with no
+    # geography attached, and a substitution could not be checked against them.
+    qualification["S3_sector"] = {
+        "rule": ("a strict subset of S1's district, carrying the S3 and S9 "
+                 "aggregate baselines"),
+        "geography": definitional["S3_sector"],
+        "measured_rows": s3,
+        "measured_rows_category_all": s9,
+        "inside_s1_district": definitional["S3_sector"].split()[0] == (
+            definitional["S1_district"]),
+    }
+    if s3 <= 0:
+        unqualified_definitional.append("S3_sector")
 
     # -- S4: thin market, strictly below the threshold ----------------------
     sectors_ranked = _rank(m, "sector", months=24, today=today)
@@ -718,6 +807,8 @@ def qualify(m: Materialized, *, today: Optional[date] = None,
             "A CANDIDATE Instance. It is reviewed and committed as its own "
             "change before Stage 1 runs; it is never read as runtime "
             "configuration and nothing here is hard-coded into the tool."),
+        "definitional_geographies": dict(definitional),
+        "substituted": definitional != DEFINITIONAL_GEOGRAPHIES,
         "coverage": {"coverage_from": m.coverage_from,
                      "coverage_to": m.coverage_to,
                      "provisional_from": m.provisional_from},
@@ -1346,10 +1437,20 @@ def run_compare(*, instance: Stage1Instance, materialized: Materialized,
                     midnight["retries"] += exc.retries
                     midnight["unrecoverable"] = True
                     raise
-                except Exception as exc:  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001 -- recorded, then stops
+                    # Same rule as the correctness pass. Continuing would leave
+                    # this case short of its thirty repetitions, and the gate
+                    # would then report `insufficient_evidence` for a reason
+                    # buried in an error list rather than the snapshot error
+                    # that actually caused it. `zero_snapshot_errors` is
+                    # unreachable from here in any case.
                     snapshot_errors.append({"shape": case.shape,
                                             "error": f"{type(exc).__name__}: {exc}"})
-                    continue
+                    raise RunAborted(
+                        f"{case.shape}: the snapshot arm failed during the "
+                        f"latency pass ({type(exc).__name__}: {exc}); the "
+                        f"sample cannot be completed and no later repetition "
+                        f"runs")
                 latency_ms.append(elapsed)
                 per_case.setdefault(case.shape, []).append(elapsed)
 
@@ -1632,6 +1733,13 @@ def build_parser() -> argparse.ArgumentParser:
                                        "candidate Stage 1 Instance")
     q.add_argument("--cache-dir", default=None)
     q.add_argument("--out", required=True, type=Path)
+    q.add_argument(
+        "--substitutions", type=Path, default=None,
+        help=("JSON file carrying a `substitutions` block, to RE-QUALIFY the "
+              "artifact against substituted definitional geographies. Every "
+              "measurement is then taken over those geographies, which is the "
+              "only way a substituted Instance can carry evidence about the "
+              "run it governs."))
 
     c = sub.add_parser("compare", help="execute the frozen corpus against both "
                                        "arms and write the Stage 1 report")
@@ -1659,7 +1767,20 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     try:
         if args.mode == "qualify":
-            out = qualify(materialized)
+            substitutions: dict[str, str] = {}
+            if args.substitutions is not None:
+                try:
+                    raw = json.loads(args.substitutions.read_text())
+                except (OSError, ValueError) as exc:
+                    print(f"refused: substitutions file unreadable: {exc}")
+                    return 2
+                try:
+                    substitutions = validate_substitutions(
+                        raw.get("substitutions", raw))
+                except InstanceRefused as exc:
+                    print(f"refused: {exc}")
+                    return 2
+            out = qualify(materialized, definitional=substitutions or None)
             args.out.parent.mkdir(parents=True, exist_ok=True)
             args.out.write_text(json.dumps(out, indent=2, sort_keys=False))
             print(f"candidate instance written to {args.out}")


### PR DESCRIPTION
**Blocking note: do not merge, release, deploy, enable, or run `qualify`/`compare` without separate authorisation.** `PPD_SNAPSHOT_ENABLED` remains absent on both apps. Scope is `comps` only.

## What this is

Stage 1 as a **controlled production-Machine corpus run**: the thirteen frozen `comps` cases executed on the deployed `property-shared` Machine against the selected artifact `v20260828T194003Z`, which that Machine already materializes under `PPD_SNAPSHOT_SHADOW_ENABLED`.

**Zero production runtime change.** `property_core/`, `app/`, `property_app/`, `property_cli/`, `fly.toml`, `fly.app.toml`, `Dockerfile.app`, `.github/` — all untouched. No request-path sampling, no queue, no background thread, no telemetry. The comparator is a separate process invoked over `fly ssh console`, so it sits in no request path and *"shadow comparison never makes a live request fail"* holds by construction.

## Governing design — rev 10

Made **before Stage 1 started and before any Stage 1 evidence existed**. One exit criterion changes:

> ~~p95 < 1 second on real traffic~~ → **p95 < 1 second on the deployed production Machine and selected artifact, measured across the frozen corpus request mix**

Organic `comps` traffic here is sparse and uncontrolled, so a percentile over it measures the callers rather than the adapter. **What that gives up is stated, not hidden — the request mix is chosen, not observed.**

The Definition is also reconciled in two places, both before Stage 1: §11's open question about rows with no geography is **closed explicitly**, and §4 now records that tooling checks S1's qualitative rule *literally and refers the judgement* rather than redefining it.

## The verdict cannot pass on absence

| Criterion | Blocks when |
|---|---|
| `all_thirteen_cases_compared` | fewer than 13 cases with **both** arms, or any arm error |
| `corpus_invariants_hold` | any §3 universal invariant or case intent fails |
| `zero_unexplained_false_empties` | a false empty with an unclassified divergence |
| `zero_geography_contamination` | out-of-area rows **at the level the case asked at**, or a row with **no usable postcode**, on either arm |
| `field_equality_on_shared_ids` | a field mismatch, **or an empty id intersection with rows on both sides** |
| `every_divergence_classified` | `unclassified > 0` |
| `no_unconfirmed_classifications` | `operator_confirmation_required > 0` |
| `zero_snapshot_errors` | any snapshot-arm error |
| `p95_under_one_second` | not exactly 390 observations **and** 30 per case → `insufficient_evidence` |

The run **aborts on the first error on either arm**, still writing the partial failed report. A snapshot failure stops *before* that case makes its live call — `zero_snapshot_errors` is already unreachable, so the live call would be a request to HMLR for a comparison that can no longer happen.

## Design points worth review

**Containment is level-correct, on both arms.** `district` → outcode; `sector` → **and** sector; `postcode` → **and** the unit. A row with **no usable postcode** is a violation at every level: §11 left this open, and skipping such rows would settle it in the weakest direction — a source could return arbitrary rows with the geography blanked and every check would pass. Reported at sector/outcode granularity; unit violations and postcode-less rows are **counts**, never named.

**The vacuous-pass guard.** Live takes `transactionId` straight from SPARQL; the snapshot strips CSV braces. If those spellings differ, no id is shared and the equality criterion is vacuously true. Recorded as a **failure**.

**Truncation only from transport evidence** (`raw_bindings_returned` vs `fetch_limit`). Saturation is `context_not_evidence` and classifies nothing.

**Later A/C/D revision is blocking**, not advisory — it cannot be evidenced from these two sources.

**Midnight is never skipped.** Snapshot arm retries 3× (free); the live arm doesn't, against a one-per-case budget. Survivors abort and write the failed report. Both arms of a pair must share a calendar date.

**S1's rule is not redefined.** An earlier revision auto-qualified at a 10% neighbour ratio — a tenth is not "comparable or greater", and reading a frozen rule downwards inside an implementation is not a change an implementation may make. The tool now checks the literal rule and, below it, **neither passes nor fails**: it records the ratio and refers the judgement, exiting non-zero while adjudication is pending.

**The substitution route is restored.** §4 permits replacing the definitional geographies *with recorded justification*; a previous revision asserted they "cannot be substituted". All three move together — S3 is a sector inside S1's district — so substituting one alone would leave the containment relation silently false.

**Instance validation is complete and exact:** the full qualification key set, enforced staleness against the calendar, canonical `qualified_at` (`fromisoformat` accepts `"20260901"` and the week date `"2026-W36-2"`).

**The live bound is real.** `max_live_per_case` below 1 is refused before any work; the budget is checked before every live call.

**Deploy uses the release workflow.** `fly deploy` ships the working directory, not a commit. `release.yml` also **redeploys `propertydata`**, so the runbook carries post-release checks for it — health, status, absence of any `PPD_SNAPSHOT_*` secret, absence of the comparator, image. "Out of scope" describes what changes, not a reason to skip verifying that nothing did.

## Verification

`./scripts/validate.sh` → **1916 passed, 27 skipped.** Snapshot suite run repeatedly with identical results.

**47 mutations applied, run, reverted — every one caught**, across four matrices: safety properties, verdict wiring, and the two correction rounds. Two mutations were **retired rather than carried** — their targets (the "live exception escapes" path and the 10% threshold) no longer exist, and pretending to test them would have been worse than saying so.

Three mutation survivors during development were my tests' faults, not the code's, and each is noted in its commit: a dead `isinstance` guard, an exit-code branch masked by a sibling branch, and an isolation test that left another failure reason populated.

## Not done

`qualify` and `compare` have not been run. No release, no deploy, no flag set. The Stage 1 Instance does not exist — `qualify` produces a candidate on the Machine after this merges and deploys, reviewed and committed as its own evidence PR before Stage 1 begins.