### PR TITLE
feat(ppd): extend snapshot coverage to the full PPD history, 1995 onward

### DIFF
--- a/docs/design/ppd-source-routing.md
+++ b/docs/design/ppd-source-routing.md
@@ -155,42 +155,61 @@ process-isolated, and the attribution literal is pinned independently in test.
 
 ## 1. Snapshot scope
 
-### 1.1 Window — 11 year-partitions
+### 1.1 Window — 32 year-partitions (full PPD history)
 
-`PPDService.comps` computes `from_date = date.today() - timedelta(days=months * 30)`
-(`property_core/ppd_service.py:262`). At the public 120-month ceiling
-(`app/api/v1/ppd.py:171`) that is 3,600 days = **9.86 years measured from today**,
-not from a year boundary:
+**The snapshot retains every calendar year of Price Paid Data, 1995 to the
+current release year.** At a 2026 release that is 32 partitions opening on
+1995-01-01.
 
-| Request date | `from_date` | Partition required |
-|---|---|---|
-| 2026-01-01 | 2016-02-23 | **2016** |
-| 2026-07-01 | 2016-08-22 | **2016** |
-| 2026-12-31 | 2017-02-21 | 2017 |
+#### Why this supersedes the eleven-partition window
 
-Ten calendar-year partitions would silently under-serve a legal 120-month request
-for most of the year. **The snapshot retains the last 11 calendar-year partitions.**
+The previous window was sized to the largest *bounded* request. `PPDService.comps`
+computes `from_date = date.today() - timedelta(days=months * 30)`, so at the
+120-month REST ceiling (`app/api/v1/ppd.py`) that is 3,600 days = 9.86 years
+measured from today, not from a year boundary — ten calendar-year partitions
+would silently under-serve a legal 120-month request for most of the year, and
+eleven was the smallest count that could not. The reasoning was correct and the
+constant carried it: *"not a tunable: ten partitions cannot serve a 120-month
+request made in December, and twelve buys coverage nothing asks for."*
+
+It held only while **every** surface was bounded, and one is not. The
+subject-property history lookup asks for a single property's whole sale record
+with no date bound at all, which is why §2.6 routed it to the live source: an
+eleven-year snapshot would have truncated a history that routinely predates it,
+and a truncated history is indistinguishable from a complete one. That exception
+became the system's last hard dependency on live SPARQL, and when that source
+degraded to 503s in September 2026 the feature failed with the answer sitting in
+the snapshot.
+
+Full history removes the exception rather than working around it. "Twelve buys
+coverage nothing asks for" was true of the bounded surfaces and false of the
+unbounded one.
 
 | Partitions | Years | Size | Transfer @100 Mbit/s |
 |---|---|---|---|
-| 10 | 2017–2026 | 193 MiB — **estimated** (year+area basis) | 16.2 s — **calculated from that estimate** |
-| **11** | **2016–2026** | **266.2 MiB — measured (year-only)** | **22.3 s — calculated from the measurement** |
-| 12 | 2015–2026 | 244 MiB — **estimated** (year+area basis) | 20.4 s — **calculated from that estimate** |
+| 11 | 2016–2026 | 266.2 MiB — measured, **superseded** | 22.3 s — calculated from that measurement |
+| **32** | **1995–2026** | **1134.3 MiB — measured (year-only)** | **95.1 s — calculated from the measurement** |
 
-**The eleven-partition row is the only measured row.** 279,109,872 bytes
-(266.2 MiB), from two independent local builds on 2026-08-28 that produced a
-byte-identical bundle (`docs/ops/ppd-snapshot-build.md`).
-An earlier revision published 214 MiB here — a superseded year+area measurement
-applied to a year-only layout, when §1.2 mandates year-only and the same Phase 3
-run measured that layout at +22%. The 10- and 12-partition rows remain year+area
-**estimates**, retained only for shape; their transfer times are calculated from
-those estimates and are therefore doubly derived.
+**Both rows are measured.** The 32-partition row is 1,189,365,783 bytes
+(1134.3 MiB), 31,525,946 rows, from two local builds on 2026-09-04 that produced
+a byte-identical bundle (sha256 `d0897c94…e874e`), against the HMLR release
+published 2026-08-28. The 11-partition row is retained as the superseded
+measurement it is; an earlier revision published 214 MiB there, a year+area
+figure applied to a year-only layout.
 
-**22.3 s is arithmetic, not a measurement**: 279,109,872 × 8 / 1e8, assuming full
-link utilisation and zero protocol overhead. It leaves ~7.7 s inside the 30 s
-readiness target — down from the ~12 s the superseded figure implied. No real
-transfer has been timed on either Machine; only G1a/G1b can produce one. Phase 3
-measured extract+probe at 2.0 s on a 3.55x larger bundle (945.5 MiB).
+**95.1 s is arithmetic, not a measurement**: 1,189,365,783 × 8 / 1e8, assuming
+full link utilisation and zero protocol overhead. Measured transfer of the
+smaller bundle ran at 63.6 Mbit/s rather than the nominal 100, so the real figure
+will be higher.
+
+**This no longer fits inside the 30 s readiness target, and does not need to.**
+Since rev 9 the snapshot boot is non-blocking: the lifespan starts the download
+on a daemon thread and returns immediately, the application is ready serving live
+data from the first request, and the snapshot becomes routable when it is ready.
+What the transfer time now bounds is *how long after readiness the snapshot
+starts answering*, not readiness itself. The 30 s target continues to govern
+application readiness, which Phase E measured at 9.89 s and this change does not
+touch.
 
 The published guarantee is **`from_date >= coverage_from`**, never "10 years".
 
@@ -692,8 +711,10 @@ one undifferentiated label.
 * Bundle **streamed** to a temp file in 1 MiB chunks, SHA-256 incremental. **The
   body is never held in memory** — verified at scale: a 945.5 MiB bundle booted at
   199.5 MB peak RSS.
