### PR TITLE
chore(release): v1.18.1 -- fix sparse Stage 1 qualification selection, serving off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Versioning here is not strict SemVer: breaking changes are documented in a
 v1.11.0, v1.10.0, v1.4.0) rather than forcing a major bump. This entry follows
 that established practice.
 
+## v1.18.1 (2026-09-02) — fix sparse Stage 1 qualification selection; serving still off
+
+Fixes the out-of-band Stage 1 comparator’s selection of sparse placeholders,
+so `S4_thin` and `S11_provisional_empty` are selected from the eligible
+artifact population rather than the dense top-200 candidate pool. Corpus
+definitions, frozen parameters and snapshot-serving policy are unchanged.
+The `property-shared` image changes, but the comparator remains outside the
+request path and inert unless explicitly invoked. Snapshot serving remains off.
+
 ## v1.18.0 (2026-09-02) — out-of-band Stage 1 shadow comparator; serving still off
 
 Adds the Stage 1 shadow comparator and its frozen corpus definition, shipped in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.18.0"
+version = "1.18.1"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates (England & Wales, GOV.UK Bearer API), rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/uv.lock
+++ b/uv.lock
@@ -1301,7 +1301,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.18.0"
+version = "1.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
**Release metadata only.** No code, test, corpus, specification, Dockerfile,
Fly configuration or workflow change — the comparator fix this versions is
already on `main` (#53, merge commit `d6a402a`).

| File | Change |
|---|---|
| `pyproject.toml` | version 1.18.0 → 1.18.1 |
| `server.json` | both version fields → 1.18.1 |
| `uv.lock` | regenerated with `uv lock`; only the editable root `property-shared` version |
| `CHANGELOG.md` | new `## v1.18.1 (2026-09-02)` entry |

## Why a patch

`main` currently carries the fix while still versioned `1.18.0` — the same
version as the published release, with different code. `release.yml` publishes
to PyPI with `skip_existing: true`, so releasing in that state would silently
skip PyPI while still redeploying both apps. This bump resolves that.

Classified as a patch under the repository's stated convention (see the note at
the top of `CHANGELOG.md`): a defect repair with no API, response, data,
dependency, configuration or flag change. The `property-shared` **image content
does change**, because the comparator file is baked into it by `Dockerfile`;
`Dockerfile.app` does not copy that file, so `propertydata`'s image content is
unaffected, though the shared release workflow still rebuilds and redeploys it
as it does on every release.

## This enables nothing

The comparator remains out of band: never imported by the application, not
wired into `CMD`, and inert unless `PPD_SHADOW_COMPARE_ENABLED` is set for the
invocation. **Snapshot serving remains off** — `PPD_SNAPSHOT_ENABLED`, the sole
routing authority for the snapshot-backed PPD/comps path, is absent from both
applications.

Merging this changes nothing that is running. Publishing the release, re-running
`qualify` against the redeployed artifact, running `compare`, and any serving
enablement each remain separately authorised. The failed v1.18.0 qualification
candidate is diagnostic evidence only and must never be promoted or reused as a
Stage 1 Instance.

## Validation

`./scripts/validate.sh` exit 0 on `c269ba1`: `uv lock --check` passed,
pre-commit passed, **1994 passed, 27 skipped, 0 failed**. The four
`tests/test_release_manifest_version.py` guards pass, confirming
`pyproject.toml`, both `server.json` fields and the changelog heading agree.
