### PR TITLE
release: v1.18.2 — live-arm diagnostic evidence for rate-limit failures; serving still off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ Versioning here is not strict SemVer: breaking changes are documented in a
 v1.11.0, v1.10.0, v1.4.0) rather than forcing a major bump. This entry follows
 that established practice.
 
-## v1.18.1 (2026-09-03) — fix sparse Stage 1 qualification selection; serving still off
+## v1.18.2 (2026-09-02) — live-arm diagnostic evidence for rate-limit failures; serving still off
+
+The out-of-band Stage 1 comparator now records why a live observation failed,
+not just that it did. A failed live arm keeps the HTTP status and reason and an
+allow-listed subset of response headers — `Retry-After`, `RateLimit-*` and
+`X-RateLimit-*` — and every live observation records when it started and
+finished, so the realised spacing between requests can be read off the report
+rather than inferred. The first Stage 1 run stopped on an HTTP 429 and preserved
+only the error string, which left the pacing question unanswerable.
+
+Comparison semantics are unchanged: one live observation per case, the same
+budget guard, no retry, no resume, no automatic backoff. The response body is
+never read and no public response model is widened; the change is confined to
+the comparator, which stays outside the request path. Snapshot serving remains
+off.
+
+## v1.18.1 (2026-09-02) — fix sparse Stage 1 qualification selection; serving still off
 
 Fixes the out-of-band Stage 1 comparator’s selection of sparse placeholders,
 so `S4_thin` and `S11_provisional_empty` are selected from the eligible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "property-shared"
-version = "1.18.1"
+version = "1.18.2"
 description = "UK property data MCP server and API — Land Registry comparable sales, Rightmove listings, EPC certificates (England & Wales, GOV.UK Bearer API), rental analysis, and stamp duty."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/property-shared",
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "websiteUrl": "https://bouch.dev/products/property-report",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "property-shared",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }

--- a/uv.lock
+++ b/uv.lock
@@ -1301,7 +1301,7 @@ wheels = [
 
 [[package]]
 name = "property-shared"
-version = "1.18.1"
+version = "1.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Release prep for the Stage 1 comparator diagnostics already merged in #57. Version surfaces plus one changelog entry — no code change.

## Changed

| File | Change |
|---|---|
| `pyproject.toml` | `1.18.1` → `1.18.2` |
| `server.json` | both version fields (top-level and `packages[0]`) → `1.18.2` |
| `uv.lock` | regenerated — `property-shared v1.18.1 -> v1.18.2` |
| `CHANGELOG.md` | one new entry, plus a one-line correction (below) |

## Changelog entry

`## v1.18.2 (2026-09-02) — live-arm diagnostic evidence for rate-limit failures; serving still off`

The comparator now records *why* a live observation failed, not just that it did: HTTP status and reason, an allow-listed subset of response headers (`Retry-After`, `RateLimit-*`, `X-RateLimit-*`), and start/finish timestamps on every live observation so realised request spacing can be read off the report. The first Stage 1 run stopped on an HTTP 429 and preserved only the error string, which left the pacing question unanswerable.

Comparison semantics unchanged: one live observation per case, same budget guard, no retry, no resume, no automatic backoff. Body never read, no public model widened, comparator stays outside the request path. **Snapshot serving remains off.**

## Also: a v1.18.1 date correction

The v1.18.1 heading is corrected from `2026-09-03` back to **`2026-09-02`**.

PR #55 moved that date *forward* to 2026-09-03 as the intended publication date; the release then actually published on **2026-09-02T11:17:49Z**, leaving the changelog a day ahead of the artifact it describes. This restores agreement with what shipped. Included here deliberately rather than left to drift.

## Validation

`./scripts/validate.sh` — **exit 0**: lockfile check, pre-commit all-files, **2011 passed, 27 skipped**. Focused release-manifest/version tests: **10 passed**.

## Scope

No code, configuration, secret, flag or serving change. Nothing is published or deployed by this PR — publishing v1.18.2 is a separate approval, and only that triggers PyPI plus both Fly deploys.