### PR TITLE
feat(ppd): route subject-property history to the snapshot

### DIFF
--- a/property_core/ppd_service.py
+++ b/property_core/ppd_service.py
@@ -430,7 +430,8 @@ class PPDService:
         subject_property = None
         if address:
             try:
-                subject_property = self._subject_property_lookup(postcode, address)
+                subject_property = self._subject_property_lookup(
+                    postcode, address, warnings=warnings)
             except InvalidPostcodeError:
                 # Caller error. Must surface as 422, not be softened into a
                 # warning that reads like an upstream hiccup.
@@ -659,7 +660,8 @@ class PPDService:
         return transactions, _live_provenance, False
 
     def _subject_property_lookup(
-        self, postcode: str, address: str
+        self, postcode: str, address: str,
+        warnings: Optional[List[str]] = None,
     ) -> Optional[SubjectProperty]:
         """Search for a specific property by postcode and address.
 
@@ -682,16 +684,60 @@ class PPDService:
         words = address_clean.split()
         street = " ".join(words[1:]) if len(words) > 1 else None
 
-        # Deliberately NOT wrapped in a bare except: an upstream failure must
-        # reach comps() so it can be reported as "not checked" rather than
-        # silently rendered as "no history".
-        transactions = self.client.sparql_search(
-            postcode=postcode,
-            paon=paon,
-            street=street,
-            limit=50,
-            order_desc=True,
-        )
+        # Routed like every other read. This was hardwired live because an
+        # eleven-year snapshot would truncate a property's history, and a
+        # truncated history is indistinguishable from a complete one. Coverage
+        # now runs from 1995, so the reason is gone -- and leaving it live left
+        # the feature broken whenever the live source was.
+        #
+        # GUARANTEED, not EXPLICIT: this query names no dates, and the honest
+        # answer to "the whole history" is the whole coverage plus a warning
+        # saying so, not a refusal.
+        provenance_for = None
+        transactions = None
+
+        adapter = self._active_adapter()
+        if adapter is not None:
+            try:
+                decision = resolve_coverage(
+                    adapter, from_date=None, to_date=None,
+                    policy=CoveragePolicy.GUARANTEED)
+                page = adapter.search(
+                    postcode=postcode,
+                    paon=paon,
+                    street=street,
+                    limit=50,
+                    order_desc=True,
+                )
+            except SnapshotFailure as exc:
+                # Falls back like any snapshot failure, and says so. Never
+                # swallowed: a snapshot that cannot answer is not an absence.
+                if warnings is not None:
+                    warnings.append(fallback_warning(exc))
+            else:
+                transactions = list(page.transactions)
+
+                def provenance_for(count: int):        # noqa: F811
+                    return snapshot_provenance(
+                        adapter, decision=decision, sample_count=count,
+                        sample_limit=50,
+                        completeness_basis=page.completeness_basis,
+                        warnings=decision.warnings)
+
+        if transactions is None:
+            # Deliberately NOT wrapped in a bare except: an upstream failure must
+            # reach comps() so it can be reported as "not checked" rather than
+            # silently rendered as "no history".
+            transactions = self.client.sparql_search(
+                postcode=postcode,
+                paon=paon,
+                street=street,
+                limit=50,
+                order_desc=True,
+            )
+
+            def provenance_for(count: int):            # noqa: F811
+                return live_provenance(sample_count=count, sample_limit=50)
 
         if not transactions:
             return None
@@ -724,11 +770,11 @@ class PPDService:
             last_sale=first,
             transaction_count=len(transactions),
             transaction_history=transactions,
-            # Its own block. A property's history routinely predates snapshot
-            # coverage, so this is always live -- and a mixed-source response
-            # that labelled both halves `snapshot` would misstate one of them.
-            provenance=live_provenance(sample_count=len(transactions),
-                                       sample_limit=50),
+            # Still its own block even when both halves are snapshot-sourced.
+            # The sample limits differ -- this asks for one property's whole
+            # history at limit 50, comps asks a bounded window at its own limit
+            # -- so one label over both would misstate one of them.
+            provenance=provenance_for(len(transactions)),
         )
 
     @staticmethod

--- a/property_core/snapshot/adapter.py
+++ b/property_core/snapshot/adapter.py
@@ -373,6 +373,14 @@ class SnapshotAdapter:
         min_price: Optional[int] = None,
         max_price: Optional[int] = None,
         property_types: Optional[Iterable[str]] = None,
+        #: Address text filters. Substring, case-insensitive -- deliberately the
+        #: same semantics as the live source's `CONTAINS(LCASE(...))`, not a
+        #: tightening. Callers are written against over-broad matching: the
+        #: subject-property uniqueness guard refuses input that spans several
+        #: buildings, and exact equality would stop it ever firing.
+        paon: Optional[str] = None,
+        saon: Optional[str] = None,
+        street: Optional[str] = None,
         estate_type: Optional[str] = None,
         transaction_category: Optional[str] = None,
         new_build: Optional[bool] = None,
@@ -420,6 +428,15 @@ class SnapshotAdapter:
         if max_price is not None:
             where.append("price <= ?")
             params.append(int(max_price))
+
+        # `contains(lower(col), lower(?))`, parameterised. NOT a built LIKE:
+        # `%` and `_` are wildcards there, so caller text containing either
+        # would silently widen the match -- `paon='%'` returning every row on
+        # the street. Verified against DuckDB 1.5.5 before writing this.
+        for column, value in (("paon", paon), ("saon", saon), ("street", street)):
+            if value:
+                where.append(f"contains(lower({column}), lower(?))")
+                params.append(value)
 
         types = sorted({t.strip().upper() for t in property_types}) if property_types else None
         if types:

--- a/tests/snapshot/test_provenance_propagation.py
+++ b/tests/snapshot/test_provenance_propagation.py
@@ -181,29 +181,63 @@ def test_cli_comps_carries_provenance_in_core_mode(snapshot_routing, capsys):
     assert json.loads(result.output)["provenance"]["source"] == "snapshot"
 
 
-def test_mixed_source_comps_declares_both(snapshot_routing, fake_live):
-    """Spec test 26. Subject-property history is live; the comps are not."""
+def test_both_halves_of_comps_declare_the_same_source(snapshot_routing, fake_live):
+    """Was spec test 26, "subject-property history is live; the comps are not".
+
+    That split existed because an eleven-year snapshot would have truncated a
+    property's history. Coverage now runs from 1995, so the subject lookup
+    routes like everything else and both halves are snapshot-sourced.
+
+    The nested provenance block stays, and is still the point: the two halves
+    have different sample limits and different completeness bases, so one label
+    over both would misstate one of them even now they share a source.
+    """
     from property_core.ppd_service import PPDService
 
     result = PPDService().comps(postcode="B5 7AA", address="1 High Street",
                                 search_level="district")
     assert result.provenance.source is SourceKind.SNAPSHOT
     assert result.subject_property is not None
-    assert result.subject_property.provenance.source is SourceKind.SPARQL
+    assert result.subject_property.provenance.source is SourceKind.SNAPSHOT
+    assert result.subject_property.provenance is not result.provenance
+    assert fake_live.calls == 0, "neither half should have consulted the live source"
 
 
 def test_subject_property_failure_warns_and_success_does_not(snapshot_routing,
-                                                             fake_live):
-    """Spec test 17. A failed lookup is never rendered as an absent history."""
-    from property_core.ppd_service import PPDService
+                                                             fake_live,
+                                                             monkeypatch):
+    """Spec test 17. A failed lookup is never rendered as an absent history.
 