-* Limits: `MAX_BUNDLE_BYTES` **1 GiB** (~3.8x margin over the measured
-  266.2 MiB bundle); socket
+* Limits: `MAX_BUNDLE_BYTES` **2 GiB** (~1.8x margin over the measured
+  1134.3 MiB bundle; raised from 1 GiB when coverage went to full history, which
+  the old ceiling refused at boot — correctly, and before a byte transferred);
+  socket
   timeout **10 s**; total download deadline **300 s**; stall detection
   **60 s**. Any breach aborts and deletes the temp file. Both time budgets are
   checked after **every** read, the one returning EOF included — checking only
@@ -728,7 +749,10 @@ this rejects a well-formed decoy archive with different contents.
 Member-validating streaming extraction. Rejected: absolute paths, any `..`
 component, symlinks, hardlinks, device/FIFO nodes, duplicate names, member count
 over `MAX_MEMBERS` (**5,000**), per-member bytes over `MAX_MEMBER_BYTES`,
-cumulative decompressed bytes over `MAX_TOTAL_BYTES` (**2 GiB**). Every resolved
+cumulative decompressed bytes over `MAX_TOTAL_BYTES` (**4 GiB** — deliberately
+above what `MAX_BUNDLE_BYTES` can deliver, since a compressed bundle at the fetch
+ceiling unpacks to more than it; equal values would admit an archive that
+extraction then refused, discovered after the whole transfer). Every resolved
 path must stay inside staging. 10/10 attack classes rejected in Phase 3,
 including a hostile archive whose **SHA-256 matched its manifest** — digest checks
 cannot catch that.
@@ -1238,10 +1262,10 @@ The two facts Phase 3 could not evidence are now **blocking gates**, not caveats
   measured bundle. The 30 s readiness target is unchanged.
 
   **Calculated inputs, to be confirmed or refuted by the measurement — never
-  reported as its result:** ~534.1 MiB simultaneous bundle-plus-extracted payload
-  (266.2 + 267.9, arithmetic only; excludes staging directories, per-attempt
-  temporary files and filesystem overhead); ~665.4 MiB preflight threshold
-  (`bundle_bytes * 2.5`); ~22.3 s transfer at a nominal 100 Mbit/s. **None of
+  reported as its result:** ~2273.6 MiB simultaneous bundle-plus-extracted payload
+  (1134.3 + 1139.3, arithmetic only; excludes staging directories, per-attempt
+  temporary files and filesystem overhead); ~2835.7 MiB preflight threshold
+  (`bundle_bytes * 2.5`); ~95.1 s transfer at a nominal 100 Mbit/s. **None of
   these is a measured peak.**
 
 * **G1b — the same measurement on `propertydata`, the 512 MB-RAM Stage 3

--- a/docs/ops/ppd-snapshot-build.md
+++ b/docs/ops/ppd-snapshot-build.md
@@ -279,8 +279,46 @@ Halt and report; there is no override flag for any of these.
 
 ## Measured results
 
-Recorded from two full local builds on 2026-08-28 (workstation, no network,
-no deployed system touched). Source: the HM Land Registry release fetched on
+Recorded from two full local builds on 2026-09-04 (workstation, no deployed
+system touched). Source: the HM Land Registry release published 2026-08-28 and
+fetched the same day, digested while streaming.
+
+| | |
+|---|---|
+| Source file | `pp-complete.csv`, 5,510,772,256 bytes, sha256 `cb3e4ffc…e9d8f5` |
+| Source release | ETag `"10f2334fe5b8179139ed2bf7cca0e108-657"`, Last-Modified Fri, 28 Aug 2026 |
+| Digest evidence | `streamed-download` — digested from the same response that wrote the file |
+| Declared coverage | `1995-01-01` … `2026-07-31`, `provisional_from` `2026-04-01` |
+| Rows written | **31,525,946** |
+| Eligible source rows (counted from the source) | 31,525,946 — equal, so nothing was lost between reading and writing |
+| Rows outside the declared window | 0 — the window is the whole register |
+| Rows with no parseable date | 0 |
+| Distinct `transaction_id` | 31,525,946 — equal, so the key holds |
+| Earliest / latest `transfer_date` | 1995-01-01 / 2026-07-31 |
+| Partitions | 32 (`year=1995` … `year=2026`) |
+| Parquet on disk | 1,194,660,216 B (**1139.3 MiB**) |
+| Bundle `.tar.zst` | 1,189,365,783 B (**1134.3 MiB**), sha256 `d0897c94…1e874e` |
+| Extracted by the runtime | 1,194,660,216 B (1139.3 MiB) |
+| Build | ingest 32.7 s · derive 38.3 s · write 22.2 s |
+| Whole pipeline | **156 s** wall clock: build → validate → package → verify → boot |
+| Peak RSS | 4,306.9 MB with `--memory 4GB` (DuckDB spills beneath the limit) |
+| Gates | all ten passed |
+| Boot through `SnapshotRuntime` + `SnapshotAdapter` | **READY**, validated through the adapter |
+
+Both builds produced a byte-identical bundle under different version names,
+which is the determinism claim: same sha256 `d0897c94…1e874e` from
+`v20260904T164011Z` and `v20260904T164625Z`.
+
+The first of those two runs was **refused at the boot check** —
+`BundleVerificationError: manifest declares 1189365783 bytes, above the
+1073741824-byte maximum` — and was not promoted. That is the fail-closed design
+working: it built, validated and packaged, then declined to publish an artifact
+every Machine would have rejected at boot. `MAX_BUNDLE_BYTES` was raised to
+2 GiB and the build re-run.
+
+### Superseded — the eleven-partition build, 2026-08-28
+
+Retained as the record of the previous window. Source: the release fetched on
 2026-08-27.
 
 | | |
@@ -297,7 +335,7 @@ no deployed system touched). Source: the HM Land Registry release fetched on
 | Rows with no parseable date | 0 |
 | Partitions | 11 (`year=2016` … `year=2026`) |
 | Parquet on disk | 280,924,336 B (**267.9 MiB**) |
