### PR TITLE
chore: point server.json at the canonical product URL

### DIFF
--- a/server.json
+++ b/server.json
@@ -4,7 +4,7 @@
   "title": "UK Property Data",
   "description": "UK property data — Land Registry comps, EPC, Rightmove, rental yields, stamp duty, Companies House",
   "version": "1.18.2",
-  "websiteUrl": "https://bouch.dev/products/property-report",
+  "websiteUrl": "https://bouch.dev/products/property-mcp",
   "repository": {
     "url": "https://github.com/paulieb89/property-shared",
     "source": "github"


### PR DESCRIPTION
One line. Remakes PR #23, which had gone stale.

`websiteUrl` named `/products/property-report`. **That link is not broken** —
verified 2026-09-04:

```
/products/property-report  → http=200, redirects to /products/property-mcp
/products/property-mcp     → http=200
```

So this is canonicalisation, not a repair. Worth doing regardless: `server.json`
is a published registry manifest, and depending on a redirect that someone may
later remove is a link that breaks quietly, somewhere you won't be looking.

#23 branched at version `1.14.2` against a main now at `1.18.2`, so it conflicted
on the version line rather than on anything it was actually changing — cheaper to
redo one line than rebase a week-old branch around an unrelated conflict.

`./scripts/validate.sh` → 2193 passed, 28 skipped.