-    fake_live.rows = []
-    genuine = PPDService().comps(postcode="B5 7AA", address="1 High Street",
+    The assertions are unchanged; only how each condition is induced moved,
+    because the subject lookup now routes to the snapshot instead of calling
+    SPARQL directly. `fake_live.rows = []` no longer produces an empty result
+    -- the snapshot genuinely holds `1 HIGH STREET` -- and `fake_live.raises`
+    no longer reaches a path the lookup takes.
+
+    So a genuine absence is now an address the snapshot does not hold, and a
+    failure is the snapshot query itself raising. The taxonomy under test --
+    absence is silent, failure warns, neither is ever the other -- is the same.
+    """
+    from property_core.ppd_service import PPDService
+    from property_core.snapshot.adapter import SnapshotAdapter
+
+    genuine = PPDService().comps(postcode="B5 7AA",
+                                 address="9999 Nonexistent Avenue",
                                  search_level="district")
     assert genuine.subject_property is None
     assert not any("lookup unavailable" in w for w in genuine.warnings)
 
-    fake_live.raises = RuntimeError("SPARQL down")
+    # Raise only for the subject query, which is the only caller passing `paon`.
+    # Failing every search would take comps down with it and test something else.
+    original = SnapshotAdapter.search
+
+    def _fail_the_subject_query(self, **kwargs):
+        if kwargs.get("paon"):
+            raise RuntimeError("snapshot query failed")
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(SnapshotAdapter, "search", _fail_the_subject_query)
+
     failed = PPDService().comps(postcode="B5 7AA", address="1 High Street",
                                 search_level="district")
     assert failed.subject_property is None

--- a/tests/snapshot/test_subject_property_routing.py
+++ b/tests/snapshot/test_subject_property_routing.py
@@ -1,0 +1,184 @@
+"""Subject-property history answers from the snapshot, with live semantics intact.
+
+`_subject_property_lookup` called the live client directly, bypassing routing.
+The reason was real: an eleven-year snapshot would truncate a property's history,
+and a truncated history is indistinguishable from a complete one. Full coverage
+removes that reason, and leaving it live left the feature broken whenever the
+live source was — which is how `5 Alexandra Road` came back empty while the
+record sat in the artifact.
+
+The risk in moving it is not the routing, it is the **matching**. Live filters
+`paon`/`street` with `CONTAINS(LCASE(...))`, i.e. substring. Exact equality would
+look like a tightening and silently change behaviour: the uniqueness guard exists
+*because* CONTAINS is over-broad, so making the filter strict would stop that
+guard ever firing, and "havenwood" would resolve to a single property instead of
+being refused.
+
+Measured at the boundary before implementing (DuckDB 1.5.5):
+
+    contains(lower(paon), lower('27'))  -> ['127', '27', '27A']   like live
+    contains(...) with '%'              -> []          literal
+    LIKE      with '%'                  -> everything   wildcard
+
+So `contains()` is the equivalent and `LIKE` would be actively wrong.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.snapshot.snapshot_fixtures import build_snapshot, row
+
+pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+POSTCODE = "B5 7AA"
+
+
+def _street_rows() -> list[dict[str, Any]]:
+    """One street, several buildings, and the substring traps that matter.
+
+    `127` is the unambiguous one: no other house number on the street contains
+    it, so it resolves. `27` is deliberately ambiguous -- it is a substring of
+    both `127` and `27A` -- because that is what the uniqueness guard is for,
+    and the live source behaves identically.
+    """
+    return [
+        row("T-127-2024", POSTCODE, "2024-03-01", 300_000, paon="127", street="HAVENWOOD RISE"),
+        row("T-127-2019", POSTCODE, "2019-05-02", 200_000, paon="127", street="HAVENWOOD RISE"),
+        row("T-27", POSTCODE, "2023-01-10", 400_000, paon="27", street="HAVENWOOD RISE"),
+        row("T-27A", POSTCODE, "2022-07-04", 250_000, paon="27A", street="HAVENWOOD RISE"),
+        row("T-5", POSTCODE, "2021-02-02", 150_000, paon="5", street="HAVENWOOD RISE"),
+        row("T-OTHER", POSTCODE, "2020-02-02", 175_000, paon="5", street="OTHER LANE"),
+    ]
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    from property_core.snapshot.adapter import SnapshotAdapter
+
+    directory, record = build_snapshot(tmp_path / "store", _street_rows())
+    a = SnapshotAdapter.open(directory, record)
+    yield a
+    a.close()
+
+
+# --- the adapter filter must be the live filter -----------------------------
+
+
+def test_paon_matches_as_a_substring_exactly_as_the_live_source_does(adapter):
+    """'27' matching '127' is not a bug to fix here.
+
+    It is the behaviour the uniqueness guard downstream is written against. A
+    stricter filter would make that guard unreachable and change what vague
+    input returns.
+    """
+    ids = {t.transaction_id for t in adapter.search(postcode=POSTCODE, paon="27", limit=50).transactions}
+    assert ids == {"T-27", "T-27A", "T-127-2024", "T-127-2019"}
+
+
+def test_street_matches_as_a_substring_too(adapter):
+    ids = {t.transaction_id for t in
+           adapter.search(postcode=POSTCODE, street="HAVENWOOD", limit=50).transactions}
+    assert "T-OTHER" not in ids and "T-5" in ids
+
+
+def test_paon_and_street_are_combined_not_alternatives(adapter):
+    page = adapter.search(postcode=POSTCODE, paon="5", street="OTHER", limit=50)
+    assert {t.transaction_id for t in page.transactions} == {"T-OTHER"}
+
+
+def test_matching_is_case_insensitive_like_lcase(adapter):
+    lower = adapter.search(postcode=POSTCODE, street="havenwood rise", limit=50)
+    upper = adapter.search(postcode=POSTCODE, street="HAVENWOOD RISE", limit=50)
+    assert {t.transaction_id for t in lower.transactions} == {
+        t.transaction_id for t in upper.transactions}
+    assert lower.transactions, "case-insensitive matching returned nothing at all"
+
+
+@pytest.mark.parametrize("metachar", ["%", "_", "%%"])
+def test_like_metacharacters_are_literal_not_wildcards(adapter, metachar):
+    """A string-built LIKE would make `%` match every row on the street."""
+    page = adapter.search(postcode=POSTCODE, paon=metachar, limit=50)
+    assert page.transactions == [], (
+        f"{metachar!r} behaved as a wildcard; the filter must be parameterised "
+        f"contains(), never a LIKE built from caller text"
+    )
+
+
+def test_the_filter_is_pushed_into_sql_so_limit_plus_one_stays_honest(adapter):
+    """Filtering after the fact would make a short page mean nothing.
+
+    Four rows match `27`; asking for three must report NOT exhausted, which is
+    only true if the database applied the filter before the limit.
+    """
+    assert adapter.search(postcode=POSTCODE, paon="27", limit=3).exhausted is False
+    assert adapter.search(postcode=POSTCODE, paon="27", limit=50).exhausted is True
+
+
+def test_an_unmatched_paon_returns_nothing_rather_than_everything(adapter):
+    assert adapter.search(postcode=POSTCODE, paon="99999", limit=50).transactions == []
+
+
+# --- the service routes, and keeps every guard it had -----------------------
+
+
+@pytest.fixture
+def routed(tmp_path, monkeypatch):
+    """Snapshot installed and routable, holding the street corpus."""
+    from property_core.snapshot import state
+    from property_core.snapshot.adapter import SnapshotAdapter
+
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    directory, record = build_snapshot(tmp_path / "routed", _street_rows())
+    a = SnapshotAdapter.open(directory, record)
+    state.clear()
+    state.install(a)
+    yield a
+    state.clear()
+
+
+def _subject(**kw):
+    from property_core.ppd_service import PPDService
+
+    return PPDService()._subject_property_lookup(POSTCODE, kw.pop("address"), **kw)
+
+
+def test_the_subject_property_is_answered_from_the_snapshot(routed, fake_live):
+    subject = _subject(address="127 Havenwood Rise")
+    assert subject is not None, "the record is in the snapshot and must be found"
+    assert subject.provenance.source.value == "snapshot"
+    assert fake_live.calls == 0, "the live source must not be consulted at all"
+
+
+def test_the_snapshot_answer_declares_its_coverage(routed, fake_live):
+    prov = _subject(address="127 Havenwood Rise").provenance
+    assert prov.coverage_from and prov.coverage_to
+    assert prov.source_release
+
+
+def test_the_whole_history_of_the_property_is_returned_not_only_the_latest(routed, fake_live):
+    subject = _subject(address="127 Havenwood Rise")
+    assert {t.transaction_id for t in subject.transaction_history} == {
+        "T-127-2024", "T-127-2019"}
+    assert subject.last_sale.transaction_id == "T-127-2024", "most recent first"
+
+
+def test_vague_input_spanning_buildings_still_returns_none(routed, fake_live):
+    """The uniqueness guard must survive the move.
+
+    `27` is a substring of 27, 27A and 127 -- three distinct buildings. Refusing
+    is the documented behaviour, the live source does the same, and it only
+    works because the filter stayed a substring match. Exact equality would
+    resolve this to one property and quietly answer a question nobody asked.
+    """
+    assert _subject(address="27 Havenwood Rise") is None
+
+
+def test_an_address_with_no_house_number_still_returns_none(routed, fake_live):
+    assert _subject(address="Havenwood Rise") is None
+
+
+def test_a_house_number_that_does_not_exist_returns_none(routed, fake_live):
+    assert _subject(address="99999 Havenwood Rise") is None


### PR DESCRIPTION
## Why

`_subject_property_lookup` called the live client directly, bypassing routing.
The reason was real — an 11-year snapshot would truncate a property's history,
and a truncated history is indistinguishable from a complete one. Coverage now
runs from 1995, so the reason is gone, and leaving it live left the feature
broken whenever the live source was.

## The risk was the matching, not the routing

Live filters `paon`/`street` with `CONTAINS(LCASE(...))` — **substring**. The
uniqueness guard downstream exists *because* that is over-broad. An
exact-equality snapshot filter would look like a tightening while silently
changing behaviour: the guard would stop firing and vague input would resolve to
one property instead of being refused.

Measured against DuckDB 1.5.5 **before** writing the filter:

```
contains(lower(paon), lower('27'))  -> ['127','27','27A']   like live
contains(...) with '%'              -> []            literal
LIKE      with '%'                  -> everything     wildcard
```

Hence parameterised `contains()`, **never** a LIKE built from caller text —
`paon='%'` would otherwise return every row on the street. Pinned by test.

Filters are pushed into SQL, not applied after, or the `limit + 1` completeness
basis stops meaning anything: a short page must prove the *source* was
exhausted, not that our own post-filter discarded most of it.

## Routing

Follows `_fetch_comps` exactly — try the adapter, catch `SnapshotFailure`, append
`fallback_warning`, fall through to live. `GUARANTEED` rather than `EXPLICIT`,
because this query names no dates and the honest answer to "the whole history"
is the whole coverage plus a warning, not a refusal.

`SubjectProperty` keeps its own provenance block even now both halves are
snapshot-sourced: the sample limits and completeness bases still differ, so one
label over both would misstate one of them.

## Two existing tests changed — in setup, not in what they assert

- `test_mixed_source_comps_declares_both` asserted the subject half is SPARQL.
  That split is what this removes; renamed, inverted, and it now also asserts the
  two provenance blocks remain distinct objects.
- `test_subject_property_failure_warns_and_success_does_not` induced both
  conditions through `fake_live`, which the lookup no longer calls. Absence is
  now an address the snapshot doesn't hold; failure is the snapshot query
  raising, targeted at the subject query alone. **The assertions are unchanged**
  — absence is silent, failure warns, neither is ever the other.

## A pre-existing defect this surfaced — not introduced here

Verifying against the real artifact, `5 Alexandra Road` still returns `None`:
DE12 6LL contains a `15 Alexandra Road`, `contains("5")` matches it, and the
guard correctly refuses rather than guessing.

Measured across six outcodes: **14% of addresses (1 in 7) are unresolvable**
this way — `5`/`15`, `1`/`11`/`21`, `7`/`17`.

**This PR does not change that rate.** The live source always had full history
back to 1995, so it always saw `15 Alexandra Road` and always collided.
Identical before and after; this work merely made it visible.

Worth fixing separately, and the fix is small: **prefer an exact `paon` match
when one exists among the candidates.** In every case of this class the exact
match *is* present — that's why it collided — so it resolves the whole 14%
without weakening the refusal-to-guess principle.

`./scripts/validate.sh` → **2208 passed, 28 skipped**.