-| Bundle `.tar.zst` | 279,109,872 B (**266.2 MiB**), sha256 `50f802b2…9072c` |
+| Bundle `.tar.zst` | 279,109,872 B (**266.2 MiB**) — superseded, sha256 `50f802b2…9072c` |
 | Extracted by the runtime | 280,925,271 B (267.9 MiB) |
 | Build | ingest 44.6 s · derive 13.5 s · write 8.7 s |
 | Whole pipeline | **82 s** wall clock: build → validate → package → verify → boot |
@@ -336,17 +374,17 @@ of the writer.
 
 ### What this means for G1a and G1b
 
-| | Superseded §1.1 / §4.7 baseline | Now | Class |
+| | Superseded 11-partition baseline | Now (32 partitions) | Class |
 |---|---|---|---|
-| Bundle size | 214 MiB (year+area) | **266.2 MiB** (+24.4%) | **measured** — 279,109,872 B |
-| Extracted | ~230 MiB implied | **267.9 MiB** | **measured** — 280,925,271 B |
-| Transfer @100 Mbit/s | 18.0 s | ~22.3 s | *calculated* — bytes × 8 / 1e8 |
-| Simultaneous bundle + extracted payload | ~444 MiB implied | ~534.1 MiB | *calculated* — 266.2 + 267.9, arithmetic only |
-| §4.7 free-space precondition (`bundle_bytes * 2.5`) | ~535 MiB | ~665.4 MiB | *calculated* — policy constant × measured bytes |
+| Bundle size | 266.2 MiB | **1134.3 MiB** | **measured** — 1,189,365,783 B |
+| Extracted | 267.9 MiB | **1139.3 MiB** | **measured** — 1,194,660,216 B |
+| Transfer @100 Mbit/s | ~22.3 s | ~95.1 s | *calculated* — bytes × 8 / 1e8 |
+| Simultaneous bundle + extracted payload | ~534.1 MiB | ~2273.6 MiB | *calculated* — 1134.3 + 1139.3, arithmetic only |
+| §4.7 free-space precondition (`bundle_bytes * 2.5`) | ~665.4 MiB | ~2835.7 MiB | *calculated* — policy constant × measured bytes |
 
 **Only the first two rows are measurements.** The remaining three are arithmetic
 over them, and are stated as inputs rather than results. In particular
-~534.1 MiB is **not** a measured peak disk figure: it is a sum that ignores
+~2273.6 MiB is **not** a measured peak disk figure: it is a sum that ignores
 staging directories, per-attempt temporary files and filesystem overhead, and no
 overlap has been observed on any machine.
 
@@ -364,8 +402,12 @@ measured at **+22%**. The real year-only bundle is materially larger (see the
 table above), which moved two numbers the rollout depends on:
 
 * the §1.1 transfer figure (18.0 s @100 Mbit/s) understated transfer time and so
-  overstated the headroom inside the 30 s readiness target — now ~22.3 s,
-  calculated, leaving ~7.7 s; and
+  overstated the headroom inside the 30 s readiness target. That correction gave
+  ~22.3 s at eleven partitions. **Both figures are now superseded**: full history
+  transfers ~95.1 s calculated, which does not fit the 30 s target at all — and
+  no longer needs to, because rev 9 made the snapshot boot non-blocking. The
+  transfer now bounds how long after readiness the snapshot starts answering,
+  not readiness itself (§1.1); and
 * the transient-disk budget, now split into **G1a** (`property-shared`, 2 GB) and
   **G1b** (`propertydata`, 512 MB), each measured against the real bundle with
   §4.7's `bundle_bytes * 2.5` free-space rule applied to it.

--- a/property_core/snapshot/archive.py
+++ b/property_core/snapshot/archive.py
@@ -30,15 +30,21 @@ from property_core.snapshot.errors import ArchiveRejected, SnapshotExtraMissingE
 class ExtractionLimits:
     """Caps applied while the archive streams past.
 
-    Defaults are sized for a rolling snapshot (an 11-partition snapshot holds
-    ~11 parquet files and unpacks to a few hundred MB) with headroom, not for
-    arbitrary archives. They match the caps published in the governing
-    specification, section 4.3.
+    Defaults are sized for the full-history snapshot (32 year partitions, one
+    parquet file each, unpacking to ~1.2 GB) with headroom, not for arbitrary
+    archives.
+
+    `max_total_bytes` is deliberately kept above what
+    `fetch.DEFAULT_MAX_BUNDLE_BYTES` can deliver. A bundle is compressed, so a
+    2 GiB bundle unpacks to more than 2 GiB of parquet; leaving these equal
+    would mean the fetch ceiling admitted an archive that extraction then
+    refused, which is a failure discovered after the whole transfer rather than
+    before it.
     """
 
     max_members: int = 5_000
-    max_total_bytes: int = 2 * 1024 ** 3
-    max_member_bytes: int = 2 * 1024 ** 3
+    max_total_bytes: int = 4 * 1024 ** 3
+    max_member_bytes: int = 4 * 1024 ** 3
 
 
 @dataclass(frozen=True)

--- a/property_core/snapshot/fetch.py
+++ b/property_core/snapshot/fetch.py
@@ -26,9 +26,20 @@ from property_core.snapshot.models import SnapshotManifest
 
 DEFAULT_CHUNK_SIZE = 1024 * 1024
 #: Hard ceiling regardless of what a manifest claims. A manifest is data from
