### PR TITLE
docs(changelog): correct the v1.18.1 heading date to 2026-09-03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Versioning here is not strict SemVer: breaking changes are documented in a
 v1.11.0, v1.10.0, v1.4.0) rather than forcing a major bump. This entry follows
 that established practice.
 
-## v1.18.1 (2026-09-02) — fix sparse Stage 1 qualification selection; serving still off
+## v1.18.1 (2026-09-03) — fix sparse Stage 1 qualification selection; serving still off
 
 Fixes the out-of-band Stage 1 comparator’s selection of sparse placeholders,
 so `S4_thin` and `S11_provisional_empty` are selected from the eligible


### PR DESCRIPTION
One-line documentation fix ahead of the v1.18.1 release.

The v1.18.1 changelog entry was drafted on 2026-09-02 and dated that day, but the release was never published: no `v1.18.1` tag or GitHub release exists and production is still serving v1.18.0. The heading now carries the intended publication date, **2026-09-03**, rather than the drafting date.

## Diff

```diff
-## v1.18.1 (2026-09-02) — fix sparse Stage 1 qualification selection; serving still off
+## v1.18.1 (2026-09-03) — fix sparse Stage 1 qualification selection; serving still off
```

One file, one line. The v1.18.0 heading immediately below carries the same date and is deliberately **not** touched — that release was published on 2026-09-02.

## Explicitly unchanged

`version` in `pyproject.toml` (still `1.18.1`), `uv.lock`, corpus definitions, frozen parameters, Stage 1 evidence files, configuration, images, secrets and the snapshot-serving policy. **Snapshot serving remains off.** No qualification rerun, comparison, HMLR call or serving-flag change is part of this PR.

## Validation

`./scripts/validate.sh` — exit 0 (lockfile check, pre-commit all-files, full suite): **1994 passed, 27 skipped**. Focused release-manifest/version tests (`test_release_manifest_version.py`, `test_mcp_server_card_version.py`, `snapshot/test_rollout_premises.py`): **66 passed**.

Held for review — not to be merged, tagged, published or deployed as part of this task.