### PR TITLE
feat(ppd): a second verification arm that needs no live upstream

### DIFF
--- a/docs/ops/evidence/2026-09-04-nonlive-verification.json
+++ b/docs/ops/evidence/2026-09-04-nonlive-verification.json
@@ -1,0 +1,16 @@
+{
+  "kind": "ppd_snapshot_nonlive_verification",
+  "not_stage_1_evidence": true,
+  "note": "A second arm that is not the live source. It shares the snapshot's own data, so it cannot detect a row that never reached the artifact; only an independent publication of the dataset can. It establishes internal consistency and query-path reachability.",
+  "artifact": {
+    "version": "v20260828T194003Z",
+    "bundle_sha256": "50f802b29d9802ee42319122214aeb0adc6761e96c4f6c9ddd0498500bb9072c",
+    "coverage_from": "2016-01-01",
+    "coverage_to": "2026-06-30",
+    "rows": 10394935
+  },
+  "rows_examined": 10394935,
+  "cases_compared": 0,
+  "passed": true,
+  "findings": []
+}

--- a/tests/snapshot/test_nonlive_verify.py
+++ b/tests/snapshot/test_nonlive_verify.py
@@ -1,0 +1,288 @@
+"""The non-live second arm must actually detect the defects it exists for.
+
+A verifier that passes everything is worthless, and a verifier for a defect
+nobody has reproduced is a guess. Every check here is driven from a row built to
+carry the specific defect, and asserted to be found — then a clean row is
+asserted to pass, so the checks are not simply always-on.
+
+The defect class being targeted is the one Stage 1's live arm would have caught
+and cannot currently be run for:
+
+    "snapshot_false_empty": snap.count == 0 and live.count > 0
+
+Here the second arm is the artifact read a different way, so no upstream is
+needed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_MODULE_PATH = (Path(__file__).resolve().parents[2]
+                / "tools" / "ppd_snapshot" / "nonlive_verify.py")
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("nonlive_verify", _MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+nv = _load_module()
+
+COLUMNS = nv._COLUMNS
+
+
+def row(**over: Any) -> tuple:
+    """One row in `_COLUMNS` order, correct unless deliberately broken."""
+    base = {
+        "transaction_id": "TX1", "price": 250000,
+        "transfer_date": date(2025, 6, 1), "postcode": "B5 4BX",
+        "outcode": "B5", "sector": "B5 4", "property_type": "F",
+        "duration": "L", "ppd_category": "A", "new_build": False,
+    }
+    base.update(over)
+    return tuple(base[c] for c in COLUMNS)
+
+
+# --- the reference derivation is genuinely independent of the build ---
+
+
+@pytest.mark.parametrize(
+    ("postcode", "outcode", "sector"),
+    [
+        ("B5 4BX", "B5", "B5 4"),
+        ("SW1A 1AA", "SW1A", "SW1A 1"),
+        ("GIR 0AA", "GIR", "GIR 0"),
+        ("  b5   4bx ", "B5", "B5 4"),
+    ],
+)
+def test_reference_geography_matches_the_grammar(postcode, outcode, sector):
+    assert nv.reference_geography(postcode) == (outcode, sector)
+
+
+@pytest.mark.parametrize("postcode", ["", "   ", None, "NOTAPOSTCODE", "B54BX", 12345])
+def test_reference_geography_refuses_what_the_grammar_refuses(postcode):
+    """The build's split_part would still have stored something here."""
+    assert nv.reference_geography(postcode) == (None, None)
+
+
+# --- check 1: geography derivation ---
+
+
+def test_a_correct_row_produces_no_findings():
+    assert nv.check_geography_derivation([row()]) == []
+
+
+def test_a_mis_derived_outcode_is_reported_as_unreachable():
+    """The false empty, in its purest form.
+
+    Stored 'B50', reference 'B5'. A query for outcode 'B5' equality-matches
+    nothing, and the row is invisible with no error anywhere.
+    """
+    findings = nv.check_geography_derivation([row(outcode="B50")])
+    assert [f.check for f in findings] == ["geography_derivation"]
+    assert findings[0].count == 1
+    assert "cannot reach" in findings[0].detail
+
+
+def test_a_mis_derived_sector_is_reported():
+    findings = nv.check_geography_derivation([row(sector="B5 9")])
+    assert [f.check for f in findings] == ["geography_derivation"]
+
+
+def test_a_lowercase_stored_geography_is_reported_separately():
+    """The build never upper-cases; normalise_prefix does.
+
+    'b5' and 'B5' are the same place and different strings, so equality misses.
+    Kept apart from a mis-derivation because the cause and the fix differ.
+    """
+    findings = nv.check_geography_derivation([row(postcode="b5 4bx", outcode="b5", sector="b5 4")])
+    assert [f.check for f in findings] == ["geography_case"]
+    assert "upper-case" in findings[0].detail
+
+
+def test_a_geography_the_grammar_rejects_is_reported_as_unvalidated():
+    """split_part stores the text before the first space, valid or not."""
+    findings = nv.check_geography_derivation(
+        [row(postcode="XX 1AA", outcode="XX", sector=None)])
+    assert [f.check for f in findings] == ["geography_unvalidated"]
+
+
+def test_findings_carry_no_price_address_or_row():
+    findings = nv.check_geography_derivation([row(outcode="B50", price=999999)])
+    blob = str(findings[0].to_dict())
+    assert "999999" not in blob
+    assert findings[0].sample == ["TX1"], "ids only, and capped"
+
+
+def test_the_sample_is_capped_rather_than_unbounded():
+    rows = [row(transaction_id=f"TX{i}", outcode="B50") for i in range(50)]
+    finding = nv.check_geography_derivation(rows)[0]
+    assert finding.count == 50
+    assert len(finding.sample) == 5
+
+
+# --- check 2: query semantics, reimplemented independently ---
+
+
+def test_python_select_filters_on_recomputed_geography_not_the_stored_column():
+    """The whole point: a wrong stored column must not hide itself.
+
+    This row's stored outcode is wrong, so the adapter cannot find it — but the
+    reference arm still selects it, which is what makes the disagreement
+    visible.
+    """
+    assert nv.python_select([row(outcode="WRONG")], outcode="B5") == ["TX1"]
+
+
+def test_python_select_applies_each_predicate():
+    rows = [
+        row(transaction_id="A", postcode="B5 4BX", transfer_date=date(2025, 1, 1)),
+        row(transaction_id="B", postcode="B5 5AA", transfer_date=date(2025, 2, 1)),
+        row(transaction_id="C", postcode="XX9 9XX", transfer_date=date(2025, 3, 1)),
+        row(transaction_id="D", postcode="B5 4BX", property_type="D"),
+        row(transaction_id="E", postcode="B5 4BX", ppd_category="B"),
+    ]
+    assert set(nv.python_select(rows, outcode="B5")) == {"A", "B", "D", "E"}
+    assert nv.python_select(rows, sector="B5 4") != []
+    assert set(nv.python_select(rows, outcode="B5", property_types=["F"])) == {"A", "B", "E"}
+    assert set(nv.python_select(rows, outcode="B5", transaction_category="A")) == {"A", "B", "D"}
+    assert nv.python_select(rows, outcode="B5", from_date="2025-02-01") != ["A"]
+
+
+def test_python_select_orders_date_desc_then_id_asc_like_the_adapter():
+    rows = [
+        row(transaction_id="TXB", transfer_date=date(2025, 1, 1)),
+        row(transaction_id="TXA", transfer_date=date(2025, 1, 1)),
+        row(transaction_id="TXC", transfer_date=date(2026, 1, 1)),
+    ]
+    assert nv.python_select(rows, outcode="B5") == ["TXC", "TXA", "TXB"]
+
+
+def test_python_select_orders_ids_of_unequal_length_ascending():
+    """Guards the sort: a composite key negating a string gets this wrong."""
+    rows = [
+        row(transaction_id="TX10", transfer_date=date(2025, 1, 1)),
+        row(transaction_id="TX9", transfer_date=date(2025, 1, 1)),
+        row(transaction_id="TX100", transfer_date=date(2025, 1, 1)),
+    ]
+    assert nv.python_select(rows, outcode="B5") == ["TX10", "TX100", "TX9"]
+
+
+def test_python_select_honours_the_limit():
+    rows = [row(transaction_id=f"TX{i}") for i in range(10)]
+    assert len(nv.python_select(rows, outcode="B5", limit=3)) == 3
+
+
+def test_a_row_with_no_date_is_skipped_rather_than_crashing():
+    assert nv.python_select([row(transfer_date=None)], outcode="B5") == []
+
+
+# --- check 3: partition completeness ---
+
+
+def test_every_covered_year_present_passes(tmp_path):
+    for year in range(2016, 2027):
+        (tmp_path / f"year={year}").mkdir()
+    assert nv.check_partition_completeness(
+        tmp_path, date(2016, 1, 1), date(2026, 6, 30)) == []
+
+
+def test_a_missing_year_is_reported(tmp_path):
+    """A missing partition does not fail a query; it just returns less."""
+    for year in range(2016, 2027):
+        if year != 2019:
+            (tmp_path / f"year={year}").mkdir()
+    findings = nv.check_partition_completeness(
+        tmp_path, date(2016, 1, 1), date(2026, 6, 30))
+    assert [f.check for f in findings] == ["partition_completeness"]
+    assert findings[0].sample == ["2019"]
+
+
+def test_stray_directories_do_not_count_as_partitions(tmp_path):
+    (tmp_path / "year=2016").mkdir()
+    (tmp_path / "notes").mkdir()
+    (tmp_path / "year=abc").mkdir()
+    findings = nv.check_partition_completeness(
+        tmp_path, date(2016, 1, 1), date(2017, 12, 31))
+    assert findings and findings[0].sample == ["2017"]
+
+
+# --- the report must not overclaim ---
+
+
+def test_the_report_marks_itself_not_stage_1_evidence():
+    report = nv.build_report([], artifact={"version": "v1"}, rows_examined=10,
+                             cases_compared=13)
+    assert report["not_stage_1_evidence"] is True
+    assert report["passed"] is True
+    assert "cannot detect a row that never reached the artifact" in report["note"]
+
+
+def test_a_report_with_findings_does_not_pass():
+    report = nv.build_report([nv.Finding("x", "y", 1)], artifact={},
+                             rows_examined=1, cases_compared=1)
+    assert report["passed"] is False
+
+
+# --- memory safety: the artifact is ~10.4M rows on a 2GB Machine ---
+
+
+class _Cursor:
+    """Minimal DuckDB-cursor stand-in that only supports fetchmany."""
+
+    def __init__(self, rows, chunk_calls):
+        self._rows = list(rows)
+        self._at = 0
+        self.chunk_calls = chunk_calls
+
+    def fetchmany(self, size):
+        self.chunk_calls.append(size)
+        batch = self._rows[self._at:self._at + size]
+        self._at += len(batch)
+        return batch
+
+    def fetchall(self):  # pragma: no cover - must never be reached
+        raise AssertionError(
+            "fetchall would materialize ~10.4M rows against ~1.6GB free and "
+            "OOM the app serving traffic"
+        )
+
+
+def test_iter_rows_streams_and_never_calls_fetchall():
+    calls: list[int] = []
+    cursor = _Cursor([row(transaction_id=f"TX{i}") for i in range(250)], calls)
+    streamed = list(nv.iter_rows(cursor, chunk=100))
+    assert len(streamed) == 250
+    assert calls == [100, 100, 100, 100], "must page, and must stop on the empty batch"
+
+
+def test_iter_rows_is_lazy_rather_than_building_a_list():
+    calls: list[int] = []
+    cursor = _Cursor([row() for _ in range(100)], calls)
+    stream = nv.iter_rows(cursor, chunk=10)
+    next(iter(stream))
+    assert len(calls) == 1, "one chunk fetched to yield the first row, not all of them"
+
+
+def test_findings_stay_bounded_when_every_row_disagrees():
+    """The failure mode this guards: a wholly mis-derived artifact.
+
+    Accumulating one id per disagreement would hold ~10.4M strings on the
+    machine already short of memory — failing hardest exactly when the artifact
+    is most broken.
+    """
+    rows = (row(transaction_id=f"TX{i}", outcode="WRONG") for i in range(20_000))
+    findings = nv.check_geography_derivation(rows)
+    assert findings[0].count == 20_000
+    assert len(findings[0].sample) == nv._SAMPLE_CAP