-#: outside this process; it does not get to size our disk usage. The measured
-#: 11-partition snapshot is 266.2 MiB, so this leaves roughly 3.8x margin.
-DEFAULT_MAX_BUNDLE_BYTES = 1 * 1024 ** 3
+#: outside this process; it does not get to size our disk usage.
+#:
+#: Raised from 1 GiB when coverage went to the full PPD history. The measured
+#: 32-partition snapshot is 1,189,365,783 B (1.108 GiB), which the old ceiling
+#: refused at boot -- correctly, and before a byte transferred. 2 GiB leaves
+#: ~1.8x margin, and the register grows by roughly a million rows a year, so
+#: this should not need revisiting for a decade.
+#:
+#: Checked against the whole stack rather than in isolation:
+#:   preflight    bundle * 2.5 = 5.37 GiB at the cap, vs 8.32 GB free on the
+#:                Machine (2.97 GiB at the actual 1.108 GiB bundle)
+#:   extraction   ExtractionLimits.max_total_bytes raised to 4 GiB in step, or
+#:                a bundle near this cap would unpack into a smaller one
+DEFAULT_MAX_BUNDLE_BYTES = 2 * 1024 ** 3
 
 #: Whole-transfer budget, evaluated BETWEEN reads. A download that never
 #: finishes is a boot that never finishes, and readiness would hang instead of

