### PR TITLE
chore(release): v1.18.0 -- out-of-band Stage 1 comparator, serving off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Versioning here is not strict SemVer: breaking changes are documented in a
 v1.11.0, v1.10.0, v1.4.0) rather than forcing a major bump. This entry follows
 that established practice.
 
+## v1.18.0 (2026-09-02) — out-of-band Stage 1 shadow comparator; serving still off
+
+Adds the Stage 1 shadow comparator and its frozen corpus definition, shipped in
+the `property-shared` image as an out-of-band operator tool. It sits outside the
+request path — the application never imports it and it is not wired into `CMD` —
+and is inert unless explicitly invoked with `PPD_SHADOW_COMPARE_ENABLED` set for
+that invocation. Snapshot serving remains off: `PPD_SNAPSHOT_ENABLED`, the sole
+routing authority for the snapshot-backed PPD/comps path, is absent from both
+applications. `propertydata` is redeployed by the shared release workflow, as on
+every release, and remains outside snapshot scope. Operational details are in
+`docs/ops/ppd-stage1-shadow-runbook.md` and `docs/design/ppd-source-routing.md`
+§7.2 (rev 10).
+
 ## v1.17.0 (2026-09-01) — non-blocking snapshot startup and a control-only shadow flag; serving still off
 
 Phase D measured 36.7 s of materialization plus 3.1 s of adapter-open

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.17.0"
+version = "1.18.0"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates (England & Wales, GOV.UK Bearer API), rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/uv.lock
+++ b/uv.lock
@@ -1301,7 +1301,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.17.0"
+version = "1.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Version and changelog only. No code, test, Dockerfile, fly config or workflow
change: this is release preparation for the already-merged, default-off Stage 1
shadow comparator (#51), which is on `main` but carries no version bump.

**Four files, all release metadata:**

| File | Change |
|---|---|
| `pyproject.toml` | `version` 1.17.0 → 1.18.0 |
| `server.json` | both version fields → 1.18.0 |
| `uv.lock` | generated by `uv lock`; only the editable root `property-shared` version field |
| `CHANGELOG.md` | new `## v1.18.0 (2026-09-02)` entry |

**What this does not do.** Merging this changes no behaviour. The comparator it
versions is out of band: the application never imports it, it is not wired into
`CMD`, and it is inert unless `PPD_SHADOW_COMPARE_ENABLED` is set for the
invocation. Snapshot serving stays off — `PPD_SNAPSHOT_ENABLED`, the sole routing
authority for the snapshot-backed PPD/comps path, is absent from both
applications. Publishing the release, running `qualify`, running `compare`, and
enabling the serving flag each remain separately authorised.

`propertydata` is redeployed by the shared release workflow, as on every release,
and remains outside snapshot scope.

Operational detail lives in `docs/ops/ppd-stage1-shadow-runbook.md` and
`docs/design/ppd-source-routing.md` §7.2 (rev 10), deliberately not restated in
the changelog.

**Local validation** on `14d1b99` (parent `3a5142c`, directly on `main`):
`./scripts/validate.sh` exit 0 — `uv lock --check` passed, pre-commit passed,
**1979 passed, 27 skipped, 0 failed**.
