### PR TITLE
fix(rightmove): tell caller error, absence and outage apart in location lookup

### DIFF
--- a/app/api/v1/rightmove.py
+++ b/app/api/v1/rightmove.py
@@ -13,6 +13,11 @@ from app.schemas.rightmove import (
     RightmoveListingsResponse,
     RightmoveSearchURLResponse,
 )
+from property_core.exceptions import (
+    InvalidPostcodeError,
+    LocationLookupError,
+    LocationNotFoundError,
+)
 from property_core.rightmove_location import RightmoveLocationAPI
 from property_core.rightmove_scraper import fetch_listing, fetch_listings
 
@@ -48,6 +53,16 @@ async def search_url(
             )
         )
         return RightmoveSearchURLResponse(url=url)
+    # Raised inside the worker thread; exceptions propagate unchanged out of
+    # anyio.to_thread.run_sync, so these map exactly as they would inline.
+    except InvalidPostcodeError as exc:
+        raise HTTPException(status_code=422, detail=exc.to_dict()) from exc
+    except LocationNotFoundError as exc:
+        # 404, not 422: the input is well-formed; what does not exist is a
+        # Rightmove location for it. Same line as GET /ppd/transaction.
+        raise HTTPException(status_code=404, detail=exc.to_dict()) from exc
+    except LocationLookupError as exc:
+        raise HTTPException(status_code=502, detail=exc.to_dict()) from exc
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"Rightmove lookup failed: {exc}") from exc
 
@@ -91,6 +106,15 @@ async def listings(
             partial(fetch_listings, search_url, max_pages=max_pages)
         )
         return RightmoveListingsResponse(count=len(results), results=results)
+    # This endpoint builds its own search URL, so it needs the same mapping as
+    # /search-url. Without it a sector returned 502 here while returning 422
+    # there, for identical input.
+    except InvalidPostcodeError as exc:
+        raise HTTPException(status_code=422, detail=exc.to_dict()) from exc
+    except LocationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=exc.to_dict()) from exc
+    except LocationLookupError as exc:
+        raise HTTPException(status_code=502, detail=exc.to_dict()) from exc
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"Rightmove listings failed: {exc}") from exc
 

--- a/property_cli/main.py
+++ b/property_cli/main.py
@@ -563,6 +563,7 @@ app.add_typer(rightmove, name="rightmove")
 
 
 @rightmove.command("search-url")