--- a/tests/snapshot/test_limits_and_deadlines.py
+++ b/tests/snapshot/test_limits_and_deadlines.py
@@ -89,12 +89,12 @@ def _spec_text() -> str:
 @pytest.mark.parametrize(
     "published, value, code_value",
     [
-        ("`MAX_BUNDLE_BYTES` **1 GiB**", 1 * 1024 ** 3, DEFAULT_MAX_BUNDLE_BYTES),
+        ("`MAX_BUNDLE_BYTES` **2 GiB**", 2 * 1024 ** 3, DEFAULT_MAX_BUNDLE_BYTES),
         ("total download deadline **300 s**", 300.0, DEFAULT_TOTAL_DEADLINE_SECONDS),
         ("stall detection **60 s**", 60.0, DEFAULT_STALL_SECONDS),
         ("socket\n  timeout **10 s**".replace("\n  ", " "), 10.0, DEFAULT_TIMEOUT),
         ("`MAX_MEMBERS` (**5,000**", 5_000, ExtractionLimits().max_members),
-        ("`MAX_TOTAL_BYTES` (**2 GiB**", 2 * 1024 ** 3,
+        ("`MAX_TOTAL_BYTES` (**4 GiB**", 4 * 1024 ** 3,
          ExtractionLimits().max_total_bytes),
         ("`bundle_bytes * 2.5`", 2.5, DISK_HEADROOM_MULTIPLIER),
     ],

--- a/tests/snapshot/test_rollout_premises.py
+++ b/tests/snapshot/test_rollout_premises.py
@@ -62,10 +62,12 @@ DECISION = REPO / "docs" / "design" / "ppd-artifact-distribution-decision.md"
 
 MiB = 1024 ** 2
 
-#: The measurement, from two independent local builds on 2026-08-28 that
-#: produced a byte-identical bundle (docs/ops/ppd-snapshot-build.md).
-BUNDLE_BYTES = 279_109_872
-EXTRACTED_BYTES = 280_925_271
+#: The measurement, from two independent local builds on 2026-09-04 that
+#: produced a byte-identical bundle (docs/ops/ppd-snapshot-build.md). Supersedes
+#: the 11-partition figures (279,109,872 / 280,925,271), which the runbook keeps
+#: as its own superseded record.
+BUNDLE_BYTES = 1_189_365_783
+EXTRACTED_BYTES = 1_194_660_216
 
 #: Nominal link rate for the transfer calculation. Not a measured rate: no real
 #: transfer has been timed on either Fly Machine. That is G1a/G1b.
@@ -124,7 +126,7 @@ def test_the_recorded_byte_counts_are_the_ones_everything_derives_from():
 #: vanish from the gate that depends on it and still pass because the other
 #: document happened to mention it. Each figure is required in the section that
 #: actually relies on it, and a failure names that section.
-SPEC_WINDOW = "### 1.1 Window — 11 year-partitions"
+SPEC_WINDOW = "### 1.1 Window — 32 year-partitions (full PPD history)"
 SPEC_ROLLOUT = "## 7. TDD and rollout"
 RUNBOOK_G1 = "### What this means for G1a and G1b"
 
@@ -182,14 +184,23 @@ def test_the_preflight_figure_is_tied_to_the_shipped_headroom_multiplier(path):
 
 
 def test_the_bundle_limit_margin_is_stated_against_the_measured_bundle():
-    """§4.1's margin was ~4.8x against 214 MiB; against the real bundle it is less."""
+    """The margin has to be stated against the bundle that actually ships.
+
+    It was ~4.8x against an estimated 214 MiB, then ~3.8x against the measured
+    266.2 MiB 11-partition bundle. Full history and a 2 GiB ceiling make it
+    ~1.8x, and each superseded figure is asserted gone rather than merely
+    replaced -- a stale margin left in the text reads as authoritative.
+    """
     margin = _rounded(DEFAULT_MAX_BUNDLE_BYTES / BUNDLE_BYTES)
     section = " ".join(_section(SPEC, "## 4. Runtime design").split())
     assert f"{margin}x" in section, (
         f"§4.1 no longer states the {margin}x margin the 1 GiB ceiling actually "
         f"has over the measured bundle"
     )
-    assert "4.8x" not in section, "the superseded margin is still published"
+    for superseded in ("4.8x", "3.8x"):
+        assert superseded not in section, (
+            f"the superseded margin {superseded} is still published"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -201,40 +212,113 @@ def _occurrences(path: Path) -> list[tuple[int, str]]:
             if "214 MiB" in line]
 
 
-def test_the_specification_states_214_MiB_only_as_a_superseded_figure():
-    """Exactly one occurrence, and it is the sentence that supersedes it."""
-    found = _occurrences(SPEC)
-    assert len(found) == 1, (
-        f"expected one historical reference to 214 MiB in the specification, "
-        f"found {len(found)}: {[n for n, _ in found]}"
-    )
-    line = found[0][1]
-    assert line.strip().startswith("An earlier revision published 214 MiB here"), (
-        f"the surviving 214 MiB reference is not the supersession sentence: {line!r}"
-    )
+#: Every figure this project has published for the bundle and then replaced.
+#: Each must survive ONLY as a marked supersession. There are two now -- 214 MiB
+#: (an estimate applied to the wrong layout) and 266.2 MiB (a real measurement
+#: of the 11-partition window) -- and a third will join them at the next rebuild,
+#: so this is a list rather than a special case.
+SUPERSEDED_BUNDLE_FIGURES = ["214 MiB", "266.2 MiB"]
 
 
-def test_the_runbook_states_214_MiB_only_in_the_superseded_baseline_column():
-    """Two anchors: the comparison table's baseline cell, and the prose beneath it."""
-    found = _occurrences(RUNBOOK)
-    assert len(found) == 2, (
-        f"expected two historical references to 214 MiB in the runbook, found "
-        f"{len(found)}: {[n for n, _ in found]}"
-    )
+@pytest.mark.parametrize("figure", SUPERSEDED_BUNDLE_FIGURES)
+def test_the_specification_marks_every_superseded_bundle_figure_as_superseded(figure):
+    """A replaced figure left unqualified reads as a live claim.
 
-    rows = {line.split("|")[1].strip(): line
-            for _, line in found if line.lstrip().startswith("|")}
-    assert "Bundle size" in rows, (
-        "214 MiB no longer appears in the comparison table's Bundle size row"
-    )
-    cells = [c.strip() for c in rows["Bundle size"].split("|")]
-    assert "214 MiB" in cells[2], "214 MiB has moved out of the baseline column"
-    assert "266.2 MiB" in cells[3], "the Bundle size row no longer carries the measurement"
+    Not an exact-sentence match: the wording has changed twice and pinning it
+    made the guard about phrasing rather than about honesty. What is pinned is
+    that each occurrence sits in text that says it has been superseded.
+    """
+    found = [(n, line) for n, line in
+             enumerate(SPEC.read_text().splitlines(), 1) if figure in line]
+    assert found, f"{figure} has vanished from the specification entirely"
 
-    prose = [line for _, line in found if not line.lstrip().startswith("|")]
-    assert len(prose) == 1 and "superseded" in prose[0].lower(), (
-        f"the prose reference does not mark 214 MiB as superseded: {prose!r}"
+    text = " ".join(SPEC.read_text().split())
+    for _n, line in found:
+        i = text.index(figure.split()[0])
+        window = text[max(0, i - 400): i + 400].lower()
+        assert "supersede" in window or "earlier revision" in window, (
+            f"{figure} appears at line {_n} without nearby text marking it "
+            f"superseded: {line!r}"
+        )
+
+
+@pytest.mark.parametrize("figure", SUPERSEDED_BUNDLE_FIGURES)
+def test_the_runbook_marks_every_superseded_bundle_figure_as_superseded(figure):
+    lines = RUNBOOK.read_text().splitlines()
+    found = [(n, line) for n, line in enumerate(lines, 1) if figure in line]
+    assert found, f"{figure} has vanished from the runbook entirely"
+    text = " ".join(RUNBOOK.read_text().split()).lower()
+    needle = figure.lower()
+    at = -1
+    while (at := text.find(needle, at + 1)) != -1:
+        window = text[max(0, at - 600): at + 600]
+        assert "supersede" in window, (
+            f"{figure} appears in the runbook at offset {at} without nearby "
+            f"text marking it superseded (lines {[n for n, _ in found]})"
+        )
+
+
+def test_no_stale_bundle_size_survives_in_production_code():
+    """The same failure class as the docs: a superseded premise outside the prose."""
+    stale = [(p, f) for p in (REPO / "property_core").rglob("*.py")
+             for f in SUPERSEDED_BUNDLE_FIGURES if f in p.read_text()]
+    assert not stale, f"superseded sizing figure still in production code: {stale}"
+
+
+# ---------------------------------------------------------------------------
+# Group B -- the corrected premises
+# ---------------------------------------------------------------------------
+
+def _window_rows() -> list[str]:
+    """The data rows of §1.1's sizing table, header and separator excluded."""
+    window = _section(SPEC, SPEC_WINDOW)
+    rows = [line for line in window.splitlines() if line.strip().startswith("|")]
+    return [r for r in rows[2:] if r.strip("| ").strip()]
+
+
+def test_the_current_row_publishes_the_measurement():
+    """The guard that matters: the row in force states a measured figure."""
+    row = next((r for r in _window_rows() if "1995–2026" in r), None)
+    assert row is not None, "the 32-partition row is gone from the window section"
+    assert "1134.3 MiB" in row and "measured" in row.lower(), (
+        f"the current row does not publish the measurement: {row!r}"
     )
+    for superseded in SUPERSEDED_BUNDLE_FIGURES:
+        assert superseded not in row, (
+            f"the current row still claims the superseded size {superseded}"
+        )
+
+
+def test_every_sizing_row_declares_measured_or_estimated():
+    """A size with no class beside it is the defect this table keeps re-learning.
+
+    It has twice published a number whose provenance was not stated next to it:
+    an estimate read as a measurement, then a measurement of a window no longer
+    in force. Each row must say which it is, and its transfer time must say what
+    it was derived from.
+    """
+    rows = _window_rows()
+    assert len(rows) >= 2, f"the sizing table has collapsed to {len(rows)} row(s)"
+    for row in rows:
+        low = row.lower()
+        assert "measured" in low or "estimated" in low, (
+            f"sizing row states a size without saying whether it is measured or "
+            f"estimated: {row!r}"
+        )
+        assert "calculated" in low, (
+            f"sizing row states a transfer time without saying it is calculated "
+            f"rather than timed: {row!r}"
+        )
+
+
+def test_superseded_sizing_rows_say_so_in_the_row_itself():
+    """A reader scanning the table must not have to find the prose beneath it."""
+    for row in _window_rows():
+        if "1995–2026" in row:
+            continue
+        assert "superseded" in row.lower(), (
+            f"a non-current sizing row is not marked superseded in the row: {row!r}"
+        )
 
 
 def test_the_comparison_table_labels_its_baseline_column_as_superseded():
@@ -259,32 +343,6 @@ def test_no_stale_eleven_partition_size_survives_in_production_code():
 # ---------------------------------------------------------------------------
 # Group B -- the corrected premises
 # ---------------------------------------------------------------------------
-
-def test_the_eleven_partition_row_publishes_the_measurement():
-    """The guard that matters: the current claim is the measured one."""
-    window = _section(SPEC, "### 1.1 Window — 11 year-partitions")
-    row = next((line for line in window.splitlines()
-                if line.strip().startswith("|") and "2016–2026" in line), None)
-    assert row is not None, "the eleven-partition row is gone from §1.1"
-    assert "266.2 MiB" in row and "measured" in row.lower(), (
-        f"the eleven-partition row does not publish the measurement: {row!r}"
-    )
-    assert "214" not in row, "the eleven-partition row still claims the superseded size"
-
-
-def test_the_estimated_rows_label_both_their_size_and_their_transfer():
-    """10 and 12 partitions are year+area estimates; their times are doubly derived."""
-    window = _section(SPEC, "### 1.1 Window — 11 year-partitions")
-    for years in ("2017–2026", "2015–2026"):
-        row = next(line for line in window.splitlines()
-                   if line.strip().startswith("|") and years in line)
-        assert "estimated" in row.lower(), f"{years} row does not label its size: {row!r}"
-        assert "calculated from that estimate" in row.lower(), (
-            f"{years} row does not label its transfer time as derived from an "
-            f"estimate rather than from a measurement: {row!r}"
-        )
-
-
 @pytest.mark.parametrize("phrase", [
     "G1a",
     "G1b",
@@ -324,7 +382,7 @@ def test_the_calculated_g1_inputs_are_not_presented_as_measurements():
     marker = "Calculated inputs"
     assert marker in rollout, "§7.2 does not separate G1's calculated inputs from its result"
     block = rollout[rollout.index(marker):rollout.index(marker) + 700]
-    for figure in ("534.1", "665.4", "22.3"):
+    for figure in ("2273.6", "2835.7", "95.1"):
         assert figure in block, f"{figure} is not inside the calculated-inputs block"
 
 

--- a/tests/snapshot/test_snapshot_build.py
+++ b/tests/snapshot/test_snapshot_build.py
@@ -28,14 +28,20 @@ from tests.snapshot.build_fixtures import csv_row, write_source_csv  # noqa: E40
 
 # -- window arithmetic -------------------------------------------------------
 
-def test_coverage_starts_at_january_of_the_eleventh_calendar_year_back():
-    # Eleven partitions ending 2026 means the window opens on 2016-01-01, which
-    # is what makes a 120-month request from any date in 2026 serviceable.
-    assert coverage_start(date(2026, 6, 30)) == date(2016, 1, 1)
+def test_coverage_starts_at_the_first_year_of_ppd():
+    # 32 partitions ending 2026 opens the window on 1995-01-01, the first year
+    # of Price Paid Data. Full history is what lets the subject-property lookup
+    # -- the one unbounded query -- route to the snapshot at all.
+    #
+    # This pins the arithmetic that PARTITION_YEARS has to track: when the
+    # release year rolls to 2027, 32 would start the window at 1996 and quietly
+    # drop a year, so the constant must be incremented and this test is what
+    # says so.
+    assert coverage_start(date(2026, 6, 30)) == date(1995, 1, 1)
 
 
-def test_expected_years_are_eleven_consecutive_calendar_years():
-    assert expected_years(date(2026, 6, 30)) == tuple(range(2016, 2027))
+def test_expected_years_span_ppd_history():
+    assert expected_years(date(2026, 6, 30)) == tuple(range(1995, 2027))
     assert len(expected_years(date(2026, 6, 30))) == PARTITION_YEARS
 
 
@@ -58,7 +64,7 @@ def built(tmp_path: Path):
         csv_row("{CCC}", "B50 4AA", "2024-03-01 00:00", 400_000),
         csv_row("{DDD}", "M3 7AA", "2026-06-30 00:00", 250_000),
         # Outside the window on both sides -- must not reach the snapshot.
-        csv_row("{OLD}", "B5 7AC", "2015-12-31 00:00", 100_000),
+        csv_row("{OLD}", "B5 7AC", "1994-12-31 00:00", 100_000),
         csv_row("{NEW}", "B5 7AD", "2026-07-01 00:00", 500_000),
     ])
     result = build_snapshot(BuildRequest(
@@ -73,7 +79,7 @@ def built(tmp_path: Path):
 def test_build_writes_one_parquet_file_per_expected_year(built):
     written = sorted(p.relative_to(built.snapshot_dir).as_posix()
                      for p in built.snapshot_dir.rglob("*.parquet"))
-    assert written == [f"year={y}/data.parquet" for y in range(2016, 2027)]
+    assert written == [f"year={y}/data.parquet" for y in range(1995, 2027)]
     assert built.parquet_files == PARTITION_YEARS
 
 
@@ -107,7 +113,7 @@ def test_build_derives_exact_outcode_and_sector_columns(built):
 
 
 def test_build_reports_the_window_it_was_given(built):
-    assert built.coverage_from == date(2016, 1, 1)
+    assert built.coverage_from == date(1995, 1, 1)
     assert built.coverage_to == date(2026, 6, 30)
     assert built.provisional_from == date(2026, 3, 1)
 
@@ -159,7 +165,7 @@ def test_a_blank_transaction_id_inside_the_window_fails_the_build(tmp_path):
 
 def test_a_malformed_price_outside_the_window_does_not_fail_the_build(tmp_path):
     # Rows the snapshot never serves are not its problem.
-    bad = list(csv_row("{OLD}", "B5 7AB", "2011-04-01 00:00", 0))
+    bad = list(csv_row("{OLD}", "B5 7AB", "1994-04-01 00:00", 0))
     bad[1] = "not-a-price"
     built = build_from(tmp_path, [
         csv_row("{OK}", "B5 7AA", "2024-03-01 00:00", 200_000), tuple(bad)])
@@ -171,7 +177,7 @@ def test_the_build_counts_eligible_source_rows_independently_of_what_it_wrote(
     built = build_from(tmp_path, [
         csv_row("{A}", "B5 7AA", "2024-03-01 00:00", 200_000),
         csv_row("{B}", "B5 7AB", "2016-03-01 00:00", 210_000),
-        csv_row("{OLD}", "B5 7AC", "2011-03-01 00:00", 100_000),
+        csv_row("{OLD}", "B5 7AC", "1994-03-01 00:00", 100_000),
     ])
     assert built.eligible_source_rows == 2
     assert built.rows == 2

--- a/tests/snapshot/test_snapshot_cli.py
+++ b/tests/snapshot/test_snapshot_cli.py
@@ -106,7 +106,7 @@ def test_the_build_report_records_what_was_measured(tmp_path):
     report = json.loads(
         (tmp_path / "dist" / "build-report-v20260828T101500Z.json").read_text())
     assert report["rows"] == 2
-    assert report["parquet_files"] == 11
+    assert report["parquet_files"] == 32
     assert report["gates"] == "passed"
     assert report["rows_per_year"]["2024"] == 1
     assert report["boot_check"]["readiness"] == "ready"

--- a/tests/snapshot/test_snapshot_end_to_end.py
+++ b/tests/snapshot/test_snapshot_end_to_end.py
@@ -85,13 +85,13 @@ def test_the_materialized_snapshot_holds_exactly_the_published_partitions(
     directory = Path(report.snapshot_dir)
     written = sorted(p.relative_to(directory).as_posix()
                      for p in directory.rglob("*.parquet"))
-    assert written == [f"year={y}/data.parquet" for y in range(2016, 2027)]
+    assert written == [f"year={y}/data.parquet" for y in range(1995, 2027)]
 
 
 def test_the_verification_record_carries_the_declared_coverage(published, tmp_path):
     runtime, report = boot(published, tmp_path)
     record = runtime.store.verified_record(report.version)
-    assert record.coverage_from == "2016-01-01"
+    assert record.coverage_from == "1995-01-01"
     assert record.coverage_to == "2026-06-30"
     assert record.provisional_from == "2026-03-01"
     assert record.layout == "year"
@@ -102,7 +102,7 @@ def test_the_booted_snapshot_opens_through_the_real_adapter(published, tmp_path)
     runtime, report = boot(published, tmp_path)
     record = runtime.store.verified_record(report.version)
     with SnapshotAdapter.open(Path(report.snapshot_dir), record) as adapter:
-        assert adapter.coverage_from == "2016-01-01"
+        assert adapter.coverage_from == "1995-01-01"
         assert adapter.version == published.version
 
 

--- a/tests/snapshot/test_snapshot_gates.py
+++ b/tests/snapshot/test_snapshot_gates.py
@@ -226,7 +226,7 @@ def test_coverage_gate_rejects_a_row_filed_under_the_wrong_year(snapshot):
 
 def test_coverage_gate_rejects_a_start_that_is_not_the_partition_boundary(snapshot):
     _, declared = snapshot
-    report = run(declared.replace(coverage_from=date(2016, 2, 1)))
+    report = run(declared.replace(coverage_from=date(1995, 2, 1)))
     assert failed(report) == {"coverage"}
 
 
@@ -265,13 +265,19 @@ def test_guarantee_gate_rejects_a_window_that_does_not_reach_back_120_months(sna
     # The shape a shortened partition count produces: the window opens later
     # than `today - 120 months`, so the largest legal request falls outside it.
     # Nothing else in the report reads `today`, so only this gate can fire.
-    report = run(declared, today=date(2025, 1, 1))
+    #
+    # With full history (window opens 1995-01-01) this needs a `today` early
+    # enough that even 32 years cannot reach back 120 months -- 1995-01-01 plus
+    # 3600 days is 2004-11-13, so 2004-01-01 is inside the failing side and
+    # 2005-01-01 the passing side. The pair brackets the real boundary rather
+    # than testing a date that now passes trivially.
+    report = run(declared, today=date(2004, 1, 1))
     assert failed(report) == {"guarantee"}
 
 
 def test_guarantee_gate_passes_once_the_window_reaches_back_far_enough(snapshot):
     _, declared = snapshot
-    assert run(declared, today=date(2025, 11, 15)).failures == ()
+    assert run(declared, today=date(2005, 1, 1)).failures == ()
 
 
 # -- provisional ------------------------------------------------------------
@@ -362,7 +368,7 @@ def test_validation_records_the_content_digest_as_a_fact(snapshot):
     _, declared = snapshot
     report = run(declared)
     assert set(report.facts["content_digest_per_year"]) == {
-        str(y) for y in range(2016, 2027)}
+        str(y) for y in range(1995, 2027)}
 
 
 def test_the_build_records_its_peak_memory(snapshot):

--- a/tests/snapshot/test_snapshot_package.py
+++ b/tests/snapshot/test_snapshot_package.py
@@ -79,7 +79,7 @@ def test_version_is_a_path_component_the_store_will_accept():
 def test_bundle_holds_exactly_the_partition_files(released):
     _, release = released
     names = sorted(m.name for m in members(release.bundle_path))
-    assert names == [f"year={y}/data.parquet" for y in range(2016, 2027)]
+    assert names == [f"year={y}/data.parquet" for y in range(1995, 2027)]
 
 
 def test_bundle_holds_no_directory_or_special_members(released):
@@ -110,7 +110,7 @@ def test_published_manifest_parses_as_the_runtime_manifest(released):
     payload = json.loads(release.manifest_path.read_text())
     manifest = SnapshotManifest(**payload)
     assert manifest.snapshot_version == release.version
-    assert manifest.parquet_files == 11
+    assert manifest.parquet_files == 32
     assert manifest.layout == "year"
 
 

--- a/tools/ppd_snapshot/boot_only_verify.py
+++ b/tools/ppd_snapshot/boot_only_verify.py
@@ -54,7 +54,7 @@ from typing import Any, Iterator, Optional, Sequence
 #: account"). A cold run must download exactly this many bytes; anything
 #: else means the bundle changed or the run was not genuinely cold. Not
 #: overridable from the CLI -- see `_is_cold_run_valid` and `main`.
-EXPECTED_BUNDLE_BYTES = 279_109_872
+EXPECTED_BUNDLE_BYTES = 1_189_365_783
 
 
 class VerificationRefused(RuntimeError):

--- a/tools/ppd_snapshot/build.py
+++ b/tools/ppd_snapshot/build.py
@@ -34,9 +34,18 @@ from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 
-#: Section 1.1. Not a tunable: ten partitions cannot serve a 120-month request
-#: made in December, and twelve buys coverage nothing asks for.
-PARTITION_YEARS = 11
+#: Full PPD history: 1995 to the current release year. Was 11, sized to the
+#: `months le=120` API ceiling on the reasoning that twelve "buys coverage
+#: nothing asks for". That reasoning held only while every surface was bounded.
+#: The subject-property history lookup is NOT bounded -- it asks for a single
+#: property's whole sale record -- which is why it was hardwired to the live
+#: source and stayed broken when that source degraded. Covering the full history
+#: is what lets it route to the snapshot like everything else.
+#:
+#: Derived, not a magic number: 2026 - 32 + 1 == 1995, the first year of PPD.
+#: It therefore needs incrementing when the release year rolls over, and
+#: `test_coverage_starts_at_the_first_year_of_ppd` pins that.
+PARTITION_YEARS = 32
 
 #: Section 1.3. HMLR revises recent months after first publication, so the tail
 #: of the window is declared provisional in the manifest.


### PR DESCRIPTION
## Why

The snapshot held 11 years, sized to the largest *bounded* request (`months le=120`).
That reasoning was correct for every bounded surface — and one is not bounded.
Subject-property history asks for a single property's whole sale record with no
date bound, which is why it was hardwired to live SPARQL, and that exception
became the system's last hard dependency on a source now returning **503 after
271.8 s**.

Full history removes the exception rather than working around it.

## The build

```
31,525,946 rows into 32 partitions   1995-01-01 → 2026-07-31
all 10 gates [ok]  partitions schema required_values rows reconciliation
                   uniqueness coverage guarantee provisional ordering
bundle 1,189,365,783 B    boot check: READY (validated through the adapter)
```

- **Reconciliation passed** — 31,525,946 written = 31,525,946 eligible counted
  *in the source*. Nothing lost.
- **Deterministic** — two builds, identical bundle sha256 `d0897c94…e874e`.
- **Offline verification** — all 31,525,946 rows checked for mis-derived
  geography, 32/32 partitions present. One benign finding: a single row whose
  source postcode is the literal string `UNKNOWN`.
- Source is the **2026-08-28** HMLR release (newer than the one behind the
  current artifact), so `coverage_to` is 2026-07-31 and freshness improves from
  66 days to ~35.

## One constant, and careful tests

`PARTITION_YEARS = 11 → 32` is the entire coverage change — everything
downstream reads coverage from the manifest or derives it.

The tests needed more than renumbering. Several used **2011 and 2015 dates as
their "outside the window" fixtures**; under a 1995 window those fall *inside*,
so the tests would have kept passing while testing nothing. Moved to 1994.

The **guarantee gate** needed real thought: it fires when the window can't reach
back 120 months, which at 32 years is trivially satisfied, so the old failing
case now passed and tested nothing. Re-bracketed around the actual boundary
(1995-01-01 + 3600 days = 2004-11-13): 2004-01-01 fails, 2005-01-01 passes.

## Limits raised, and the docs that had to move with them

The first build was **refused at the boot check** — `BundleVerificationError:
1189365783 bytes, above the 1073741824-byte maximum` — and not promoted. That's
the fail-closed design working: it built, validated and packaged, then declined
to publish an artifact every Machine would reject at boot.

| Constant | Was | Now |
|---|---|---|
| `DEFAULT_MAX_BUNDLE_BYTES` | 1 GiB | **2 GiB** (~1.8× over the real bundle) |
| `ExtractionLimits.max_total_bytes` | 2 GiB | **4 GiB** |
| `EXPECTED_BUNDLE_BYTES` | 279,109,872 | **1,189,365,783** |

`max_total_bytes` is deliberately kept **above** what the fetch ceiling admits —
a compressed bundle at the cap unpacks to more than the cap, and equal values
would admit an archive extraction then refused, discovered *after* the whole
transfer.

**The documentation was not optional.** Three tests read the specification and
fail when code and doc disagree. Every derived figure is republished in the
section that relies on it: bundle 266.2 → 1134.3 MiB, transfer 22.3 → 95.1 s,
preflight 665.4 → 2835.7 MiB, margin 3.8× → 1.8×.

§1.1 is **rewritten rather than renumbered**, because it argued *for* eleven
partitions and that argument no longer holds. It also records a consequence
rather than burying it: **95.1 s does not fit the 30 s readiness target and no
longer needs to** — since rev 9 the boot is non-blocking, so the transfer bounds
when the snapshot *starts answering*, not readiness (9.89 s, unchanged).

The Group B honesty guards are **generalised, not re-pointed**: they policed one
superseded figure, there are now two and a third arrives next rebuild, so it's a
list — and the sizing-table guards assert the general property (every row
declares measured-or-estimated; every non-current row says superseded in the row
itself).

## Deploy ordering — important

**The image carrying the raised `MAX_BUNDLE_BYTES` must be deployed BEFORE
`current.json` flips to the new artifact.** Otherwise every Machine refuses the
1.1 GiB bundle at boot and falls back to live.

Publishing to Tigris is owner-held by design and not automatable from here.

`./scripts/validate.sh` → **2125 passed, 28 skipped**.