### PR TITLE
ops(stage1): recover orphaned 2 September Stage 1 evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ scripts/*
 !scripts/rightmove_address_dump.py
 !scripts/fly_observability_snapshot.py
 !scripts/validate.sh
+
+# Live git worktrees, not disposable scratch. Untracked and unignored, this
+# directory presented as `?? .claude/worktrees/` in every status, one
+# `git clean -fd` away from destroying four checked-out worktrees. Ignoring it
+# is the protection: git clean skips ignored paths without -x.
+.claude/worktrees/

--- a/docs/ops/evidence/2026-09-02-stage1-before.json
+++ b/docs/ops/evidence/2026-09-02-stage1-before.json
@@ -1,0 +1,1432 @@
+{
+  "schema_version": "2",
+  "target": {
+    "app": "property-shared",
+    "org": "personal",
+    "metrics_prefix": "property_shared"
+  },
+  "query": {
+    "window": "30m",
+    "started_at": "2026-09-02T00:01:16Z",
+    "ended_at": "2026-09-02T00:01:27Z",
+    "prometheus_base": "https://api.fly.io/prometheus/personal/api/v1",
+    "auth_scheme": "FlyV1",
+    "scrape_interval_seconds": 15
+  },
+  "series": [
+    {
+      "key": "instance_up",
+      "title": "Instance up",
+      "promql": "fly_instance_up{app=\"property-shared\"}",
+      "unit": "bool",
+      "kind": "instant",
+      "status": "ok",
+      "value": 1.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "value": 1.0,
+          "timestamp": 1788307276
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": ""
+    },
+    {
+      "key": "instance_info",
+      "title": "Machine identity",
+      "promql": "fly_instance_info{app=\"property-shared\"}",
+      "unit": "info",
+      "kind": "instant",
+      "status": "ok",
+      "value": 1.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "cpu_count": "1",
+            "cpu_kind": "shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "memory_mb": "2048",
+            "process_group": "app",
+            "region": "lhr"
+          },
+          "value": 1.0,
+          "timestamp": 1788307276
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": "Labels carry instance (Machine ID), cpu_kind, cpu_count, memory_mb, process_group."
+    },
+    {
+      "key": "instance_uptime_seconds",
+      "title": "Instance uptime",
+      "promql": "fly_instance_uptime_seconds{app=\"property-shared\"}",
+      "unit": "seconds",
+      "kind": "instant",
+      "status": "ok",
+      "value": 55005.00773938,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "value": 55005.00773938,
+          "timestamp": 1788307277
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": "Resets on Machine restart \u2014 the cheapest check that a restart actually happened."
+    },
+    {
+      "key": "scrape_up",
+      "title": "Metrics scrape up",
+      "promql": "up{app=\"property-shared\"}",
+      "unit": "bool",
+      "kind": "instant",
+      "status": "ok",
+      "value": 1.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "value": 1.0,
+          "timestamp": 1788307277
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": "0 here means Fly could not scrape the app's /metrics; app_custom series then go stale."
+    },
+    {
+      "key": "app_concurrency",
+      "title": "App concurrency",
+      "promql": "fly_app_concurrency{app=\"property-shared\"}",
+      "unit": "connections",
+      "kind": "instant",
+      "status": "no_data",
+      "value": null,
+      "samples": [],
+      "error": null,
+      "no_data_reason": "empty_result",
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": "Verified absent for property-shared and propertydata on 2026-09-01 while present for five other fleet apps. Expect no_data, and do not read it as zero."
+    },
+    {
+      "key": "load_average_5m",
+      "title": "Load average (5m)",
+      "promql": "fly_instance_load_average{app=\"property-shared\",minutes=\"5\"}",
+      "unit": "load",
+      "kind": "instant",
+      "status": "ok",
+      "value": 0.01,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "minutes": "5",
+            "region": "lhr"
+          },
+          "value": 0.01,
+          "timestamp": 1788307277
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": ""
+    },
+    {
+      "key": "load_average_5m_peak",
+      "title": "Load average (5m) peak over window",
+      "promql": "max_over_time(fly_instance_load_average{app=\"property-shared\",minutes=\"5\"}[30m])",
+      "unit": "load",
+      "kind": "instant",
+      "status": "ok",
+      "value": 0.02,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "minutes": "5",
+            "region": "lhr"
+          },
+          "value": 0.02,
+          "timestamp": 1788307278
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "max_over_time over the collection window of the kernel 5-minute load average.",
+      "note": ""
+    },
+    {
+      "key": "cpu_busy_pct",
+      "title": "CPU busy",
+      "promql": "100 * (1 - sum(rate(fly_instance_cpu{app=\"property-shared\",mode=\"idle\"}[30m])) / sum(rate(fly_instance_cpu{app=\"property-shared\"}[30m])))",
+      "unit": "percent",
+      "kind": "instant",
+      "status": "ok",
+      "value": 0.42335165446494294,
+      "samples": [
+        {
+          "labels": {},
+          "value": 0.42335165446494294,
+          "timestamp": 1788307278
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "100 * (1 - idle_rate / total_rate) across all cpu modes and cpu_ids over the window.",
+      "note": ""
+    },
+    {
+      "key": "cpu_throttle",
+      "title": "CPU throttle",
+      "promql": "fly_instance_cpu_throttle{app=\"property-shared\"}",
+      "unit": "count",
+      "kind": "instant",
+      "status": "ok",
+      "value": 0.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "value": 0.0,
+          "timestamp": 1788307278
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": ""
+    },
+    {
+      "key": "memory_total",
+      "title": "Machine memory total",
+      "promql": "fly_instance_memory_mem_total{app=\"property-shared\"}",
+      "unit": "bytes",
+      "kind": "instant",
+      "status": "ok",
+      "value": 2064257024.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "value": 2064257024.0,
+          "timestamp": 1788307278
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": ""
+    },
+    {
+      "key": "memory_available",
+      "title": "Machine memory available",
+      "promql": "fly_instance_memory_mem_available{app=\"property-shared\"}",
+      "unit": "bytes",
+      "kind": "instant",
+      "status": "ok",
+      "value": 1692741632.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "value": 1692741632.0,
+          "timestamp": 1788307278
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": ""
+    },
+    {
+      "key": "memory_available_min",
+      "title": "Machine memory available, minimum over window",
+      "promql": "min_over_time(fly_instance_memory_mem_available{app=\"property-shared\"}[30m])",
+      "unit": "bytes",
+      "kind": "instant",
+      "status": "ok",
+      "value": 1692741632.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "value": 1692741632.0,
+          "timestamp": 1788307279
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "min_over_time of MemAvailable over the window \u2014 the Machine-wide low-water mark.",
+      "note": "This is the G1a Machine-wide available-memory figure, not process RSS."
+    },
+    {
+      "key": "instance_exit_oom",
+      "title": "OOM exits",
+      "promql": "fly_instance_exit_oom{app=\"property-shared\"}",
+      "unit": "count",
+      "kind": "instant",
+      "status": "no_data",
+      "value": null,
+      "samples": [],
+      "error": null,
+      "no_data_reason": "empty_result",
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": "Absent unless an OOM kill has occurred; no_data here is the healthy reading."
+    },
+    {
+      "key": "rootfs_free_bytes",
+      "title": "Root filesystem free",
+      "promql": "fly_instance_filesystem_blocks_free{app=\"property-shared\"} * fly_instance_filesystem_block_size{app=\"property-shared\"}",
+      "unit": "bytes",
+      "kind": "instant",
+      "status": "ok",
+      "value": 8038342656.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "mount": "/.fly-upper-layer",
+            "region": "lhr"
+          },
+          "value": 8038342656.0,
+          "timestamp": 1788307279
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "blocks_free * block_size, per mount. Mount label identifies the filesystem.",
+      "note": "Fly's ephemeral rootfs reports as mount /.fly-upper-layer. This is the free-space figure the snapshot preflight (bundle_bytes * 2.5) is measured against."
+    },
+    {
+      "key": "rootfs_free_bytes_min",
+      "title": "Root filesystem free, minimum over window",
+      "promql": "min_over_time((fly_instance_filesystem_blocks_free{app=\"property-shared\"} * fly_instance_filesystem_block_size{app=\"property-shared\"})[30m:15s])",
+      "unit": "bytes",
+      "kind": "instant",
+      "status": "ok",
+      "value": 8038342656.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "mount": "/.fly-upper-layer",
+            "region": "lhr"
+          },
+          "value": 8038342656.0,
+          "timestamp": 1788307279
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "min_over_time of (blocks_free * block_size) on the same mount, sampled at 15s (Fly's real stored resolution) over the window. This is the free-space low-water mark, nothing more. The additional space a run consumed is baseline_free - minimum_free on that mount \u2014 see summarise_transient_disk(). It is NOT total_bytes - minimum_free, which is total disk in use including the image and everything already present.",
+      "note": "Corroborating only. At 15s resolution a materialisation lasting ~20 s yields one or two samples and its true peak can fall entirely between them. The verifier's own 0.2 s directory sampling is the authoritative transient-disk measurement."
+    },
+    {
+      "key": "rootfs_total_bytes",
+      "title": "Root filesystem total",
+      "promql": "fly_instance_filesystem_blocks{app=\"property-shared\"} * fly_instance_filesystem_block_size{app=\"property-shared\"}",
+      "unit": "bytes",
+      "kind": "instant",
+      "status": "ok",
+      "value": 8350298112.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "mount": "/.fly-upper-layer",
+            "region": "lhr"
+          },
+          "value": 8350298112.0,
+          "timestamp": 1788307279
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "blocks * block_size, per mount.",
+      "note": ""
+    },
+    {
+      "key": "net_recv_bytes_rate",
+      "title": "Network received",
+      "promql": "sum(rate(fly_instance_net_recv_bytes{app=\"property-shared\",device=\"eth0\"}[30m]))",
+      "unit": "bytes/sec",
+      "kind": "instant",
+      "status": "ok",
+      "value": 341.08925495041393,
+      "samples": [
+        {
+          "labels": {},
+          "value": 341.08925495041393,
+          "timestamp": 1788307279
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "rate() of the eth0 counter over the window, summed.",
+      "note": ""
+    },
+    {
+      "key": "net_sent_bytes_rate",
+      "title": "Network sent",
+      "promql": "sum(rate(fly_instance_net_sent_bytes{app=\"property-shared\",device=\"eth0\"}[30m]))",
+      "unit": "bytes/sec",
+      "kind": "instant",
+      "status": "ok",
+      "value": 4236.625979652234,
+      "samples": [
+        {
+          "labels": {},
+          "value": 4236.625979652234,
+          "timestamp": 1788307280
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "rate() of the eth0 counter over the window, summed.",
+      "note": ""
+    },
+    {
+      "key": "app_http_responses_by_status",
+      "title": "App HTTP responses by status",
+      "promql": "sum by (status) (increase(fly_app_http_responses_count{app=\"property-shared\"}[30m]))",
+      "unit": "responses",
+      "kind": "instant",
+      "status": "ok",
+      "value": null,
+      "samples": [
+        {
+          "labels": {
+            "status": "200"
+          },
+          "value": 88.0,
+          "timestamp": 1788307280
+        },
+        {
+          "labels": {
+            "status": "202"
+          },
+          "value": 31.0,
+          "timestamp": 1788307280
+        },
+        {
+          "labels": {
+            "status": "400"
+          },
+          "value": 1.0,
+          "timestamp": 1788307280
+        },
+        {
+          "labels": {
+            "status": "404"
+          },
+          "value": 15.0,
+          "timestamp": 1788307280
+        },
+        {
+          "labels": {
+            "status": "405"
+          },
+          "value": 4.0,
+          "timestamp": 1788307280
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "increase() of the Fly proxy app-side response counter over the window, by status.",
+      "note": ""
+    },
+    {
+      "key": "edge_http_responses_by_status",
+      "title": "Edge HTTP responses by status",
+      "promql": "sum by (status) (increase(fly_edge_http_responses_count{app=\"property-shared\"}[30m]))",
+      "unit": "responses",
+      "kind": "instant",
+      "status": "ok",
+      "value": null,
+      "samples": [
+        {
+          "labels": {
+            "status": "200"
+          },
+          "value": 57.0,
+          "timestamp": 1788307280
+        },
+        {
+          "labels": {
+            "status": "202"
+          },
+          "value": 22.0,
+          "timestamp": 1788307280
+        },
+        {
+          "labels": {
+            "status": "400"
+          },
+          "value": 3.0,
+          "timestamp": 1788307280
+        },
+        {
+          "labels": {
+            "status": "404"
+          },
+          "value": 16.0,
+          "timestamp": 1788307280
+        },
+        {
+          "labels": {
+            "status": "405"
+          },
+          "value": 3.0,
+          "timestamp": 1788307280
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "increase() of the Fly edge response counter over the window, by status.",
+      "note": "Edge series carry no instance label \u2014 they are per-PoP, not per-Machine."
+    },
+    {
+      "key": "app_http_p95",
+      "title": "App HTTP p95 latency",
+      "promql": "histogram_quantile(0.95, sum by (le) (rate(fly_app_http_response_time_seconds_bucket{app=\"property-shared\"}[30m])))",
+      "unit": "seconds",
+      "kind": "instant",
+      "status": "ok",
+      "value": 0.021750741967929216,
+      "samples": [
+        {
+          "labels": {},
+          "value": 0.021750741967929216,
+          "timestamp": 1788307280
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "histogram_quantile(0.95) over the Fly proxy app-side latency histogram.",
+      "note": ""
+    },
+    {
+      "key": "app_http_p99",
+      "title": "App HTTP p99 latency",
+      "promql": "histogram_quantile(0.99, sum by (le) (rate(fly_app_http_response_time_seconds_bucket{app=\"property-shared\"}[30m])))",
+      "unit": "seconds",
+      "kind": "instant",
+      "status": "ok",
+      "value": 0.02435014839358584,
+      "samples": [
+        {
+          "labels": {},
+          "value": 0.02435014839358584,
+          "timestamp": 1788307281
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "histogram_quantile(0.99) over the Fly proxy app-side latency histogram.",
+      "note": ""
+    },
+    {
+      "key": "edge_http_p95",
+      "title": "Edge HTTP p95 latency",
+      "promql": "histogram_quantile(0.95, sum by (le) (rate(fly_edge_http_response_time_seconds_bucket{app=\"property-shared\"}[30m])))",
+      "unit": "seconds",
+      "kind": "instant",
+      "status": "ok",
+      "value": 0.12386113293808856,
+      "samples": [
+        {
+          "labels": {},
+          "value": 0.12386113293808856,
+          "timestamp": 1788307281
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "histogram_quantile(0.95) over the Fly edge latency histogram.",
+      "note": ""
+    },
+    {
+      "key": "hard_limit_reached",
+      "title": "Concurrency hard limit reached",
+      "promql": "sum(increase(fly_app_hard_limit_reached_count{app=\"property-shared\"}[30m]))",
+      "unit": "events",
+      "kind": "instant",
+      "status": "ok",
+      "value": 0.0,
+      "samples": [
+        {
+          "labels": {},
+          "value": 0.0,
+          "timestamp": 1788307282
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "increase() over the window.",
+      "note": ""
+    },
+    {
+      "key": "soft_limit_reached",
+      "title": "Concurrency soft limit reached",
+      "promql": "sum(increase(fly_app_soft_limit_reached_count{app=\"property-shared\"}[30m]))",
+      "unit": "events",
+      "kind": "instant",
+      "status": "ok",
+      "value": 0.0,
+      "samples": [
+        {
+          "labels": {},
+          "value": 0.0,
+          "timestamp": 1788307282
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "increase() over the window.",
+      "note": ""
+    },
+    {
+      "key": "process_rss",
+      "title": "Process RSS",
+      "promql": "process_resident_memory_bytes{app=\"property-shared\"}",
+      "unit": "bytes",
+      "kind": "instant",
+      "status": "ok",
+      "value": 198901760.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "value": 198901760.0,
+          "timestamp": 1788307282
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "app_custom",
+      "derived": false,
+      "derivation": "",
+      "note": "Scraped from the app's own /metrics; single uvicorn process (see gate G2)."
+    },
+    {
+      "key": "process_rss_peak",
+      "title": "Process RSS peak over window",
+      "promql": "max_over_time(process_resident_memory_bytes{app=\"property-shared\"}[30m])",
+      "unit": "bytes",
+      "kind": "instant",
+      "status": "ok",
+      "value": 198901760.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "value": 198901760.0,
+          "timestamp": 1788307282
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "app_custom",
+      "derived": true,
+      "derivation": "max_over_time of the scraped RSS gauge over the window.",
+      "note": "Bounded below by the scrape interval: a spike shorter than one scrape is invisible here. Not a substitute for measuring RSS inside the process under test."
+    },
+    {
+      "key": "process_open_fds",
+      "title": "Open file descriptors",
+      "promql": "process_open_fds{app=\"property-shared\"}",
+      "unit": "count",
+      "kind": "instant",
+      "status": "ok",
+      "value": 10.0,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "value": 10.0,
+          "timestamp": 1788307283
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "app_custom",
+      "derived": false,
+      "derivation": "",
+      "note": ""
+    },
+    {
+      "key": "app_requests_by_route",
+      "title": "App requests by surface/route/status class",
+      "promql": "sum by (surface, route, status_class) (increase(property_shared_http_requests_total{app=\"property-shared\"}[30m]))",
+      "unit": "requests",
+      "kind": "instant",
+      "status": "ok",
+      "value": null,
+      "samples": [
+        {
+          "labels": {
+            "route": "/.well-known/glama.json",
+            "status_class": "2xx",
+            "surface": "web"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "route": "/mcp",
+            "status_class": "2xx",
+            "surface": "mcp_proxy"
+          },
+          "value": 119.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "route": "/mcp",
+            "status_class": "4xx",
+            "surface": "mcp_proxy"
+          },
+          "value": 12.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "route": "/v1/health",
+            "status_class": "2xx",
+            "surface": "infra"
+          },
+          "value": 60.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "route": "/v1/meta",
+            "status_class": "2xx",
+            "surface": "api"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "route": "/v1/meta/integrations",
+            "status_class": "2xx",
+            "surface": "api"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "route": "/web",
+            "status_class": "2xx",
+            "surface": "web"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "route": "/web",
+            "status_class": "4xx",
+            "surface": "web"
+          },
+          "value": 12.0,
+          "timestamp": 1788307283
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "app_custom",
+      "derived": true,
+      "derivation": "increase() of the app's own request counter over the window.",
+      "note": ""
+    },
+    {
+      "key": "app_request_p95",
+      "title": "App-measured request p95 latency",
+      "promql": "histogram_quantile(0.95, sum by (le) (rate(property_shared_http_request_duration_seconds_bucket{app=\"property-shared\"}[30m])))",
+      "unit": "seconds",
+      "kind": "instant",
+      "status": "ok",
+      "value": 0.0082125,
+      "samples": [
+        {
+          "labels": {},
+          "value": 0.0082125,
+          "timestamp": 1788307283
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "app_custom",
+      "derived": true,
+      "derivation": "histogram_quantile(0.95) over the app's own request-duration histogram.",
+      "note": ""
+    },
+    {
+      "key": "app_tool_calls",
+      "title": "MCP tool calls by tool and status",
+      "promql": "sum by (tool, status) (increase(property_shared_tool_calls_total{app=\"property-shared\"}[30m]))",
+      "unit": "calls",
+      "kind": "instant",
+      "status": "ok",
+      "value": null,
+      "samples": [
+        {
+          "labels": {
+            "status": "error",
+            "tool": "epc_certificate"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "status": "error",
+            "tool": "ppd_transactions"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "status": "error",
+            "tool": "rental_analysis"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "status": "error",
+            "tool": "rightmove_search"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "status": "ok",
+            "tool": "epc_certificate"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "status": "ok",
+            "tool": "ppd_transactions"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "status": "ok",
+            "tool": "property_comps"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "status": "ok",
+            "tool": "property_epc_summaries"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "status": "ok",
+            "tool": "rightmove_search"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        },
+        {
+          "labels": {
+            "status": "ok",
+            "tool": "stamp_duty"
+          },
+          "value": 0.0,
+          "timestamp": 1788307283
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "app_custom",
+      "derived": true,
+      "derivation": "increase() of the MCP tool-call counter over the window.",
+      "note": "Verified to have no live series for property-shared on 2026-09-01 despite the duration histogram existing \u2014 the counter is stale, not zero."
+    },
+    {
+      "key": "app_client_connections",
+      "title": "MCP client handshakes by client",
+      "promql": "sum by (client_name) (increase(property_shared_client_connections_total{app=\"property-shared\"}[30m]))",
+      "unit": "handshakes",
+      "kind": "instant",
+      "status": "ok",
+      "value": null,
+      "samples": [
+        {
+          "labels": {
+            "client_name": "AgentIndexBot"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "Anthropic/ClaudeAI"
+          },
+          "value": 1.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "Kelivo MCP"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "acton-probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "acton-skill-extractor"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "agent-tools.cloud"
+          },
+          "value": 1.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "agent-world-probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "agentage-mcp-catalog-health"
+          },
+          "value": 1.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "aisec-registry-probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "avp1-scan"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "chathome-skills-probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "claude-ai (via mcp-remote 0.8.3)"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "claude-code"
+          },
+          "value": 2.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "codex-mcp-client"
+          },
+          "value": 3.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "factanker-probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "forge-registry-probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "glama"
+          },
+          "value": 1.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "glimind-probe"
+          },
+          "value": 4.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "golemreach-trust"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "hultra-link"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "ledgerhall"
+          },
+          "value": 18.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "local-agent-mode-property (via mcp-remote 0.8.3)"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "mcp"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "mcp-checker"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "mcp-ledger-probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "mcp-remote-fallback-test"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "mcp-rugpull-research"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "mcp2-research"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "mcpbeat"
+          },
+          "value": 1.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "mcphq-probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "mcpindex-trust"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "mcpscan"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "policylayer-crawler"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "proofbench-probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "sheet-add-in"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "test"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        },
+        {
+          "labels": {
+            "client_name": "unreached-probe"
+          },
+          "value": 0.0,
+          "timestamp": 1788307284
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "app_custom",
+      "derived": true,
+      "derivation": "increase() of the MCP initialize-handshake counter over the window.",
+      "note": ""
+    },
+    {
+      "key": "range_memory_available",
+      "title": "Machine memory available over time",
+      "promql": "fly_instance_memory_mem_available{app=\"property-shared\"}",
+      "unit": "bytes",
+      "kind": "range",
+      "status": "ok",
+      "value": null,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "points": 61,
+          "min": 1692741632.0,
+          "max": 1692741632.0,
+          "first": 1692741632.0,
+          "last": 1692741632.0
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": false,
+      "derivation": "",
+      "note": ""
+    },
+    {
+      "key": "range_rootfs_free",
+      "title": "Root filesystem free over time",
+      "promql": "fly_instance_filesystem_blocks_free{app=\"property-shared\"} * fly_instance_filesystem_block_size{app=\"property-shared\"}",
+      "unit": "bytes",
+      "kind": "range",
+      "status": "ok",
+      "value": null,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "mount": "/.fly-upper-layer",
+            "region": "lhr"
+          },
+          "points": 61,
+          "min": 8038342656.0,
+          "max": 8038342656.0,
+          "first": 8038342656.0,
+          "last": 8038342656.0
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "fly_builtin",
+      "derived": true,
+      "derivation": "blocks_free * block_size, per mount, sampled across the window.",
+      "note": ""
+    },
+    {
+      "key": "range_process_rss",
+      "title": "Process RSS over time",
+      "promql": "process_resident_memory_bytes{app=\"property-shared\"}",
+      "unit": "bytes",
+      "kind": "range",
+      "status": "ok",
+      "value": null,
+      "samples": [
+        {
+          "labels": {
+            "app": "property-shared",
+            "host": "81e9",
+            "instance": "7849207a412608",
+            "region": "lhr"
+          },
+          "points": 61,
+          "min": 198901760.0,
+          "max": 198901760.0,
+          "first": 198901760.0,
+          "last": 198901760.0
+        }
+      ],
+      "error": null,
+      "no_data_reason": null,
+      "provenance": "app_custom",
+      "derived": false,
+      "derivation": "",
+      "note": ""
+    }
+  ],
+  "transient_disk": [
+    {
+      "status": "ok",
+      "baseline_free_bytes": 8038342656.0,
+      "minimum_free_bytes": 8038342656.0,
+      "total_bytes": 8350298112.0,
+      "delta_bytes": 0.0,
+      "method": "delta_bytes = baseline_free - minimum_free, on one mount. Not total_bytes - minimum_free, which measures total occupancy.",
+      "resolution_caveat": "Fly stores one sample per 15s. A materialisation lasting ~20 s produces one or two samples, so this delta may understate the true peak or miss it entirely.",
+      "authoritative_source": "/app/boot_only_verify.py, which samples the verifier directory every 0.2 s, is the authoritative transient-disk measurement; this delta only corroborates it.",
+      "labels": {
+        "app": "property-shared",
+        "host": "81e9",
+        "instance": "7849207a412608",
+        "mount": "/.fly-upper-layer",
+        "region": "lhr"
+      },
+      "points": 61
+    }
+  ],
+  "commands": [
+    {
+      "key": "status",
+      "command": "fly status --json -a property-shared",
+      "status": "ok",
+      "data": {
+        "name": "property-shared",
+        "hostname": "property-shared.fly.dev",
+        "machines": [
+          {
+            "id": "7849207a412608",
+            "state": "started",
+            "region": "lhr",
+            "image": "registry.fly.io/property-shared:deployment-01M1E210R0WZARCGJRC5VSZAKY",
+            "created_at": "2026-01-21T19:31:15Z",
+            "updated_at": "2026-09-01T08:43:59Z"
+          }
+        ]
+      },
+      "error": null
+    },
+    {
+      "key": "checks",
+      "command": "fly checks list --json -a property-shared",
+      "status": "ok",
+      "data": [
+        {
+          "machine": "7849207a412608",
+          "name": "servicecheck-00-http-8080",
+          "status": "passing",
+          "output": "{\"status\":\"ok\"}"
+        }
+      ],
+      "error": null
+    },
+    {
+      "key": "image",
+      "command": "fly image show --json -a property-shared",
+      "status": "ok",
+      "data": [
+        {
+          "Registry": "registry.fly.io",
+          "Repository": "property-shared",
+          "Tag": "deployment-01M1E210R0WZARCGJRC5VSZAKY",
+          "Digest": "sha256:863733618cc80d35cb2a2f2f8999c17baa74e35e1ce9dc837069e2866d0f0818",
+          "Labels": "{\"GH_ACTION_NAME\":\"__run\",\"GH_EVENT_NAME\":\"release\",\"GH_REPO\":\"paulieb89/property-shared\",\"GH_SHA\":\"eda3a84ac6fe17488778946978c2a0d6801ae436\"}",
+          "Version": "N/A",
+          "MachineID": "7849207a412608"
+        }
+      ],
+      "error": null
+    }
+  ],
+  "logs": null,
+  "notes": [
+    "No Grafana dashboard titled 'BOUCH MCP Fleet' is checked in anywhere under the mcpfleet workspace; the only checked-in dashboard is monitoring/grafana-dashboard.json ('Property Shared API'), whose PromQL targets metric names that do not exist in Fly's Prometheus (http_request_duration_seconds_*, http_requests_inprogress, http_response_size_bytes_*, external_request_duration_seconds_*). That dashboard is written for a prometheus_fastapi_instrumentator naming scheme the deployed app does not use. No series here is sourced from it. The app_custom series below are taken from the live Fly label index and from the checked-in definitions in app/core/metrics.py, not from any dashboard.",
+    "Transient disk from this collector is corroborating evidence, never the measurement. The additional space a run consumed on a mount is baseline_free - minimum_free on that same mount; total_bytes - minimum_free would instead report total disk in use at the low-water mark, including the image and everything already present. Fly stores samples every 15s, so a ~20 s materialisation yields one or two samples and its true peak can fall entirely between them. /app/boot_only_verify.py samples the verifier directory every 0.2 s and is the authoritative transient-disk measurement.",
+    "no_data (absent series, NOT zero): app_concurrency, instance_exit_oom"
+  ]
+}

--- a/docs/ops/evidence/2026-09-02-stage1-before.md
+++ b/docs/ops/evidence/2026-09-02-stage1-before.md
@@ -1,0 +1,322 @@
+# Fly observability snapshot — `property-shared`
+
+- **App**: `property-shared` (org `personal`)
+- **Window**: `30m`
+- **Collected**: 2026-09-02T00:01:16Z → 2026-09-02T00:01:27Z (UTC)
+- **Schema**: `2`
+
+`no_data` means the series has no samples — it is **not** a reading of zero. `error` means collection failed and nothing was measured.
+
+## Readings
+
+| Metric | Unit | Value | Status |
+|---|---|---|---|
+| Instance up | bool | 1 | `ok` |
+| Machine identity | info | 1 | `ok` |
+| Instance uptime | seconds | 5.501e+04 | `ok` |
+| Metrics scrape up | bool | 1 | `ok` |
+| App concurrency | connections | — | `no_data` |
+| Load average (5m) | load | 0.01 | `ok` |
+| Load average (5m) peak over window *(derived)* | load | 0.02 | `ok` |
+| CPU busy *(derived)* | percent | 0.4234 | `ok` |
+| CPU throttle | count | 0 | `ok` |
+| Machine memory total | bytes | 2,064,257,024 (1.92 GiB) | `ok` |
+| Machine memory available | bytes | 1,692,741,632 (1.58 GiB) | `ok` |
+| Machine memory available, minimum over window *(derived)* | bytes | 1,692,741,632 (1.58 GiB) | `ok` |
+| OOM exits | count | — | `no_data` |
+| Root filesystem free *(derived)* | bytes | 8,038,342,656 (7.49 GiB) | `ok` |
+| Root filesystem free, minimum over window *(derived)* | bytes | 8,038,342,656 (7.49 GiB) | `ok` |
+| Root filesystem total *(derived)* | bytes | 8,350,298,112 (7.78 GiB) | `ok` |
+| Network received *(derived)* | bytes/sec | 341.1 | `ok` |
+| Network sent *(derived)* | bytes/sec | 4,237 | `ok` |
+| App HTTP responses by status *(derived)* | responses | 5 series | `ok` |
+| Edge HTTP responses by status *(derived)* | responses | 5 series | `ok` |
+| App HTTP p95 latency *(derived)* | seconds | 0.02175 | `ok` |
+| App HTTP p99 latency *(derived)* | seconds | 0.02435 | `ok` |
+| Edge HTTP p95 latency *(derived)* | seconds | 0.1239 | `ok` |
+| Concurrency hard limit reached *(derived)* | events | 0 | `ok` |
+| Concurrency soft limit reached *(derived)* | events | 0 | `ok` |
+| Process RSS | bytes | 198,901,760 (0.19 GiB) | `ok` |
+| Process RSS peak over window *(derived)* | bytes | 198,901,760 (0.19 GiB) | `ok` |
+| Open file descriptors | count | 10 | `ok` |
+| App requests by surface/route/status class *(derived)* | requests | 8 series | `ok` |
+| App-measured request p95 latency *(derived)* | seconds | 0.008212 | `ok` |
+| MCP tool calls by tool and status *(derived)* | calls | 10 series | `ok` |
+| MCP client handshakes by client *(derived)* | handshakes | 38 series | `ok` |
+| Machine memory available over time | bytes | 1 series | `ok` |
+| Root filesystem free over time *(derived)* | bytes | 1 series | `ok` |
+| Process RSS over time | bytes | 1 series | `ok` |
+
+## Breakdowns
+
+**Machine identity**
+  - app=property-shared, cpu_count=1, cpu_kind=shared, host=81e9, instance=7849207a412608, memory_mb=2048, process_group=app, region=lhr: 1
+
+**App HTTP responses by status**
+  - status=200: 88
+  - status=202: 31
+  - status=400: 1
+  - status=404: 15
+  - status=405: 4
+
+**Edge HTTP responses by status**
+  - status=200: 57
+  - status=202: 22
+  - status=400: 3
+  - status=404: 16
+  - status=405: 3
+
+**App requests by surface/route/status class**
+  - route=/.well-known/glama.json, status_class=2xx, surface=web: 0
+  - route=/mcp, status_class=2xx, surface=mcp_proxy: 119
+  - route=/mcp, status_class=4xx, surface=mcp_proxy: 12
+  - route=/v1/health, status_class=2xx, surface=infra: 60
+  - route=/v1/meta, status_class=2xx, surface=api: 0
+  - route=/v1/meta/integrations, status_class=2xx, surface=api: 0
+  - route=/web, status_class=2xx, surface=web: 0
+  - route=/web, status_class=4xx, surface=web: 12
+
+**MCP tool calls by tool and status**
+  - status=error, tool=epc_certificate: 0
+  - status=error, tool=ppd_transactions: 0
+  - status=error, tool=rental_analysis: 0
+  - status=error, tool=rightmove_search: 0
+  - status=ok, tool=epc_certificate: 0
+  - status=ok, tool=ppd_transactions: 0
+  - status=ok, tool=property_comps: 0
+  - status=ok, tool=property_epc_summaries: 0
+  - status=ok, tool=rightmove_search: 0
+  - status=ok, tool=stamp_duty: 0
+
+**MCP client handshakes by client**
+  - client_name=AgentIndexBot: 0
+  - client_name=Anthropic/ClaudeAI: 1
+  - client_name=Kelivo MCP: 0
+  - client_name=acton-probe: 0
+  - client_name=acton-skill-extractor: 0
+  - client_name=agent-tools.cloud: 1
+  - client_name=agent-world-probe: 0
+  - client_name=agentage-mcp-catalog-health: 1
+  - client_name=aisec-registry-probe: 0
+  - client_name=avp1-scan: 0
+  - client_name=chathome-skills-probe: 0
+  - client_name=claude-ai (via mcp-remote 0.8.3): 0
+  - client_name=claude-code: 2
+  - client_name=codex-mcp-client: 3
+  - client_name=factanker-probe: 0
+  - client_name=forge-registry-probe: 0
+  - client_name=glama: 1
+  - client_name=glimind-probe: 4
+  - client_name=golemreach-trust: 0
+  - client_name=hultra-link: 0
+  - client_name=ledgerhall: 18
+  - client_name=local-agent-mode-property (via mcp-remote 0.8.3): 0
+  - client_name=mcp: 0
+  - client_name=mcp-checker: 0
+  - client_name=mcp-ledger-probe: 0
+  - client_name=mcp-remote-fallback-test: 0
+  - client_name=mcp-rugpull-research: 0
+  - client_name=mcp2-research: 0
+  - client_name=mcpbeat: 1
+  - client_name=mcphq-probe: 0
+  - client_name=mcpindex-trust: 0
+  - client_name=mcpscan: 0
+  - client_name=policylayer-crawler: 0
+  - client_name=probe: 0
+  - client_name=proofbench-probe: 0
+  - client_name=sheet-add-in: 0
+  - client_name=test: 0
+  - client_name=unreached-probe: 0
+
+## Transient disk (corroborating, not authoritative)
+
+| Mount | Instance | Baseline free | Minimum free | Delta | Status |
+|---|---|---|---|---|---|
+| /.fly-upper-layer | 7849207a412608 | 8,038,342,656 (7.49 GiB) | 8,038,342,656 (7.49 GiB) | 0 | `ok` |
+
+- Method: delta_bytes = baseline_free - minimum_free, on one mount. Not total_bytes - minimum_free, which measures total occupancy.
+- Resolution: Fly stores one sample per 15s. A materialisation lasting ~20 s produces one or two samples, so this delta may understate the true peak or miss it entirely.
+- Authoritative source: /app/boot_only_verify.py, which samples the verifier directory every 0.2 s, is the authoritative transient-disk measurement; this delta only corroborates it.
+
+## Not measured
+
+| Metric | Status | Detail |
+|---|---|---|
+| App concurrency | `no_data` | query matched no series. Verified absent for property-shared and propertydata on 2026-09-01 while present for five other fleet apps. Expect no_data, and do not read it as zero. |
+| OOM exits | `no_data` | query matched no series. Absent unless an OOM kill has occurred; no_data here is the healthy reading. |
+
+## Commands
+
+- `fly status --json -a property-shared` → `ok`
+- `fly checks list --json -a property-shared` → `ok`
+- `fly image show --json -a property-shared` → `ok`
+
+## Notes
+
+- No Grafana dashboard titled 'BOUCH MCP Fleet' is checked in anywhere under the mcpfleet workspace; the only checked-in dashboard is monitoring/grafana-dashboard.json ('Property Shared API'), whose PromQL targets metric names that do not exist in Fly's Prometheus (http_request_duration_seconds_*, http_requests_inprogress, http_response_size_bytes_*, external_request_duration_seconds_*). That dashboard is written for a prometheus_fastapi_instrumentator naming scheme the deployed app does not use. No series here is sourced from it. The app_custom series below are taken from the live Fly label index and from the checked-in definitions in app/core/metrics.py, not from any dashboard.
+- Transient disk from this collector is corroborating evidence, never the measurement. The additional space a run consumed on a mount is baseline_free - minimum_free on that same mount; total_bytes - minimum_free would instead report total disk in use at the low-water mark, including the image and everything already present. Fly stores samples every 15s, so a ~20 s materialisation yields one or two samples and its true peak can fall entirely between them. /app/boot_only_verify.py samples the verifier directory every 0.2 s and is the authoritative transient-disk measurement.
+- no_data (absent series, NOT zero): app_concurrency, instance_exit_oom
+
+## PromQL used
+
+- **Instance up** (`fly_builtin`)
+  ```
+  fly_instance_up{app="property-shared"}
+  ```
+- **Machine identity** (`fly_builtin`)
+  ```
+  fly_instance_info{app="property-shared"}
+  ```
+- **Instance uptime** (`fly_builtin`)
+  ```
+  fly_instance_uptime_seconds{app="property-shared"}
+  ```
+- **Metrics scrape up** (`fly_builtin`)
+  ```
+  up{app="property-shared"}
+  ```
+- **App concurrency** (`fly_builtin`)
+  ```
+  fly_app_concurrency{app="property-shared"}
+  ```
+- **Load average (5m)** (`fly_builtin`)
+  ```
+  fly_instance_load_average{app="property-shared",minutes="5"}
+  ```
+- **Load average (5m) peak over window** (`fly_builtin`, derived)
+  ```
+  max_over_time(fly_instance_load_average{app="property-shared",minutes="5"}[30m])
+  ```
+  Derivation: max_over_time over the collection window of the kernel 5-minute load average.
+- **CPU busy** (`fly_builtin`, derived)
+  ```
+  100 * (1 - sum(rate(fly_instance_cpu{app="property-shared",mode="idle"}[30m])) / sum(rate(fly_instance_cpu{app="property-shared"}[30m])))
+  ```
+  Derivation: 100 * (1 - idle_rate / total_rate) across all cpu modes and cpu_ids over the window.
+- **CPU throttle** (`fly_builtin`)
+  ```
+  fly_instance_cpu_throttle{app="property-shared"}
+  ```
+- **Machine memory total** (`fly_builtin`)
+  ```
+  fly_instance_memory_mem_total{app="property-shared"}
+  ```
+- **Machine memory available** (`fly_builtin`)
+  ```
+  fly_instance_memory_mem_available{app="property-shared"}
+  ```
+- **Machine memory available, minimum over window** (`fly_builtin`, derived)
+  ```
+  min_over_time(fly_instance_memory_mem_available{app="property-shared"}[30m])
+  ```
+  Derivation: min_over_time of MemAvailable over the window — the Machine-wide low-water mark.
+- **OOM exits** (`fly_builtin`)
+  ```
+  fly_instance_exit_oom{app="property-shared"}
+  ```
+- **Root filesystem free** (`fly_builtin`, derived)
+  ```
+  fly_instance_filesystem_blocks_free{app="property-shared"} * fly_instance_filesystem_block_size{app="property-shared"}
+  ```
+  Derivation: blocks_free * block_size, per mount. Mount label identifies the filesystem.
+- **Root filesystem free, minimum over window** (`fly_builtin`, derived)
+  ```
+  min_over_time((fly_instance_filesystem_blocks_free{app="property-shared"} * fly_instance_filesystem_block_size{app="property-shared"})[30m:15s])
+  ```
+  Derivation: min_over_time of (blocks_free * block_size) on the same mount, sampled at 15s (Fly's real stored resolution) over the window. This is the free-space low-water mark, nothing more. The additional space a run consumed is baseline_free - minimum_free on that mount — see summarise_transient_disk(). It is NOT total_bytes - minimum_free, which is total disk in use including the image and everything already present.
+- **Root filesystem total** (`fly_builtin`, derived)
+  ```
+  fly_instance_filesystem_blocks{app="property-shared"} * fly_instance_filesystem_block_size{app="property-shared"}
+  ```
+  Derivation: blocks * block_size, per mount.
+- **Network received** (`fly_builtin`, derived)
+  ```
+  sum(rate(fly_instance_net_recv_bytes{app="property-shared",device="eth0"}[30m]))
+  ```
+  Derivation: rate() of the eth0 counter over the window, summed.
+- **Network sent** (`fly_builtin`, derived)
+  ```
+  sum(rate(fly_instance_net_sent_bytes{app="property-shared",device="eth0"}[30m]))
+  ```
+  Derivation: rate() of the eth0 counter over the window, summed.
+- **App HTTP responses by status** (`fly_builtin`, derived)
+  ```
+  sum by (status) (increase(fly_app_http_responses_count{app="property-shared"}[30m]))
+  ```
+  Derivation: increase() of the Fly proxy app-side response counter over the window, by status.
+- **Edge HTTP responses by status** (`fly_builtin`, derived)
+  ```
+  sum by (status) (increase(fly_edge_http_responses_count{app="property-shared"}[30m]))
+  ```
+  Derivation: increase() of the Fly edge response counter over the window, by status.
+- **App HTTP p95 latency** (`fly_builtin`, derived)
+  ```
+  histogram_quantile(0.95, sum by (le) (rate(fly_app_http_response_time_seconds_bucket{app="property-shared"}[30m])))
+  ```
+  Derivation: histogram_quantile(0.95) over the Fly proxy app-side latency histogram.
+- **App HTTP p99 latency** (`fly_builtin`, derived)
+  ```
+  histogram_quantile(0.99, sum by (le) (rate(fly_app_http_response_time_seconds_bucket{app="property-shared"}[30m])))
+  ```
+  Derivation: histogram_quantile(0.99) over the Fly proxy app-side latency histogram.
+- **Edge HTTP p95 latency** (`fly_builtin`, derived)
+  ```
+  histogram_quantile(0.95, sum by (le) (rate(fly_edge_http_response_time_seconds_bucket{app="property-shared"}[30m])))
+  ```
+  Derivation: histogram_quantile(0.95) over the Fly edge latency histogram.
+- **Concurrency hard limit reached** (`fly_builtin`, derived)
+  ```
+  sum(increase(fly_app_hard_limit_reached_count{app="property-shared"}[30m]))
+  ```
+  Derivation: increase() over the window.
+- **Concurrency soft limit reached** (`fly_builtin`, derived)
+  ```
+  sum(increase(fly_app_soft_limit_reached_count{app="property-shared"}[30m]))
+  ```
+  Derivation: increase() over the window.
+- **Process RSS** (`app_custom`)
+  ```
+  process_resident_memory_bytes{app="property-shared"}
+  ```
+- **Process RSS peak over window** (`app_custom`, derived)
+  ```
+  max_over_time(process_resident_memory_bytes{app="property-shared"}[30m])
+  ```
+  Derivation: max_over_time of the scraped RSS gauge over the window.
+- **Open file descriptors** (`app_custom`)
+  ```
+  process_open_fds{app="property-shared"}
+  ```
+- **App requests by surface/route/status class** (`app_custom`, derived)
+  ```
+  sum by (surface, route, status_class) (increase(property_shared_http_requests_total{app="property-shared"}[30m]))
+  ```
+  Derivation: increase() of the app's own request counter over the window.
+- **App-measured request p95 latency** (`app_custom`, derived)
+  ```
+  histogram_quantile(0.95, sum by (le) (rate(property_shared_http_request_duration_seconds_bucket{app="property-shared"}[30m])))
+  ```
+  Derivation: histogram_quantile(0.95) over the app's own request-duration histogram.
+- **MCP tool calls by tool and status** (`app_custom`, derived)
+  ```
+  sum by (tool, status) (increase(property_shared_tool_calls_total{app="property-shared"}[30m]))
+  ```
+  Derivation: increase() of the MCP tool-call counter over the window.
+- **MCP client handshakes by client** (`app_custom`, derived)
+  ```
+  sum by (client_name) (increase(property_shared_client_connections_total{app="property-shared"}[30m]))
+  ```
+  Derivation: increase() of the MCP initialize-handshake counter over the window.
+- **Machine memory available over time** (`fly_builtin`)
+  ```
+  fly_instance_memory_mem_available{app="property-shared"}
+  ```
+- **Root filesystem free over time** (`fly_builtin`, derived)
+  ```
+  fly_instance_filesystem_blocks_free{app="property-shared"} * fly_instance_filesystem_block_size{app="property-shared"}
+  ```
+  Derivation: blocks_free * block_size, per mount, sampled across the window.
+- **Process RSS over time** (`app_custom`)
+  ```
+  process_resident_memory_bytes{app="property-shared"}
+  ```

--- a/docs/ops/evidence/2026-09-02-stage1-candidate-instance-v1.18.1.json
+++ b/docs/ops/evidence/2026-09-02-stage1-candidate-instance-v1.18.1.json
@@ -1,0 +1,106 @@
+{
+  "kind": "stage1_qualification_candidate",
+  "is_instance": false,
+  "note": "A CANDIDATE Instance. It is reviewed and committed as its own change before Stage 1 runs; it is never read as runtime configuration and nothing here is hard-coded into the tool.",
+  "definitional_geographies": {
+    "S1_district": "B5",
+    "S2_neighbour_district": "B50",
+    "S3_sector": "B5 4"
+  },
+  "substituted": false,
+  "coverage": {
+    "coverage_from": "2016-01-01",
+    "coverage_to": "2026-06-30",
+    "provisional_from": "2026-03-01"
+  },
+  "comparator_version": "1",
+  "baselines_satisfy_their_relations": true,
+  "baselines_refusal": null,
+  "baselines_note": "S1 is measured over B5, and S3/S9 over B5 4. If they do not satisfy the strict-subset and category-B relations, the Definition allows a substituted geography with recorded justification -- which is an authoring decision, not something this tool may make.",
+  "unqualified_definitional_cases": [],
+  "requires_owner_adjudication": [],
+  "substitution_route": "Definition section 4 permits substituting a definitional geography with recorded justification. Supply all of ['S1_district', 'S2_neighbour_district', 'S3_sector'] under the Instance's `substitutions` key, each with a `geography` and a `justification`.",
+  "unqualified_placeholders": [],
+  "candidate_instance": {
+    "instance_kind": "stage1",
+    "snapshot_version": "v20260828T194003Z",
+    "bundle_sha256": "50f802b29d9802ee42319122214aeb0adc6761e96c4f6c9ddd0498500bb9072c",
+    "geographies": {
+      "S4_thin": "B3 2",
+      "S5_dense": "E14 9",
+      "S6_unit": "HA9 0DY",
+      "S7_type_weak": "E14 9",
+      "S8_type_strong": "LU7 3",
+      "S11_provisional_empty": "CV11 7",
+      "S13_empty_unit": "HA9 0DY"
+    },
+    "aggregate_baselines": {
+      "S1_full": 139,
+      "S3_full": 70,
+      "S9_full": 136
+    },
+    "qualified_at": "2026-09-02",
+    "qualification": {
+      "S1_district": {
+        "rule": "the longer neighbouring outcode holds comparable or greater volume (Definition section 4)",
+        "geography": "B5",
+        "measured_rows": 139,
+        "neighbour_geography": "B50",
+        "measured_neighbour_rows": 182,
+        "measured_neighbour_ratio": 1.3094,
+        "comparable_or_greater": true
+      },
+      "S2_district": {
+        "rule": "non-empty under frozen parameters",
+        "geography": "B50",
+        "measured_rows": 182
+      },
+      "S3_sector": {
+        "rule": "a strict subset of S1's district, carrying the S3 and S9 aggregate baselines",
+        "geography": "B5 4",
+        "measured_rows": 70,
+        "measured_rows_category_all": 136,
+        "inside_s1_district": true
+      },
+      "S4_thin": {
+        "rule": "non-empty and strictly below thin_market_threshold (5) under frozen parameters",
+        "measured_rows": 4
+      },
+      "S5_dense": {
+        "rule": "matching rows greatly exceed limit (50)",
+        "measured_rows": 649
+      },
+      "S6_unit": {
+        "rule": "aggregate-dense (>= 10 rows), so not individually identifying",
+        "measured_rows": 109
+      },
+      "S7_type_weak": {
+        "rule": "at least 90% of the base is F",
+        "measured_share_f": 0.9892,
+        "measured_rows": 649
+      },
+      "S8_type_strong": {
+        "rule": "a real spread across F/D/S/T, F not dominant",
+        "measured_share_f": 0.0442,
+        "measured_types_present": [
+          "D",
+          "F",
+          "S",
+          "T"
+        ]
+      },
+      "S11_provisional_empty": {
+        "rule": "returns zero rows over months=6 while the window intersects the provisional period",
+        "measured_rows": 0,
+        "window_intersects_provisional": true
+      },
+      "S13_empty_unit": {
+        "rule": "non-empty under the residential default, zero rows once filtered to property_type=D",
+        "measured_rows_default": 109,
+        "measured_rows_type_d": 0
+      }
+    },
+    "staleness_bound_days": 45,
+    "governs_run": "<fill in: the Stage 1 run this Instance governs>"
+  }
+}

--- a/docs/ops/evidence/2026-09-02-stage1-report-v1.18.1.json
+++ b/docs/ops/evidence/2026-09-02-stage1-report-v1.18.1.json
@@ -1,0 +1,533 @@
+{
+  "kind": "stage1_shadow_comparison",
+  "stage_1_evidence": true,
+  "latency_sample_kind": "deployed_machine_frozen_corpus",
+  "not_organic_traffic": "The request mix is the frozen thirteen-case corpus, chosen in advance, executed on the deployed production Machine against the selected artifact. It is not a sample of organic traffic and must never be described as one (governing spec rev 10).",
+  "definition": "docs/design/ppd-shadow-corpus.md",
+  "artifact": {
+    "snapshot_version": "v20260828T194003Z",
+    "bundle_sha256": "50f802b29d9802ee42319122214aeb0adc6761e96c4f6c9ddd0498500bb9072c",
+    "coverage_from": "2016-01-01",
+    "coverage_to": "2026-06-30",
+    "provisional_from": "2026-03-01",
+    "comparator_version": "1"
+  },
+  "instance": {
+    "instance_kind": "stage1",
+    "qualified_at": "2026-09-02",
+    "governs_run": "stage1-v20260828T194003Z-2026-09-02",
+    "staleness_bound_days": 45,
+    "aggregate_baselines": {
+      "S1_full": 139,
+      "S3_full": 70,
+      "S9_full": 136
+    },
+    "baselines_are": "declared during qualification, not measured here"
+  },
+  "isolation": {
+    "installed_into_server_state": false,
+    "snapshot_routing_enabled": false,
+    "artifacts_downloaded": 0,
+    "snapshot_written_to": false
+  },
+  "limits": {
+    "live_delay_seconds": 2.0,
+    "latency_repeats": 30,
+    "max_live_per_case": 1,
+    "deadline_seconds": 3600.0,
+    "min_available_memory_bytes": 268435456,
+    "live_calls_made": 3
+  },
+  "excluded": {
+    "health": 0,
+    "memory": 0
+  },
+  "midnight": {
+    "retries": 0,
+    "unrecoverable": false,
+    "pair_date_mismatches": 0
+  },
+  "aborted": "S3: the live arm failed (HTTPError: HTTP Error 429: Too Many Requests); completeness is already lost, so no later case runs",
+  "cases_total": 3,
+  "cases_compared": 2,
+  "live_errors": [
+    {
+      "shape": "S3",
+      "error": "HTTPError: HTTP Error 429: Too Many Requests"
+    }
+  ],
+  "latency": {
+    "snapshot_arm": {
+      "n": 0,
+      "p50_ms": null,
+      "p95_ms": null,
+      "p99_ms": null,
+      "max_ms": null,
+      "method": "nearest rank: sorted ascending, 1-based rank ceil(p/100*N)"
+    },
+    "per_case_ms": {}
+  },
+  "exit_criteria": {
+    "all_thirteen_cases_compared": {
+      "passed": false,
+      "cases_recorded": 3,
+      "cases_compared": 2,
+      "required": 13,
+      "cases_missing_snapshot_arm": [],
+      "cases_missing_live_arm": [
+        "S3"
+      ],
+      "cases_never_reached": [
+        "S11",
+        "S12",
+        "S13",
+        "S14",
+        "S4",
+        "S5",
+        "S6",
+        "S7",
+        "S8",
+        "S9"
+      ],
+      "live_errors": 1,
+      "snapshot_errors": 0,
+      "note": "the frozen corpus is thirteen cases with two arms each; a report covering fewer is not a smaller Stage 1 result, it is not a Stage 1 result"
+    },
+    "corpus_invariants_hold": {
+      "passed": false,
+      "assertions_checked": 18,
+      "failures": [],
+      "note": "Definition section 3's universal invariants and each shape's intent, asserted on the snapshot arm; a case reporting sample_complete true is a defect, not a divergence"
+    },
+    "zero_unexplained_false_empties": {
+      "passed": false,
+      "false_empty_shapes": [],
+      "note": "a false empty is only a failure when it is unexplained; these are checked against the classification below"
+    },
+    "zero_geography_contamination": {
+      "passed": false,
+      "findings": []
+    },
+    "field_equality_on_shared_ids": {
+      "passed": false,
+      "mismatch_rows": 0,
+      "vacuous_comparison_shapes": [],
+      "note": "a shape listed under vacuous_comparison_shapes shared no transaction id while both arms returned rows; equality over an empty intersection proves nothing and is reported as a failure, not a pass"
+    },
+    "every_divergence_classified": {
+      "passed": false,
+      "unclassified": 0,
+      "note": "an unclassified divergence blocks exit"
+    },
+    "no_unconfirmed_classifications": {
+      "passed": true,
+      "operator_confirmation_required": 0,
+      "note": "later A/C/D revision cannot be evidenced from these two sources; while any remain proposed, Stage 1 cannot exit on this report alone -- external confirmation is a separately authorised step"
+    },
+    "zero_snapshot_errors": {
+      "passed": true,
+      "errors": []
+    },
+    "p95_under_one_second": {
+      "passed": false,
+      "verdict": "insufficient_evidence",
+      "p95_ms": null,
+      "n": 0,
+      "required_observations": 390,
+      "required_repeats_per_case": 30,
+      "cases_short_of_the_required_repeats": [
+        "S1",
+        "S11",
+        "S12",
+        "S13",
+        "S14",
+        "S2",
+        "S3",
+        "S4",
+        "S5",
+        "S6",
+        "S7",
+        "S8",
+        "S9"
+      ],
+      "criterion": "p95 < 1 second on the deployed production Machine and selected artifact, measured across the frozen corpus request mix (governing spec rev 10)",
+      "note": "a partial sample is insufficient_evidence, never a pass: a percentile over fewer observations than the gate is defined over is a different measurement"
+    }
+  },
+  "passed": false,
+  "cases": [
+    {
+      "shape": "S1",
+      "intent": "contamination boundary",
+      "request": {
+        "wire": {
+          "postcode": "B5",
+          "search_level": "district",
+          "months": 24,
+          "limit": 50,
+          "transaction_category": "A",
+          "filter_outliers": false,
+          "auto_escalate": true,
+          "enrich_epc": false,
+          "property_type": "<omitted>",
+          "address": "<omitted>"
+        },
+        "effective": {
+          "property_type": "residential_default (F/D/S/T)",
+          "address": null,
+          "transaction_category": "A"
+        }
+      },
+      "artifact": {
+        "snapshot_version": "v20260828T194003Z",
+        "bundle_sha256": "50f802b29d9802ee42319122214aeb0adc6761e96c4f6c9ddd0498500bb9072c",
+        "coverage_from": "2016-01-01",
+        "coverage_to": "2026-06-30",
+        "provisional_from": "2026-03-01",
+        "comparator_version": "1"
+      },
+      "snapshot": {
+        "count": 50,
+        "latency_ms": 325.15,
+        "thin_market": false,
+        "outcodes_returned": [
+          "B5"
+        ],
+        "sectors_returned": [
+          "B5 4",
+          "B5 5",
+          "B5 6",
+          "B5 7"
+        ],
+        "warning_classes": [
+          "coverage_clamp",
+          "freshness"
+        ],
+        "saturated_at_limit": true,
+        "returned_date_from": "2025-06-20",
+        "returned_date_to": "2026-06-26",
+        "source": "snapshot",
+        "observed_at": "2026-09-02",
+        "derived_from_date": "2024-09-12",
+        "resolved_to_date": "2026-06-30",
+        "recent_period_provisional": true,
+        "sample_complete": false
+      },
+      "snapshot_invariants": {
+        "coverage_clamp_warning_present": true,
+        "sample_complete_is_false": true,
+        "completeness_basis_is_null": true,
+        "answered_by_snapshot": true,
+        "provisional_flagged": true,
+        "geography_isolation": true
+      },
+      "live": {
+        "count": 50,
+        "latency_ms": 58192.46,
+        "thin_market": false,
+        "outcodes_returned": [
+          "B5"
+        ],
+        "sectors_returned": [
+          "B5 4",
+          "B5 5",
+          "B5 6",
+          "B5 7"
+        ],
+        "warning_classes": [
+          "live_incompleteness"
+        ],
+        "saturated_at_limit": true,
+        "returned_date_from": "2025-10-06",
+        "returned_date_to": "2026-07-03",
+        "source": "sparql",
+        "observed_at": "2026-09-02",
+        "derived_from_date": "2024-09-12",
+        "resolved_to_date": null,
+        "recent_period_provisional": false,
+        "sample_complete": false,
+        "transport_evidence": {
+          "raw_bindings_returned": 150,
+          "fetch_limit": 150,
+          "source_exhausted": false
+        }
+      },
+      "live_truncation_evidenced": true,
+      "diff": {
+        "only_live": {
+          "count": 21,
+          "by_month": {
+            "2025-10": 14,
+            "2026-02": 1,
+            "2026-05": 1,
+            "2026-06": 3,
+            "2026-07": 2
+          }
+        },
+        "only_snapshot": {
+          "count": 21,
+          "by_month": {
+            "2025-06": 2,
+            "2025-07": 4,
+            "2025-08": 7,
+            "2025-09": 8
+          }
+        },
+        "shared": {
+          "count": 29
+        },
+        "count_delta": 0,
+        "field_mismatches": {},
+        "field_mismatch_rows": 0,
+        "field_mismatch_by_month": {},
+        "compared_fields": [
+          "transaction_id",
+          "price",
+          "date",
+          "postcode",
+          "property_type",
+          "estate_type",
+          "transaction_category",
+          "new_build",
+          "paon",
+          "saon",
+          "street",
+          "town",
+          "county",
+          "locality",
+          "district"
+        ]
+      },
+      "snapshot_false_empty": false,
+      "empty_id_intersection_with_rows_on_both_sides": false,
+      "classification": {
+        "provisional_tail_lag": 6,
+        "later_acd_revision": 0,
+        "live_truncation_or_ordering": 36,
+        "unclassified": 0,
+        "operator_confirmation_required": 0,
+        "truncation_evidence": {
+          "live_raw_bindings_reached_fetch_limit": true,
+          "context_not_evidence": {
+            "live_page_saturated": true,
+            "snapshot_page_saturated": true
+          }
+        }
+      }
+    },
+    {
+      "shape": "S2",
+      "intent": "reverse boundary",
+      "request": {
+        "wire": {
+          "postcode": "B50",
+          "search_level": "district",
+          "months": 24,
+          "limit": 50,
+          "transaction_category": "A",
+          "filter_outliers": false,
+          "auto_escalate": true,
+          "enrich_epc": false,
+          "property_type": "<omitted>",
+          "address": "<omitted>"
+        },
+        "effective": {
+          "property_type": "residential_default (F/D/S/T)",
+          "address": null,
+          "transaction_category": "A"
+        }
+      },
+      "artifact": {
+        "snapshot_version": "v20260828T194003Z",
+        "bundle_sha256": "50f802b29d9802ee42319122214aeb0adc6761e96c4f6c9ddd0498500bb9072c",
+        "coverage_from": "2016-01-01",
+        "coverage_to": "2026-06-30",
+        "provisional_from": "2026-03-01",
+        "comparator_version": "1"
+      },
+      "snapshot": {
+        "count": 50,
+        "latency_ms": 307.92,
+        "thin_market": false,
+        "outcodes_returned": [
+          "B50"
+        ],
+        "sectors_returned": [
+          "B50 4"
+        ],
+        "warning_classes": [
+          "coverage_clamp",
+          "freshness"
+        ],
+        "saturated_at_limit": true,
+        "returned_date_from": "2026-01-14",
+        "returned_date_to": "2026-06-12",
+        "source": "snapshot",
+        "observed_at": "2026-09-02",
+        "derived_from_date": "2024-09-12",
+        "resolved_to_date": "2026-06-30",
+        "recent_period_provisional": true,
+        "sample_complete": false
+      },
+      "snapshot_invariants": {
+        "coverage_clamp_warning_present": true,
+        "sample_complete_is_false": true,
+        "completeness_basis_is_null": true,
+        "answered_by_snapshot": true,
+        "provisional_flagged": true,
+        "geography_isolation": true
+      },
+      "live": {
+        "count": 50,
+        "latency_ms": 57406.43,
+        "thin_market": false,
+        "outcodes_returned": [
+          "B50"
+        ],
+        "sectors_returned": [
+          "B50 4"
+        ],
+        "warning_classes": [
+          "live_incompleteness"
+        ],
+        "saturated_at_limit": true,
+        "returned_date_from": "2026-02-09",
+        "returned_date_to": "2026-07-15",
+        "source": "sparql",
+        "observed_at": "2026-09-02",
+        "derived_from_date": "2024-09-12",
+        "resolved_to_date": null,
+        "recent_period_provisional": false,
+        "sample_complete": false,
+        "transport_evidence": {
+          "raw_bindings_returned": 150,
+          "fetch_limit": 150,
+          "source_exhausted": false
+        }
+      },
+      "live_truncation_evidenced": true,
+      "diff": {
+        "only_live": {
+          "count": 7,
+          "by_month": {
+            "2026-02": 2,
+            "2026-05": 1,
+            "2026-06": 2,
+            "2026-07": 2
+          }
+        },
+        "only_snapshot": {
+          "count": 7,
+          "by_month": {
+            "2026-01": 3,
+            "2026-02": 4
+          }
+        },
+        "shared": {
+          "count": 43
+        },
+        "count_delta": 0,
+        "field_mismatches": {},
+        "field_mismatch_rows": 0,
+        "field_mismatch_by_month": {},
+        "compared_fields": [
+          "transaction_id",
+          "price",
+          "date",
+          "postcode",
+          "property_type",
+          "estate_type",
+          "transaction_category",
+          "new_build",
+          "paon",
+          "saon",
+          "street",
+          "town",
+          "county",
+          "locality",
+          "district"
+        ]
+      },
+      "snapshot_false_empty": false,
+      "empty_id_intersection_with_rows_on_both_sides": false,
+      "classification": {
+        "provisional_tail_lag": 5,
+        "later_acd_revision": 0,
+        "live_truncation_or_ordering": 9,
+        "unclassified": 0,
+        "operator_confirmation_required": 0,
+        "truncation_evidence": {
+          "live_raw_bindings_reached_fetch_limit": true,
+          "context_not_evidence": {
+            "live_page_saturated": true,
+            "snapshot_page_saturated": true
+          }
+        }
+      }
+    },
+    {
+      "shape": "S3",
+      "intent": "sector isolation",
+      "request": {
+        "wire": {
+          "postcode": "B5 4",
+          "search_level": "sector",
+          "months": 24,
+          "limit": 50,
+          "transaction_category": "A",
+          "filter_outliers": false,
+          "auto_escalate": true,
+          "enrich_epc": false,
+          "property_type": "<omitted>",
+          "address": "<omitted>"
+        },
+        "effective": {
+          "property_type": "residential_default (F/D/S/T)",
+          "address": null,
+          "transaction_category": "A"
+        }
+      },
+      "artifact": {
+        "snapshot_version": "v20260828T194003Z",
+        "bundle_sha256": "50f802b29d9802ee42319122214aeb0adc6761e96c4f6c9ddd0498500bb9072c",
+        "coverage_from": "2016-01-01",
+        "coverage_to": "2026-06-30",
+        "provisional_from": "2026-03-01",
+        "comparator_version": "1"
+      },
+      "snapshot": {
+        "count": 50,
+        "latency_ms": 245.84,
+        "thin_market": false,
+        "outcodes_returned": [
+          "B5"
+        ],
+        "sectors_returned": [
+          "B5 4"
+        ],
+        "warning_classes": [
+          "coverage_clamp",
+          "freshness"
+        ],
+        "saturated_at_limit": true,
+        "returned_date_from": "2024-12-13",
+        "returned_date_to": "2026-04-28",
+        "source": "snapshot",
+        "observed_at": "2026-09-02",
+        "derived_from_date": "2024-09-12",
+        "resolved_to_date": "2026-06-30",
+        "recent_period_provisional": true,
+        "sample_complete": false
+      },
+      "snapshot_invariants": {
+        "coverage_clamp_warning_present": true,
+        "sample_complete_is_false": true,
+        "completeness_basis_is_null": true,
+        "answered_by_snapshot": true,
+        "provisional_flagged": true,
+        "geography_isolation": true
+      },
+      "live_error": "HTTPError: HTTP Error 429: Too Many Requests"
+    }
+  ]
+}

--- a/docs/ops/evidence/stage1-candidate-instance.json
+++ b/docs/ops/evidence/stage1-candidate-instance.json
@@ -1,0 +1,98 @@
+{
+  "kind": "stage1_qualification_candidate",
+  "is_instance": false,
+  "note": "A CANDIDATE Instance. It is reviewed and committed as its own change before Stage 1 runs; it is never read as runtime configuration and nothing here is hard-coded into the tool.",
+  "definitional_geographies": {
+    "S1_district": "B5",
+    "S2_neighbour_district": "B50",
+    "S3_sector": "B5 4"
+  },
+  "substituted": false,
+  "coverage": {
+    "coverage_from": "2016-01-01",
+    "coverage_to": "2026-06-30",
+    "provisional_from": "2026-03-01"
+  },
+  "comparator_version": "1",
+  "baselines_satisfy_their_relations": true,
+  "baselines_refusal": null,
+  "baselines_note": "S1 is measured over B5, and S3/S9 over B5 4. If they do not satisfy the strict-subset and category-B relations, the Definition allows a substituted geography with recorded justification -- which is an authoring decision, not something this tool may make.",
+  "unqualified_definitional_cases": [],
+  "requires_owner_adjudication": [],
+  "substitution_route": "Definition section 4 permits substituting a definitional geography with recorded justification. Supply all of ['S1_district', 'S2_neighbour_district', 'S3_sector'] under the Instance's `substitutions` key, each with a `geography` and a `justification`.",
+  "unqualified_placeholders": [
+    "S11_provisional_empty",
+    "S4_thin"
+  ],
+  "candidate_instance": {
+    "instance_kind": "stage1",
+    "snapshot_version": "v20260828T194003Z",
+    "bundle_sha256": "50f802b29d9802ee42319122214aeb0adc6761e96c4f6c9ddd0498500bb9072c",
+    "geographies": {
+      "S5_dense": "E14 9",
+      "S6_unit": "HA9 0DY",
+      "S7_type_weak": "E14 9",
+      "S8_type_strong": "LU7 3",
+      "S13_empty_unit": "HA9 0DY"
+    },
+    "aggregate_baselines": {
+      "S1_full": 139,
+      "S3_full": 70,
+      "S9_full": 136
+    },
+    "qualified_at": "2026-09-02",
+    "qualification": {
+      "S1_district": {
+        "rule": "the longer neighbouring outcode holds comparable or greater volume (Definition section 4)",
+        "geography": "B5",
+        "measured_rows": 139,
+        "neighbour_geography": "B50",
+        "measured_neighbour_rows": 182,
+        "measured_neighbour_ratio": 1.3094,
+        "comparable_or_greater": true
+      },
+      "S2_district": {
+        "rule": "non-empty under frozen parameters",
+        "geography": "B50",
+        "measured_rows": 182
+      },
+      "S3_sector": {
+        "rule": "a strict subset of S1's district, carrying the S3 and S9 aggregate baselines",
+        "geography": "B5 4",
+        "measured_rows": 70,
+        "measured_rows_category_all": 136,
+        "inside_s1_district": true
+      },
+      "S5_dense": {
+        "rule": "matching rows greatly exceed limit (50)",
+        "measured_rows": 649
+      },
+      "S6_unit": {
+        "rule": "aggregate-dense (>= 10 rows), so not individually identifying",
+        "measured_rows": 109
+      },
+      "S7_type_weak": {
+        "rule": "at least 90% of the base is F",
+        "measured_share_f": 0.9892,
+        "measured_rows": 649
+      },
+      "S8_type_strong": {
+        "rule": "a real spread across F/D/S/T, F not dominant",
+        "measured_share_f": 0.0442,
+        "measured_types_present": [
+          "D",
+          "F",
+          "S",
+          "T"
+        ]
+      },
+      "S13_empty_unit": {
+        "rule": "non-empty under the residential default, zero rows once filtered to property_type=D",
+        "measured_rows_default": 109,
+        "measured_rows_type_d": 0
+      }
+    },
+    "staleness_bound_days": 45,
+    "governs_run": "<fill in: the Stage 1 run this Instance governs>"
+  }
+}


### PR DESCRIPTION
## Why

Five files existed **only as untracked files** in the detached worktree
`property-shared-verify-v1.18.0`, reachable from no branch or tag. Removing that
worktree — or any `git clean -fd` — would have destroyed them. They record a real
run against a real Machine and are not reproducible.

## What is recovered

| File | What it is |
|---|---|
| `2026-09-02-stage1-before.json` / `.md` | The Step 0 observability baseline, captured before the run |
| `stage1-candidate-instance.json` | Earlier qualification candidate |
| `2026-09-02-stage1-candidate-instance-v1.18.1.json` | The candidate that became the committed Instance |
| `2026-09-02-stage1-report-v1.18.1.json` | **The partial report from the aborted first Stage 1 run** |

Filenames are preserved exactly as written by the run, including the undated
earlier candidate — these are evidence artifacts, so renaming them would modify
provenance.

## The report is the reason this matters

```
aborted: "S3: the live arm failed (HTTPError: HTTP Error 429: Too Many
          Requests); completeness is already lost, so no later case runs"
live_calls_made: 3   cases_compared: 2   comparator_version: "1"
limits.live_delay_seconds: 2.0
cases_never_reached: S4-S9, S11-S14
```

Two live calls were admitted; the third was refused. Each live call runs roughly
58 s, so realised spacing was already about 60 s — raising `--live-delay-seconds`
is not obviously the remedy, because the constraint is not visibly a per-request
gap.

This is the evidence that motivated v1.18.2's live-arm diagnostics. Written under
`comparator_version: "1"`, it preserved only the error string — no response
headers, no per-request timestamps — so it **cannot** say what the throttle is
counted against or when it resets. The throttle key remains unknown: source IP,
query cost, client fingerprint, endpoint-wide load and global load are all still
live candidates. Per-account is ruled out only by the request shape, since the
client reaches the SPARQL endpoint anonymously.

It is a partial report and **is not Stage 1 evidence**. The frozen corpus is
thirteen cases; a report covering fewer is not a smaller Stage 1 result.

## Hygiene

Checked before committing, per the runbook's rule that no transaction id,
address, price or row may reach a report:

- `price`, `paon`, `saon`, `street`, `town`, `locality` appear **only as field
  names** in `diff.compared_fields`, never as values.
- `request.wire.address` is already `"<omitted>"`; `request.effective.address` is
  `null`.
- `HA9 0DY` in the two candidates is the S6_unit/S13_empty_unit geography, which
  the committed Instance already carries and which qualification showed to be
  aggregate-dense at 109 rows — not individually identifying.

## Also included

`.claude/worktrees/` added to `.gitignore`. It held four live worktrees while
showing as `?? .claude/worktrees/` in every `git status`, one `git clean -fd`
away from destruction. Ignoring it *is* the protection — `git clean` skips
ignored paths without `-x`. Verified: `git clean -nd` now reports nothing.