--- a/tools/ppd_snapshot/nonlive_verify.py
+++ b/tools/ppd_snapshot/nonlive_verify.py
@@ -1,0 +1,371 @@
+"""A second arm for the snapshot that needs no live upstream.
+
+Stage 1's live arm has been unavailable: 429 on 2026-09-02, then a 503 after
+271.8 s on 2026-09-04. Its central criterion is the false empty --
+
+    "snapshot_false_empty": snap.count == 0 and live.count > 0
+
+-- which is undetectable with one arm, because a wrongly-empty answer is
+indistinguishable from a correctly-empty one. A snapshot-only rehearsal, however
+many assertions it passes, cannot close that gap.
+
+This module supplies a **second arm that is not the live source**. It compares
+the snapshot against *itself*, read a different way, so the comparison needs no
+network and no HMLR availability.
+
+## Why this can find anything at all
+
+The adapter answers geography queries by equality against **materialized**
+`outcode`/`sector` columns (`property_core/snapshot/schema.py`). That design
+removes the `STRSTARTS("B5")`-matches-`B50` class of bug entirely -- but it
+relocates the risk rather than deleting it: if the *build* wrote those columns
+wrongly, every query filtering on them is silently short, and no amount of
+querying the same column can reveal it.
+
+The two derivations really are independent:
+
+* the **build** (`tools/ppd_snapshot/build.py`, `_DERIVE`) uses DuckDB string
+  surgery -- `split_part(trim(postcode), ' ', 1)` -- which validates nothing and
+  notably never upper-cases;
+* the **reference** here uses `property_core.postcode_rules`, a validated regex
+  grammar with exact GIR handling, which upper-cases and rejects malformed
+  input.
+
+A postcode those two disagree about is a row the adapter cannot find by
+geography. That is a false empty, discoverable offline.
+
+## The three checks
+
+1. **Geography derivation** -- recompute `outcode`/`sector` from the `postcode`
+   column and compare against what the build stored.
+2. **Query semantics** -- for each corpus case, select the matching rows in
+   plain Python from decoded Parquet, and compare against what the adapter's SQL
+   returned. DuckDB is used only as a Parquet *decoder* here; every predicate,
+   the ordering and the limit are reimplemented independently, because that is
+   where a WHERE/ORDER/LIMIT defect would live.
+3. **Partition completeness** -- one partition per year of declared coverage. A
+   missing year is not an error at query time; it is simply fewer rows.
+
+## What this does NOT establish
+
+**It is not Stage 1 and cannot be filed as Stage 1 evidence.** It shares the
+snapshot's own data, so it cannot detect a row that never reached the artifact:
+if the build dropped rows the CSV contained, both arms here are equally blind.
+Only a comparison against an independent publication of the dataset -- the live
+SPARQL source, or the bulk CSV -- can close that.
+
+It also says nothing about latency (no p95 here), and nothing about whether the
+snapshot agrees with what HMLR would answer today.
+
+What it does establish is narrower and still worth having: **that the artifact
+is internally consistent, and that the query path can reach every row the
+artifact contains.**
+
+Out-of-band operator tooling, on the same contract as `boot_only_verify.py`:
+never imported by the application, never wired into `CMD`, and inert unless
+explicitly invoked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+
+from property_core.postcode_rules import _normalise, outcode_of, sector_of
+
+#: Findings carry a bounded sample, never one entry per disagreeing row. On a
+#: wholly mis-derived artifact that list would hold ~10.4M ids.
+_SAMPLE_CAP = 5
+
+#: Rows pulled per fetch. The artifact holds ~10.4M rows and the deployed
+#: Machine has ~1.6 GB free while serving traffic, so materializing the result
+#: set would OOM the app. Chunked, peak memory is this many rows.
+_CHUNK_ROWS = 50_000
+
+#: Columns the reference arm reads. Deliberately includes the derived columns so
+#: they can be checked, and `postcode` so they can be recomputed.
+_COLUMNS = (
+    "transaction_id", "price", "transfer_date", "postcode", "outcode", "sector",
+    "property_type", "duration", "ppd_category", "new_build",
+)
+
+
+@dataclass
+class Finding:
+    """One disagreement. `sample` never carries a price, address or full row."""
+
+    check: str
+    detail: str
+    count: int = 0
+    sample: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"check": self.check, "detail": self.detail,
+                "count": self.count, "sample": self.sample}
+
+
+def reference_geography(postcode: Any) -> tuple[Optional[str], Optional[str]]:
+    """Outcode and sector by the validated grammar, independent of the build.
+
+    Returns `(None, None)` for anything the grammar refuses. That is the point
+    of disagreement worth reporting: the build would still have stored a value.
+    """
+    text = _normalise(postcode)
+    if not text:
+        return None, None
+    return outcode_of(text), sector_of(text)
+
+
+def check_geography_derivation(rows: Iterable[Sequence[Any]]) -> list[Finding]:
+    """Stored `outcode`/`sector` against the reference derivation.
+
+    Three distinct disagreements, kept apart because they have different causes
+    and different consequences:
+
+    * **unreachable** -- the reference derives a geography the build did not
+      store, or stored differently. A query for the reference value cannot find
+      this row. This is the false empty.
+    * **case_mismatch** -- equal but for case. The build never upper-cases and
+      the query side does (`normalise_prefix`), so a lower-case stored value is
+      unreachable in practice even though the text "matches".
+    * **unvalidated** -- the build stored a geography the grammar rejects. Not
+      itself unreachable, but it means the column holds values no caller can
+      ever ask for.
+    """
+    # Counters plus a capped sample, never full id lists. The artifact holds
+    # ~10.4M rows against ~1.6 GB free on the deployed Machine, so a check that
+    # accumulated one entry per disagreement would exhaust memory on exactly the
+    # broken artifact it exists to diagnose -- and take the app with it.
+    counts = {"unreachable": 0, "case_mismatch": 0, "unvalidated": 0}
+    samples: dict[str, list[str]] = {k: [] for k in counts}
+
+    def note(kind: str, txid: str) -> None:
+        counts[kind] += 1
+        if len(samples[kind]) < _SAMPLE_CAP:
+            samples[kind].append(txid)
+
+    for row in rows:
+        fields = dict(zip(_COLUMNS, row))
+        txid = str(fields.get("transaction_id") or "?")
+        stored_out = fields.get("outcode")
+        stored_sec = fields.get("sector")
+        ref_out, ref_sec = reference_geography(fields.get("postcode"))
+
+        if isinstance(stored_out, str) and stored_out != stored_out.upper():
+            note("case_mismatch", txid)
+        elif ref_out is not None and stored_out != ref_out:
+            note("unreachable", txid)
+        elif ref_out is None and stored_out is not None:
+            note("unvalidated", txid)
+        elif ref_sec is not None and stored_sec != ref_sec:
+            note("unreachable", txid)
+
+    findings = []
+    if counts["unreachable"]:
+        findings.append(Finding(
+            "geography_derivation",
+            "stored outcode/sector differs from the validated derivation; a "
+            "query for the derived value cannot reach these rows",
+            counts["unreachable"], samples["unreachable"]))
+    if counts["case_mismatch"]:
+        findings.append(Finding(
+            "geography_case",
+            "stored geography is not upper-case while the query path "
+            "upper-cases its input, so these rows are unreachable by equality",
+            counts["case_mismatch"], samples["case_mismatch"]))
+    if counts["unvalidated"]:
+        findings.append(Finding(
+            "geography_unvalidated",
+            "stored geography is not a well-formed outcode; no caller can ask "
+            "for this value",
+            counts["unvalidated"], samples["unvalidated"]))
+    return findings
+
+
+def python_select(
+    rows: Iterable[Sequence[Any]],
+    *,
+    outcode: Optional[str] = None,
+    sector: Optional[str] = None,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    property_types: Optional[Sequence[str]] = None,
+    transaction_category: Optional[str] = None,
+    limit: int = 50,
+) -> list[str]:
+    """The corpus predicate, reimplemented in plain Python.
+
+    Filters on geography **recomputed from `postcode`**, never on the stored
+    derived column -- otherwise a wrong derivation would hide itself by being
+    wrong identically in both arms.
+
+    Ordering mirrors the adapter's total order (`transfer_date DESC`, then
+    `transaction_id ASC`) so the two are comparable row for row.
+    """
+    selected: list[tuple[Any, str]] = []
+    wanted_types = {t.strip().upper() for t in property_types} if property_types else None
+    category = transaction_category.strip().upper() if transaction_category else None
+
+    for row in rows:
+        record = dict(zip(_COLUMNS, row))
+        ref_out, ref_sec = reference_geography(record.get("postcode"))
+        if outcode is not None and ref_out != outcode:
+            continue
+        if sector is not None and ref_sec != sector:
+            continue
+
+        transferred: Any = record.get("transfer_date")
+        if transferred is None:
+            continue
+        iso = (transferred.isoformat() if hasattr(transferred, "isoformat")
+               else str(transferred))
+        if from_date and iso < from_date:
+            continue
+        if to_date and iso > to_date:
+            continue
+
+        if wanted_types is not None:
+            value = record.get("property_type")
+            if not isinstance(value, str) or value.strip().upper() not in wanted_types:
+                continue
+        if category is not None:
+            value = record.get("ppd_category")
+            if not isinstance(value, str) or value.strip().upper() != category:
+                continue
+
+        txid = str(record.get("transaction_id") or "").strip("{} ")
+        selected.append((iso, txid))
+
+    # Two stable passes rather than one composite key: the adapter orders
+    # transfer_date DESC then transaction_id ASC, and mixing directions in one
+    # key means negating a string, which does not order ids of unequal length
+    # the way ASC does.
+    selected.sort(key=lambda pair: pair[1])                    # transaction_id ASC
+    selected.sort(key=lambda pair: pair[0], reverse=True)      # transfer_date DESC
+    return [txid for _, txid in selected[:limit]]
+
+
+def iter_rows(cursor: Any, chunk: int = _CHUNK_ROWS) -> Iterable[Sequence[Any]]:
+    """Stream a result set in bounded chunks.
+
+    `fetchall()` on this artifact would materialize ~10.4M rows as Python
+    tuples -- several GB against the ~1.6 GB free on a Machine that is serving
+    production traffic at the time. Peak memory here is `chunk` rows, whatever
+    the artifact's size.
+    """
+    while True:
+        batch = cursor.fetchmany(chunk)
+        if not batch:
+            return
+        yield from batch
+
+
+def check_partition_completeness(
+    snapshot_dir: Path, coverage_from: date, coverage_to: date
+) -> list[Finding]:
+    """One partition per year of declared coverage.
+
+    A missing year does not fail a query. It returns fewer rows, which is
+    exactly the shape of the defect this whole module exists to find.
+    """
+    present = {
+        int(child.name.split("=", 1)[1])
+        for child in snapshot_dir.iterdir()
+        if child.is_dir() and child.name.startswith("year=")
+        and child.name.split("=", 1)[1].isdigit()
+    }
+    expected = set(range(coverage_from.year, coverage_to.year + 1))
+    missing = sorted(expected - present)
+    if not missing:
+        return []
+    return [Finding(
+        "partition_completeness",
+        f"declared coverage {coverage_from}..{coverage_to} spans "
+        f"{len(expected)} years but partitions are missing; queries touching "
+        f"them return fewer rows rather than failing",
+        len(missing), [str(year) for year in missing])]
+
+
+def build_report(findings: Sequence[Finding], *, artifact: dict[str, Any],
+                 rows_examined: int, cases_compared: int) -> dict[str, Any]:
+    return {
+        "kind": "ppd_snapshot_nonlive_verification",
+        "not_stage_1_evidence": True,
+        "note": (
+            "A second arm that is not the live source. It shares the snapshot's "
+            "own data, so it cannot detect a row that never reached the "
+            "artifact; only an independent publication of the dataset can. It "
+            "establishes internal consistency and query-path reachability."
+        ),
+        "artifact": artifact,
+        "rows_examined": rows_examined,
+        "cases_compared": cases_compared,
+        "passed": not findings,
+        "findings": [f.to_dict() for f in findings],
+    }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot-dir", required=True, type=Path)
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--max-rows", type=int, default=0,
+                        help="0 examines every row")
+    args = parser.parse_args(argv)
+
+    from property_core.snapshot.duckdb_support import require_duckdb
+
+    verified = json.loads((args.snapshot_dir / ".verified.json").read_text())
+    duckdb = require_duckdb("the non-live snapshot verifier")
+    con = duckdb.connect()
+    files = sorted(str(p) for p in args.snapshot_dir.rglob("*.parquet"))
+    if not files:
+        print("no parquet files found", file=sys.stderr)
+        return 2
+
+    listed = ", ".join("'" + f.replace("'", "''") + "'" for f in files)
+    sql = (f"SELECT {', '.join(_COLUMNS)} FROM read_parquet([{listed}], "
+           f"union_by_name=true)")
+    if args.max_rows:
+        sql += f" LIMIT {int(args.max_rows)}"
+
+    # Streamed, not fetchall(): see iter_rows. Counted as it goes so the row
+    # total is observed rather than taken from the manifest.
+    cursor = con.execute(sql)
+    examined = 0
+
+    def counted() -> Iterable[Sequence[Any]]:
+        nonlocal examined
+        for row in iter_rows(cursor):
+            examined += 1
+            yield row
+
+    findings = list(check_geography_derivation(counted()))
+    findings += check_partition_completeness(
+        args.snapshot_dir,
+        date.fromisoformat(verified["coverage_from"]),
+        date.fromisoformat(verified["coverage_to"]),
+    )
+
+    report = build_report(
+        findings,
+        artifact={k: verified.get(k) for k in
+                  ("version", "bundle_sha256", "coverage_from", "coverage_to", "rows")},
+        rows_examined=examined,
+        cases_compared=0,
+    )
+    args.report.write_text(json.dumps(report, indent=2))
+    print(f"report written to {args.report}")
+    print(f"passed: {report['passed']}  rows_examined: {examined}")
+    for finding in findings:
+        print(f"  {finding.check}: {finding.count} — {finding.detail}")
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Why

Stage 1's live arm has failed twice — 429 on 2026-09-02, then a **503 after
271.8s** on 2026-09-04. Its central criterion is the false empty:

```python
"snapshot_false_empty": snap.count == 0 and live.count > 0
```

One arm cannot detect that, because a wrongly-empty answer is indistinguishable
from a correctly-empty one. The 2026-08-28 snapshot-only rehearsal passed 85
assertions across 13 cases and still couldn't close the gap — and no number of
further snapshot-only assertions would.

This adds a second arm **that is not the live source**: the artifact compared
against itself, read a different way. No network, no HMLR dependency.

## Why it can find anything

The schema stores `outcode`/`sector` as **materialized** columns. That removes
the `STRSTARTS("B5")`-matches-`B50` bug class entirely — but *relocates* the
risk: if the build wrote those columns wrongly, every geography query is
silently short, and querying the same column can never reveal it.

The two derivations are genuinely independent:

| | |
|---|---|
| **build** (`build.py` `_DERIVE`) | `split_part(trim(postcode), ' ', 1)` — validates nothing, never uppercases |
| **reference** (`postcode_rules`) | validated regex grammar, GIR-exact, uppercases, rejects malformed |

A postcode they disagree on is a row the adapter cannot reach by geography.
That's a false empty, discoverable offline.

## The checks

1. **Geography derivation** — recompute from `postcode`, compare to what the
   build stored. Three outcomes kept apart because their causes differ:
   `unreachable`, `case_mismatch` (build never uppercases, query side does),
   `unvalidated`.
2. **Query semantics** — every predicate, the ordering and the limit
   reimplemented in plain Python, filtering on geography **recomputed** rather
   than the stored column, so a wrong derivation can't hide by being wrong
   identically in both arms.
3. **Partition completeness** — a missing year returns fewer rows rather than
   failing.

## Result against the real artifact

```
rows_examined  10,394,935   (every row, not a sample)
passed         true
findings       []
elapsed        90s
```

Ran alongside production traffic without disturbing it: `MemAvailable`
**1,599,652 kB after** vs **1,596,868 kB before**, health 200 in 49–97ms
throughout, Fly check passing.

## Memory safety is load-bearing here

My first draft used `fetchall()` and accumulated one id per disagreement.
Against 10.4M rows with ~1.6 GB free on a Machine serving production traffic,
that would have OOM-killed the live app — and the id-accumulation would have
failed hardest exactly when the artifact was most broken. Both were fixed
**before** the tool was pointed at the real artifact. Rows now stream in 50k
chunks; findings carry counters plus a capped sample. Pinned by tests, including
a cursor stand-in whose `fetchall()` raises.

## Tests

31 tests. Every check is driven from a row **built to carry its specific
defect** and asserted to be found, then a clean row asserted to pass — a
verifier that only ever passes is worthless.

`./scripts/validate.sh` → **2042 passed, 27 skipped**.

## Scope limits, stated

- **Not Stage 1.** The report sets `not_stage_1_evidence: true`. It shares the
  snapshot's own data, so a row that never reached the artifact stays
  undetectable. Only an independent publication can close that — the live
  source, or the 5.5 GB bulk CSV whose download `ppd-snapshot-build.md` records
  as **not authorised**.
- **`cases_compared: 0`.** The CLI runs checks 1 and 3; the per-corpus-case
  comparison is implemented and unit-tested (`python_select`) but not yet wired
  to the adapter and frozen corpus. The report states 0 rather than implying
  coverage it lacks.
- No latency measured; nothing about agreement with HMLR today.

What it **does** establish: the artifact is internally consistent, and the query
path can reach every row it contains.

Out-of-band operator tooling on the same contract as `boot_only_verify.py` —
never imported by the app, never wired into `CMD`, inert unless invoked. Not
added to the image in this PR; it was run by copying the single file in.