+@_ppd_errors
 def rightmove_search_url(
     postcode: list[str] = typer.Argument(..., help="Postcode (can include spaces)"),
     property_type: str = typer.Option("sale"),
@@ -599,6 +600,7 @@ def rightmove_search_url(
 
 
 @rightmove.command("listings")
+@_ppd_errors
 def rightmove_listings(
     postcode: list[str] = typer.Argument(..., help="Postcode or outcode, e.g. 'NG1 1AA'"),
     property_type: str = typer.Option("sale", help="sale or rent"),

--- a/property_core/__init__.py
+++ b/property_core/__init__.py
@@ -23,6 +23,8 @@ from property_core.attribution import (
 from property_core.exceptions import (
     InvalidDateRangeError,
     InvalidPostcodeError,
+    LocationLookupError,
+    LocationNotFoundError,
     PPDCoverageError,
     PPDError,
     SnapshotFailure,
@@ -106,6 +108,8 @@ __all__ = [
     "HMLR_LICENCE_URL",
     "InvalidDateRangeError",
     "InvalidPostcodeError",
+    "LocationLookupError",
+    "LocationNotFoundError",
     "PPDCoverageError",
     "PPDError",
     "PPDProvenance",

--- a/property_core/exceptions.py
+++ b/property_core/exceptions.py
@@ -1,9 +1,17 @@
-"""Protocol-neutral PPD exceptions.
+"""Protocol-neutral typed failures for `property_core`.
 
 `property_core` has four consumers (REST API, two MCP servers, CLI) that map
 failures differently, so these carry typed data and no transport concerns. The
 REST layer chooses the response code; MCP surfaces them as tool errors; the CLI
 exits non-zero.
+
+`PPDError` is the base for every typed failure here, not only PPD ones -- the
+name is historical. Non-PPD paths (Rightmove location lookup, below) subclass it
+deliberately, because the REST mapping convention and `property_cli`'s
+`_ppd_errors` decorator both key off this base, and a parallel hierarchy would
+mean a second decorator and a second set of `except` clauses saying the same
+thing. Nothing PPD-flavoured crosses a protocol boundary: a caller sees
+`str(exc)` and `code`, and `code` names the actual failure.
 
 The distinction these types exist to preserve: **a failure is not an absence**.
 An empty result means "no matching rows within the stated coverage" and nothing
@@ -221,4 +229,50 @@ class UpstreamShapeError(UpstreamUnavailableError):
     """
 
     code = "upstream_shape_error"
+    retryable = True
+
+
+class LocationNotFoundError(PPDError):
+    """A well-formed postcode or outcode that Rightmove holds no location for.
+
+    Distinct from `InvalidPostcodeError`, and the distinction is the caller's
+    next action. `XX99 9XX` satisfies the grammar, so telling that caller their
+    input "is not valid" states a false fact and sends them hunting a typo that
+    is not there. The upstream answered normally, with an empty match list, so
+    this is not a failure either -- it is an absence, and consumers map it the
+    same way they already map `TransactionNotFoundError`.
+    """
+
+    code = "rightmove_location_not_found"
+    retryable = False
+
+    def __init__(self, value: str, *, field: str = "postcode"):
+        self.value = value
+        self.field = field
+        super().__init__(
+            f"no Rightmove location matches {field} {value!r}; the input is "
+            f"well-formed, so this is an absence rather than a bad input"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "error": self.code,
+            "detail": str(self),
+            "field": self.field,
+            "value": self.value,
+            "retryable": self.retryable,
+        }
+
+
+class LocationLookupError(UpstreamUnavailableError):
+    """Rightmove's location service could not be consulted.
+
+    Previously a bare `Exception` raised for BOTH a transport failure and a
+    successful-but-empty lookup, which made the two indistinguishable to every
+    consumer. It now covers only the former. Reparenting is what supplies
+    `to_dict()`, `retryable` and `_ppd_errors` handling -- setting the
+    attributes by hand would supply the data without the behaviour.
+    """
+
+    code = "rightmove_location_unavailable"
     retryable = True

--- a/property_core/postcode_rules.py
+++ b/property_core/postcode_rules.py
@@ -87,6 +87,40 @@ def normalise_prefix(value: object, *, field: str = "postcode_prefix") -> str:
     return text
 
 
+def normalise_postcode_or_outcode(value: object, *, field: str = "postcode") -> str:
+    """Validate a full postcode or an outcode. Raises InvalidPostcodeError.
+
+    Rightmove's typeahead resolves full postcodes ('B5 4BX' -> POSTCODE^4991456)
+    and outcodes ('B5' -> OUTCODE^86), and returns no match for a sector ('B5 7',
+    'E14 9') -- probed live 2026-09-03.
+
+    Deliberately between the two existing helpers, and neither of them fits:
+    `normalise_prefix` admits sectors, which can never resolve, so it would send
+    input upstream that is guaranteed to come back empty; `normalise_postcode`
+    admits only full postcodes, so it would reject an outcode that does resolve
+    and is a documented input. Composed from the same private predicates as
+    both, so the GIR special cases cannot drift apart from them.
+    """
+    from property_core.exceptions import InvalidPostcodeError
+
+    text = _normalise(value)
+    if _is_full(text) or _is_outcode(text):
+        return text
+    expected = "a full postcode ('B5 4BX') or an outcode ('B5')"
+    if _is_sector(text):
+        # A sector is well-formed, so "not valid" alone sends the caller looking
+        # for a typo that is not there. Name the input that would work.
+        expected += (
+            f"; a postcode sector has no Rightmove location -- use the outcode "
+            f"{text.split(' ')[0]!r} or a full postcode"
+        )
+    raise InvalidPostcodeError(
+        value=value if isinstance(value, str) else repr(value),
+        field=field,
+        expected=expected,
+    )
+
+
 def is_sector(prefix: str) -> bool:
     return _is_sector(prefix)
 

--- a/property_core/rightmove_location.py
+++ b/property_core/rightmove_location.py
@@ -13,9 +13,17 @@ from urllib.parse import urlencode
 
 import requests
 
+from property_core.exceptions import LocationLookupError, LocationNotFoundError
+from property_core.postcode_rules import normalise_postcode_or_outcode
 
-class LocationLookupError(Exception):
-    """Raised when Rightmove location lookup fails."""
+# Re-exported so `from property_core.rightmove_location import LocationLookupError`
+# keeps working. The types live in `property_core.exceptions` with the rest of
+# the taxonomy, because that is what the REST mapping and the CLI decorator read.
+__all__ = [
+    "LocationLookupError",
+    "LocationNotFoundError",
+    "RightmoveLocationAPI",
+]
 
 
 _SORT_TYPES = {
@@ -67,8 +75,23 @@ class RightmoveLocationAPI:
         self._last_request_time = time.time()
 
     def lookup_postcode(self, postcode: str) -> Optional[str]:
-        """Return Rightmove location identifier for a postcode/outcode."""
-        postcode_upper = postcode.upper().strip()
+        """Return Rightmove location identifier for a postcode/outcode.
+
+        Validated here, at the network boundary, rather than at each of the eight
+        call sites of `build_search_url` -- one grammar in one place cannot drift
+        the way eight copies would, and a shape that can never resolve is refused
+        before it spends an upstream request.
+
+        Returns `None` when the upstream answered and held no match. That is an
+        absence this signature can express, so it stays expressible here;
+        `build_search_url` converts it, because a function that must return a URL
+        cannot.
+
+        Raises:
+            InvalidPostcodeError: the input is not a full postcode or outcode.
+            LocationLookupError: Rightmove could not be consulted.
+        """
+        postcode_upper = normalise_postcode_or_outcode(postcode)
         if self._cache is not None and postcode_upper in self._cache:
             return self._cache[postcode_upper]
 
@@ -115,9 +138,10 @@ class RightmoveLocationAPI:
         """Build a Rightmove search URL from a postcode/outcode."""
         location_identifier = self.lookup_postcode(postcode)
         if not location_identifier:
-            raise LocationLookupError(
-                f"Could not find location identifier for postcode '{postcode}'."
-            )
+            # Absence, not failure: the input passed the grammar and the upstream
+            # answered normally with no match. Raising LocationLookupError here
+            # made an empty result indistinguishable from an outage.
+            raise LocationNotFoundError(postcode)
 
         # Full postcodes tend to be very tight searches; default to a small radius
         # so the first request is more likely to return results.

--- a/tests/test_rightmove_location_taxonomy.py
+++ b/tests/test_rightmove_location_taxonomy.py
@@ -1,0 +1,217 @@
+"""Rightmove location lookup separates caller error, absence and upstream failure.
+
+`build_search_url` raised a single bare `LocationLookupError` both when the
+upstream connection failed and when the upstream answered normally with no
+match. Those are different facts about the world and they need different
+remedies, so a consumer that can only see one type cannot choose between
+"reformulate your input", "that place has no Rightmove record" and "try again".
+
+The grammar is settled by a live probe (2026-09-03), not by the docstring:
+
+    'SW1A 1AA' -> 'POSTCODE^837246'   full postcode: resolves
+    'B5 4BX'   -> 'POSTCODE^4991456'  full postcode: resolves
+    'B5'       -> 'OUTCODE^86'        outcode:       resolves
+    'NG1'      -> 'OUTCODE^1752'      outcode:       resolves
+    'B5 7'     -> None                sector:        never resolves
+    'E14 9'    -> None                sector:        never resolves
+    'XX99 9XX' -> None                well-formed, nonexistent
+
+So outcodes must keep working -- narrowing this to full postcodes only would be
+a breaking change for a documented input -- while a sector must be refused
+before it reaches Rightmove, because no sector can ever resolve.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from property_core.exceptions import InvalidPostcodeError, PPDError
+from property_core.rightmove_location import (
+    LocationLookupError,
+    LocationNotFoundError,
+    RightmoveLocationAPI,
+)
+
+import requests
+
+
+def _matches(location_id: str, location_type: str) -> dict:
+    return {"matches": [{"id": location_id, "type": location_type}]}
+
+
+NO_MATCH = {"matches": []}
+
+
+@pytest.fixture
+def api():
+    # Cache off: a cached identifier would let a later assertion pass without
+    # the request under test ever being made.
+    return RightmoveLocationAPI(cache_enabled=False, rate_limit_delay=0)
+
+
+# --- (i) shapes Rightmove can never resolve: caller error, before any request ---
+
+
+@pytest.mark.parametrize("sector", ["B5 7", "E14 9", "SW1A 1", "GIR 0"])
+def test_a_sector_is_rejected_before_any_request(api, sector):
+    with patch.object(requests, "get") as get:
+        with pytest.raises(InvalidPostcodeError):
+            api.lookup_postcode(sector)
+        assert get.call_count == 0, "a sector can never resolve; it must not reach Rightmove"
+
+
+def test_the_sector_message_names_the_outcode_that_would_work(api):
+    with patch.object(requests, "get"):
+        with pytest.raises(InvalidPostcodeError) as exc:
+            api.lookup_postcode("B5 7")
+    # A caller told only "not valid" goes hunting for a typo that is not there.
+    assert "'B5'" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "garbage",
+    ["", "   ", "NOTAPOSTCODE", "B5;DROP", "../etc", "B5\n7", "12345", "B5 4BX EXTRA", "<script>"],
+)
+def test_garbage_is_rejected_before_any_request(api, garbage):
+    with patch.object(requests, "get") as get:
+        with pytest.raises(InvalidPostcodeError):
+            api.lookup_postcode(garbage)
+        get.assert_not_called()
+
+
+def test_a_non_string_is_rejected_rather_than_coerced(api):
+    with patch.object(requests, "get") as get:
+        with pytest.raises(InvalidPostcodeError):
+            api.lookup_postcode(None)  # type: ignore[arg-type]
+        get.assert_not_called()
+
+
+# --- inputs that DO resolve must keep resolving ---
+
+
+@pytest.mark.parametrize("outcode", ["B5", "NG1", "SW1A", "EC1V", "B50", "GIR"])
+def test_outcodes_reach_the_upstream_and_resolve(api, outcode):
+    with patch.object(requests, "get") as get:
+        get.return_value.json.return_value = _matches("86", "OUTCODE")
+        get.return_value.raise_for_status.return_value = None
+        assert api.lookup_postcode(outcode) == "OUTCODE^86"
+        assert get.call_count == 1, "an outcode is a documented input and must reach Rightmove"
+
+
+@pytest.mark.parametrize("postcode", ["SW1A 1AA", "B5 4BX", "GIR 0AA"])
+def test_full_postcodes_reach_the_upstream_and_resolve(api, postcode):
+    with patch.object(requests, "get") as get:
+        get.return_value.json.return_value = _matches("837246", "POSTCODE")
+        get.return_value.raise_for_status.return_value = None
+        assert api.lookup_postcode(postcode) == "POSTCODE^837246"
+
+
+def test_whitespace_and_case_are_normalised_not_rejected(api):
+    with patch.object(requests, "get") as get:
+        get.return_value.json.return_value = _matches("4991456", "POSTCODE")
+        get.return_value.raise_for_status.return_value = None
+        api.lookup_postcode(" b5   4bx ")
+        assert get.call_args.kwargs["params"]["query"] == "B5 4BX"
+
+
+# --- (ii) well-formed but no match: absence, not caller error ---
+
+
+def test_a_wellformed_unknown_postcode_is_not_found_not_invalid(api):
+    with patch.object(requests, "get") as get:
+        get.return_value.json.return_value = NO_MATCH
+        get.return_value.raise_for_status.return_value = None
+        with pytest.raises(LocationNotFoundError) as exc:
+            api.build_search_url("XX99 9XX")
+    # The input satisfies the grammar; calling it invalid states a false fact.
+    assert not isinstance(exc.value, InvalidPostcodeError)
+
+
+def test_lookup_postcode_still_returns_none_for_no_match(api):
+    """`lookup_postcode` can express absence, so it keeps its Optional contract.
+
+    Only `build_search_url` must convert, because it has to return a URL.
+    """
+    with patch.object(requests, "get") as get:
+        get.return_value.json.return_value = NO_MATCH
+        get.return_value.raise_for_status.return_value = None
+        assert api.lookup_postcode("XX99 9XX") is None
+
+
+def test_a_match_without_an_id_is_absence_not_a_crash(api):
+    with patch.object(requests, "get") as get:
+        get.return_value.json.return_value = {"matches": [{"type": "OUTCODE"}]}
+        get.return_value.raise_for_status.return_value = None
+        assert api.lookup_postcode("B5") is None
+
+
+# --- (iii) transport failure stays an upstream failure ---
+
+
+def test_transport_failure_stays_a_lookup_error_and_is_retryable(api):
+    with patch.object(requests, "get", side_effect=requests.RequestException("boom")):
+        with pytest.raises(LocationLookupError) as exc:
+            api.lookup_postcode("B5 4BX")
+    assert exc.value.retryable is True
+    assert exc.value.to_dict()["error"] == "rightmove_location_unavailable"
+
+
+# --- the three outcomes must stay tellable apart, and reach the consumers ---
+
+
+def test_the_three_outcomes_are_pairwise_distinguishable():
+    """No two of these may be catchable by the same `except` unless intended.
+
+    They differ only by subclass, so a consumer mapping them to 422 / 404 / 502
+    depends on exactly this.
+    """
+    assert not issubclass(LocationNotFoundError, InvalidPostcodeError)
+    assert not issubclass(InvalidPostcodeError, LocationNotFoundError)
+    assert not issubclass(LocationLookupError, LocationNotFoundError)
+    assert not issubclass(LocationNotFoundError, LocationLookupError)
+    assert not issubclass(LocationLookupError, InvalidPostcodeError)
+
+
+def test_all_three_are_ppd_errors_so_the_cli_decorator_catches_them():
+    """`_ppd_errors` catches the base, so subclassing is what wires the CLI up."""
+    for exc_type in (InvalidPostcodeError, LocationNotFoundError, LocationLookupError):
+        assert issubclass(exc_type, PPDError)
+
+
+def test_all_three_carry_a_typed_payload():
+    for exc in (
+        InvalidPostcodeError("B5 7", field="postcode", expected="an outcode"),
+        LocationNotFoundError("XX99 9XX"),
+        LocationLookupError("boom"),
+    ):
+        payload = exc.to_dict()
+        assert payload["error"] and payload["detail"]
+        assert "retryable" in payload
+
+
+def test_the_typed_errors_are_exported_from_property_core():
+    import property_core
+
+    for name in ("LocationNotFoundError", "LocationLookupError"):
+        assert hasattr(property_core, name), f"{name} must be importable from property_core"
+        assert name in property_core.__all__
+
+
+# --- build_search_url is the layer that converts, and it still builds URLs ---
+
+
+def test_build_search_url_still_builds_a_url_for_a_resolvable_input(api):
+    with patch.object(requests, "get") as get:
+        get.return_value.json.return_value = _matches("86", "OUTCODE")
+        get.return_value.raise_for_status.return_value = None
+        url = api.build_search_url("B5")
+    assert "locationIdentifier=OUTCODE%5E86" in url
+
+
+def test_a_sector_is_refused_by_build_search_url_too(api):
+    with patch.object(requests, "get") as get:
+        with pytest.raises(InvalidPostcodeError):
+            api.build_search_url("B5 7")
+        get.assert_not_called()

--- a/tests/test_rightmove_router.py
+++ b/tests/test_rightmove_router.py
@@ -108,3 +108,68 @@ def _stub_detail():
     return RightmoveListingDetail(
         id=123456, url="https://www.rightmove.co.uk/properties/123456"
     )
+
+
+class TestCallerErrorMapping:
+    """Caller mistakes must not be reported as our failure.
+
+    A sector returned 502 Bad Gateway -- the API blaming itself for input that
+    Rightmove can never resolve. Both endpoints build their own search URL, so
+    both need the mapping; fixing only /search-url would leave identical input
+    answered 422 on one route and 502 on the other.
+    """
+
+    SECTOR = "B5 7"
+    UNKNOWN = "XX99 9XX"
+
+    @pytest.mark.parametrize("path", ["/v1/rightmove/search-url", "/v1/rightmove/listings"])
+    def test_a_sector_is_422_not_502(self, client, path):
+        with patch.object(rightmove_router, "fetch_listings") as fetch:
+            resp = client.get(path, params={"postcode": self.SECTOR})
+        assert resp.status_code == 422, resp.text
+        body = resp.json()["detail"]
+        assert body["error"] == "invalid_postcode"
+        assert body["retryable"] is False
+        # The remedy must survive into the response, not just the log.
+        assert "'B5'" in body["expected"]
+        assert fetch.call_count == 0, "a refused input must not reach the scraper"
+
+    @pytest.mark.parametrize("path", ["/v1/rightmove/search-url", "/v1/rightmove/listings"])
+    def test_a_wellformed_unknown_postcode_is_404_not_502(self, client, path):
+        with patch.object(rightmove_router, "fetch_listings") as fetch, patch(
+            "property_core.rightmove_location.requests.get"
+        ) as get:
+            get.return_value.json.return_value = {"matches": []}
+            get.return_value.raise_for_status.return_value = None
+            resp = client.get(path, params={"postcode": self.UNKNOWN})
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["detail"]["error"] == "rightmove_location_not_found"
+        assert fetch.call_count == 0, "an absent location must not reach the scraper"
+
+    @pytest.mark.parametrize("path", ["/v1/rightmove/search-url", "/v1/rightmove/listings"])
+    def test_a_transport_failure_is_still_502_with_a_typed_body(self, client, path):
+        import requests as _requests
+
+        with patch(
+            "property_core.rightmove_location.requests.get",
+            side_effect=_requests.RequestException("upstream down"),
+        ):
+            resp = client.get(path, params={"postcode": "B5 4BX"})
+        assert resp.status_code == 502, resp.text
+        body = resp.json()["detail"]
+        assert body["error"] == "rightmove_location_unavailable"
+        assert body["retryable"] is True, "an outage is worth retrying; caller error is not"
+
+    def test_listing_detail_mapping_is_unchanged(self, client):
+        """Guard the fix from over-reaching.
+
+        /listing/{id} takes a numeric id, not a postcode, and already maps
+        correctly. It also carries a deliberate warning against catching
+        ValueError there, since pydantic's ValidationError subclasses it and an
+        upstream shape change would then be misreported as caller error.
+        """
+        with patch.object(rightmove_router, "fetch_listing") as fetch:
+            assert client.get("/v1/rightmove/listing/abc").status_code == 422
+            assert fetch.call_count == 0
+            fetch.side_effect = ValueError("upstream shape changed")
+            assert client.get("/v1/rightmove/listing/123").status_code == 502

--- a/tests/test_rightmove_service_live.py
+++ b/tests/test_rightmove_service_live.py
@@ -118,3 +118,33 @@ async def test_rightmove_listing_detail_live() -> None:
     assert detail.url.startswith("https://www.rightmove.co.uk/properties/")
     assert detail.address is not None
     assert detail.tenure_type in ("FREEHOLD", "LEASEHOLD", None)
+
+
+def test_rightmove_resolves_outcodes_and_full_postcodes_but_never_sectors() -> None:
+    """Pin the grammar the typed-error taxonomy is built on.
+
+    `normalise_postcode_or_outcode` admits full postcodes and outcodes and
+    refuses sectors, because that is what Rightmove actually does -- probed
+    2026-09-03. If Rightmove ever starts resolving sectors, or stops resolving
+    outcodes, this fails loudly instead of the library quietly refusing input
+    that works (or spending requests on input that cannot).
+    """
+    if os.getenv("RUN_LIVE_TESTS") != "1":
+        pytest.skip("Set RUN_LIVE_TESTS=1 to run live network tests")
+
+    from property_core.exceptions import InvalidPostcodeError
+
+    api = RightmoveLocationAPI(cache_enabled=False)
+
+    for full in ("SW1A 1AA", "B5 4BX"):
+        assert (api.lookup_postcode(full) or "").startswith("POSTCODE^"), full
+        time.sleep(0.5)
+
+    for outcode in ("B5", "NG1"):
+        assert (api.lookup_postcode(outcode) or "").startswith("OUTCODE^"), outcode
+        time.sleep(0.5)
+
+    # Refused locally, so no request is spent proving what cannot resolve.
+    for sector in ("B5 7", "E14 9"):
+        with pytest.raises(InvalidPostcodeError):
+            api.lookup_postcode(sector)

--- a/tests/test_rightmove_surfaces.py
+++ b/tests/test_rightmove_surfaces.py
@@ -1,0 +1,116 @@
+"""The typed Rightmove errors reach the MCP and CLI surfaces readably.
+
+Neither MCP server needs a code change: FastMCP renders `str(exc)` for an
+exception raised inside a tool, so a self-describing typed error arrives as a
+readable message on its own. These tests pin that, because "no change needed"
+is a claim about behaviour and should fail loudly if it stops being true.
+
+The target shape is the one a real ChatGPT session produced for the equivalent
+PPD error (docs/ops/2026-08-30-property-shared-stall.md):
+
+    Error calling tool 'ppd_transactions': postcode 'DE12' is not valid;
+    expected a full UK postcode, e.g. 'B5 4BX'
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _call_rightmove_search(mcp, postcode: str) -> str:
+    """Drive the real FastMCP dispatcher and return the error text it renders."""
+    from fastmcp import Client
+
+    async with Client(mcp) as client:
+        with pytest.raises(Exception) as exc:  # noqa: PT011 - FastMCP's own wrapper type
+            await client.call_tool("rightmove_search", {"postcode": postcode})
+    return str(exc.value)
+
+
+async def test_the_plain_mcp_server_reports_a_sector_readably():
+    from app.mcp.server import mcp
+
+    message = await _call_rightmove_search(mcp, "B5 7")
+    assert "not valid" in message
+    assert "'B5'" in message, "the remedy must survive to the model"
+    assert "Traceback" not in message, "a stack trace is not an answer"
+
+
+async def test_the_mcp_app_server_reports_a_sector_readably():
+    # property_app registers its tools inside main(), not at server import, so
+    # the tools module must be imported for the dispatcher to know them.
+    from property_app import tools  # noqa: F401
+    from property_app.server import mcp
+
+    message = await _call_rightmove_search(mcp, "B5 7")
+    assert "not valid" in message
+    assert "Traceback" not in message
+
+
+def test_a_refused_input_never_reaches_rightmove_from_mcp():
+    """The shape gate sits at the network boundary, so no request is spent."""
+    from property_core.rightmove_location import RightmoveLocationAPI
+    from property_core.exceptions import InvalidPostcodeError
+
+    api = RightmoveLocationAPI(cache_enabled=False, rate_limit_delay=0)
+    with patch("property_core.rightmove_location.requests.get") as get:
+        with pytest.raises(InvalidPostcodeError):
+            api.build_search_url("B5 7")
+        assert get.call_count == 0
+
+
+# --- CLI: core mode only, deliberately ---
+
+
+def _invoke(args: list[str]):
+    from typer.testing import CliRunner
+
+    import property_cli.main as M
+
+    return CliRunner().invoke(M.app, args)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["rightmove", "search-url", "B5 7"],
+        ["rightmove", "listings", "B5 7"],
+    ],
+)
+def test_cli_core_mode_exits_1_with_typed_json_not_a_traceback(args):
+    """`@_ppd_errors` catches the base class, so subclassing is what wires this up.
+
+    Scope note: this covers CORE mode only. In `--api-url` mode the request goes
+    through `HTTPClient.get`, which calls `raise_for_status()` and discards the
+    typed body, so a 422/404 surfaces as `httpx.HTTPStatusError` and escapes this
+    decorator. Fixing that means teaching `HTTPClient` to rebuild the typed error
+    from the response body, which applies to every `--api-url` command, not just
+    these two -- tracked separately rather than smuggled in here.
+    """
+    result = _invoke(args)
+    assert result.exit_code == 1, result.output
+    assert "Traceback" not in result.output
+    # _echo_json pretty-prints across several lines, so parse the whole payload.
+    payload = json.loads(result.output)
+    assert payload["error"] == "invalid_postcode"
+    assert payload["retryable"] is False
+    assert "'B5'" in payload["expected"]
+
+
+def test_cli_core_mode_still_accepts_an_outcode():
+    with patch("property_core.rightmove_location.requests.get") as get:
+        get.return_value.json.return_value = {"matches": [{"id": "86", "type": "OUTCODE"}]}
+        get.return_value.raise_for_status.return_value = None
+        result = _invoke(["rightmove", "search-url", "B5"])
+    assert result.exit_code == 0, result.output
+    assert "OUTCODE%5E86" in result.output


### PR DESCRIPTION
## The defect

`build_search_url` raised one bare `LocationLookupError` **both** when the
transport failed and when Rightmove answered normally with no match. No consumer
could tell those apart, and the REST layer flattened everything to `502` — the
API blaming itself for input the caller got wrong.

## Three outcomes, now distinguishable

| Input | Type | REST |
|---|---|---|
| sector (`B5 7`), garbage | `InvalidPostcodeError` (reused) | 422 |
| well-formed, no match (`XX99 9XX`) | **`LocationNotFoundError`** (new) | 404 |
| transport failure | `LocationLookupError` (**reparented**) | 502 |

`XX99 9XX` is a **404, not a 422**: it satisfies the grammar, so calling it
invalid states a false fact and sends the caller hunting a typo that isn't
there. The upstream answered normally with an empty match list. This is the line
`TransactionNotFoundError` already draws.

Reparenting `LocationLookupError` from bare `Exception` to
`UpstreamUnavailableError` is what supplies `to_dict()`, `retryable` and
`_ppd_errors` handling. Setting those attributes by hand would have given the
data without the behaviour.

## The grammar is probed, not assumed

The 2026-08-30 control tested full postcodes and one sector, never an outcode.
Probed live 2026-09-03:

```
'SW1A 1AA' -> POSTCODE^837246     'B5'  -> OUTCODE^86
'B5 4BX'   -> POSTCODE^4991456    'NG1' -> OUTCODE^1752
'B5 7', 'E14 9' -> None           'XX99 9XX' -> None
```

**Outcodes resolve.** Narrowing to full postcodes only — which reusing
`normalise_postcode` would have done — is a breaking change for a documented
input. Sectors never resolve, so they are refused before a request is spent.

Neither existing helper fits: `normalise_prefix` admits sectors,
`normalise_postcode` rejects outcodes. The new
`normalise_postcode_or_outcode` is composed from the same private predicates as
both, so the `GIR` special cases cannot drift apart.

A `RUN_LIVE_TESTS=1` test pins this grammar against the real API, so it fails
loudly if Rightmove ever changes.

## Placement

Validation goes in `lookup_postcode`, at the network boundary — **not** at the
**eight** call sites of `build_search_url` (`app/api/v1/rightmove.py` ×2,
`app/mcp/server.py`, `property_app/tools.py`,
`property_app/dashboards/listings.py`, `property_cli/main.py` ×2, plus
`rental_service`, `yield_service`, `report_service`). One grammar in one place
cannot drift the way eight copies would.

`lookup_postcode` keeps returning `None` for no match — its signature can
express absence. `build_search_url` converts, because a function that must
return a URL cannot.

## Both routes, and what is deliberately untouched

`/listings` builds its own search URL, so fixing only `/search-url` would have
answered identical input 422 on one route and 502 on the other. Tests assert
`fetch_listings` is **never reached** on a 422/404, so a status-code-only pass
cannot hide the request still going out.

- **Neither MCP server needs a code change** — FastMCP renders `str(exc)` and
  the typed errors are self-describing. Pinned by test anyway, because "no
  change needed" is a behavioural claim.
- **`listing_detail` untouched**, and guarded by a test. It takes a numeric id,
  already maps correctly, and carries a standing warning against catching
  `ValueError` there (pydantic's `ValidationError` subclasses it).

## Scope limits, stated

- **CLI is core mode only.** Under `--api-url`, `HTTPClient.get` calls
  `raise_for_status()` and discards the typed body, so a 422/404 surfaces as
  `httpx.HTTPStatusError` and escapes `_ppd_errors`. Teaching `HTTPClient` to
  rebuild the typed error applies to *every* `--api-url` command — its own change.
- **`yield_service` / `rental_service` / `report_service` still catch
  `Exception` broadly**, so a sector passed to `property_yield` is still
  degraded to an empty analysis while `rightmove_search` now reports it
  honestly. Same "a failure is not an absence" defect one layer up,
  behaviour-changing for five more tool surfaces — its own PR.

## Verification

`./scripts/validate.sh` → **2061 passed, 27 skipped**. The live grammar pin
passes against the real Rightmove API under `RUN_LIVE_TESTS=1`.

One pre-existing test caught a violation in my own docstring
(`test_exceptions_are_protocol_neutral` forbids HTTP status codes in
`property_core/exceptions.py`); the docstring was fixed rather than the test.