### PR TITLE
fix(ppd): an exact house number is not ambiguous, and a partial one is not a match

### DIFF
--- a/property_core/ppd_service.py
+++ b/property_core/ppd_service.py
@@ -742,9 +742,33 @@ class PPDService:
         if not transactions:
             return None
 
+        # Both sources match `paon` by SUBSTRING, so asking for "5" also returns
+        # 15, 25 and 5A. Two separate problems follow, and the uniqueness check
+        # alone solves neither:
+        #
+        #   * "5" was REFUSED because 15 came back with it -- though 5 is exactly
+        #     one of the candidates and exactly what was asked for. Measured
+        #     across six outcodes of the real artifact, this made 14% of
+        #     addresses, 1 in 7, unresolvable.
+        #   * "2" was ANSWERED WITH 25, because 25 was the only partial match
+        #     and a single candidate passes a uniqueness check unchallenged.
+        #     That is another property's sale history presented as yours, which
+        #     is the failure this module exists to prevent.
+        #
+        # Narrowing to an exact `paon` first fixes both. It is not a relaxation:
+        # nothing is selected that was not already returned, and the uniqueness
+        # check still runs afterwards on what survives.
+        wanted = self._normalise_paon(paon)
+        exact = [t for t in transactions if self._normalise_paon(t.paon) == wanted]
+        if not exact:
+            # Every candidate merely CONTAINS the requested number. None of them
+            # is the property that was asked for.
+            return None
+        transactions = exact
+
         # Uniqueness check: all matched transactions must represent the same
-        # building. If CONTAINS matching returned multiple distinct houses,
-        # the input was ambiguous and we should not guess.
+        # building. An exact house number is not identity on its own -- the same
+        # number exists on other streets -- so this still has to hold.
         identities = {(t.paon, t.street) for t in transactions}
         if len(identities) != 1:
             return None
@@ -776,6 +800,17 @@ class PPDService:
             # -- so one label over both would misstate one of them.
             provenance=provenance_for(len(transactions)),
         )
+
+    @staticmethod
+    def _normalise_paon(value: Optional[str]) -> str:
+        """Compare house numbers on case and spacing only.
+
+        Deliberately no more than that: "5" and "5A" are different properties,
+        and anything that equated them would be inventing identity rather than
+        comparing it.
+        """
+        return " ".join((value or "").upper().split())
+
 
     @staticmethod
     def _parse_paon(address: str) -> Optional[str]:

--- a/tests/snapshot/test_subject_property_exact_match.py
+++ b/tests/snapshot/test_subject_property_exact_match.py
@@ -1,0 +1,127 @@
+"""An exact house-number match is not ambiguous, and must not be refused.
+
+`paon`/`street` are matched by substring on both sources, so asking for
+"5 Alexandra Road" also returns 15 Alexandra Road. The uniqueness guard then saw
+two buildings and refused — correctly, given what it was shown, but the question
+was never actually ambiguous: `5` is *exactly* one of the candidates, and it is
+the one that was asked for.
+
+Measured across six outcodes of the real artifact: **14% of addresses (1 in 7)**
+were unresolvable this way — 5/15, 1/11/21, 7/17. In every case of that class the
+exact match is present, because its presence is *why* the collision happened.
+
+This does not weaken the refusal to guess. It narrows to the exact match first
+and applies the same guard afterwards, so genuine ambiguity — asking for "5"
+where the street holds only 15 and 25 — still refuses.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.snapshot.snapshot_fixtures import build_snapshot, row
+
+pytest.importorskip("duckdb", reason="needs the optional 'snapshot' extra")
+
+POSTCODE = "B5 7AA"
+STREET = "ALEXANDRA ROAD"
+
+
+def _rows() -> list[dict[str, Any]]:
+    return [
+        row("T-5-2024", POSTCODE, "2024-03-01", 225_000, paon="5", street=STREET),
+        row("T-5-2008", POSTCODE, "2008-04-30", 120_000, paon="5", street=STREET),
+        row("T-15", POSTCODE, "2001-11-30", 90_000, paon="15", street=STREET),
+        row("T-25", POSTCODE, "2003-01-01", 95_000, paon="25", street=STREET),
+        row("T-5A", POSTCODE, "2019-06-01", 180_000, paon="5A", street=STREET),
+        row("T-OTHER-5", POSTCODE, "2015-01-01", 200_000, paon="5", street="BEECH LANE"),
+    ]
+
+
+@pytest.fixture
+def routed(tmp_path, monkeypatch):
+    from property_core.snapshot import state
+    from property_core.snapshot.adapter import SnapshotAdapter
+
+    monkeypatch.setenv("PPD_SNAPSHOT_ENABLED", "1")
+    directory, record = build_snapshot(tmp_path / "s", _rows())
+    a = SnapshotAdapter.open(directory, record)
+    state.clear()
+    state.install(a)
+    yield a
+    state.clear()
+
+
+def _subject(address: str, postcode: str = POSTCODE):
+    from property_core.ppd_service import PPDService
+
+    return PPDService()._subject_property_lookup(postcode, address)
+
+
+# --- the 14% case ------------------------------------------------------------
+
+
+def test_an_exact_house_number_resolves_despite_a_longer_neighbour(routed, fake_live):
+    """`5` collides with `15`, `25` and `5A`, and is still exactly one of them."""
+    subject = _subject("5 Alexandra Road")
+    assert subject is not None, "the exact match was present and was refused"
+    assert {t.transaction_id for t in subject.transaction_history} == {
+        "T-5-2024", "T-5-2008"}
+    assert subject.last_sale.transaction_id == "T-5-2024"
+
+
+def test_the_neighbours_history_is_not_attached(routed, fake_live):
+    """The failure that matters: 15's sale price presented as 5's."""
+    history = {t.transaction_id for t in _subject("5 Alexandra Road").transaction_history}
+    assert not history & {"T-15", "T-25", "T-5A", "T-OTHER-5"}
+
+
+def test_the_suffixed_number_is_a_different_property(routed, fake_live):
+    subject = _subject("5A Alexandra Road")
+    assert subject is not None
+    assert {t.transaction_id for t in subject.transaction_history} == {"T-5A"}
+
+
+def test_a_longer_number_still_resolves_to_itself(routed, fake_live):
+    assert {t.transaction_id for t in _subject("15 Alexandra Road").transaction_history} == {
+        "T-15"}
+
+
+def test_the_street_still_discriminates(routed, fake_live):
+    """Exact `paon` alone is not identity: 5 exists on two streets here."""
+    subject = _subject("5 Beech Lane")
+    assert subject is not None
+    assert {t.transaction_id for t in subject.transaction_history} == {"T-OTHER-5"}
+
+
+# --- and genuine ambiguity still refuses --------------------------------------
+
+
+def test_no_exact_match_among_partial_ones_still_refuses(routed, fake_live):
+    """Asking for `2` where the street holds none: 25 is not what was asked for."""
+    assert _subject("2 Alexandra Road") is None
+
+
+def test_a_number_that_exists_nowhere_still_returns_none(routed, fake_live):
+    assert _subject("9999 Alexandra Road") is None
+
+
+def test_an_address_with_no_house_number_still_returns_none(routed, fake_live):
+    assert _subject("Alexandra Road") is None
+
+
+def test_an_exact_number_on_a_street_that_does_not_match_returns_none(routed, fake_live):
+    assert _subject("5 Nonexistent Way") is None
+
+
+# --- the narrowing must not become a silent guess -----------------------------
+
+
+def test_matching_is_case_and_space_insensitive_like_the_filter(routed, fake_live):
+    for spelling in ("5 alexandra road", "5  ALEXANDRA  ROAD", " 5 Alexandra Road "):
+        subject = _subject(spelling)
+        assert subject is not None, f"{spelling!r} did not resolve"
+        assert {t.transaction_id for t in subject.transaction_history} == {
+            "T-5-2024", "T-5-2008"}

--- a/tests/snapshot/test_subject_property_routing.py
+++ b/tests/snapshot/test_subject_property_routing.py
@@ -165,15 +165,36 @@ def test_the_whole_history_of_the_property_is_returned_not_only_the_latest(route
     assert subject.last_sale.transaction_id == "T-127-2024", "most recent first"
 
 
-def test_vague_input_spanning_buildings_still_returns_none(routed, fake_live):
-    """The uniqueness guard must survive the move.
+def test_an_exact_house_number_resolves_despite_longer_neighbours(routed, fake_live):
+    """`27` collides with 27A and 127 and is still exactly one of them.
 
-    `27` is a substring of 27, 27A and 127 -- three distinct buildings. Refusing
-    is the documented behaviour, the live source does the same, and it only
-    works because the filter stayed a substring match. Exact equality would
-    resolve this to one property and quietly answer a question nobody asked.
+    This asserted `None` when written, matching the behaviour at the time. That
+    refusal was the 14%-of-addresses defect: the request was never ambiguous,
+    because the exact match was among the candidates. Narrowing to it first is
+    what changed; see test_subject_property_exact_match.py.
     """
-    assert _subject(address="27 Havenwood Rise") is None
+    subject = _subject(address="27 Havenwood Rise")
+    assert subject is not None
+    assert {t.transaction_id for t in subject.transaction_history} == {"T-27"}
+
+
+def test_input_with_no_exact_match_still_returns_none(routed, fake_live):
+    """Genuine ambiguity, which is now the narrow case it should always have been.
+
+    `2` is a substring of 27, 27A and 127 and is none of them. Every candidate
+    merely contains the number asked for, so nothing here is the property the
+    caller meant.
+    """
+    assert _subject(address="2 Havenwood Rise") is None
+
+
+def test_an_exact_number_on_two_streets_still_returns_none(routed, fake_live):
+    """An exact house number is not identity on its own.
+
+    `5` exists on HAVENWOOD RISE and on OTHER LANE. With no street to
+    discriminate, the uniqueness check still refuses.
+    """
+    assert _subject(address="5") is None
 
 
 def test_an_address_with_no_house_number_still_returns_none(routed, fake_live):


### PR DESCRIPTION
Both sources match `paon` by **substring**, so "5 Alexandra Road" also returns
15, 25 and 5A. Two faults followed, and the uniqueness check solved neither.

## 1. "5" was refused — 14% of addresses

15 came back with it, the check saw two buildings, returned `None`. But 5 was
*exactly* one of the candidates and exactly what was asked for.

Measured across six outcodes of the real artifact: **14% of addresses, 1 in 7**,
unresolvable this way — 5/15, 1/11/21, 7/17. In every case of that class the
exact match is present, because its presence is *why* the collision happened.

## 2. "2" was answered with 25 — a silent wrong answer

25 was the only partial match, and **a single candidate passes a uniqueness
check unchallenged**. That is another property's sale history returned as yours,
its price feeding `subject_price_percentile` and `subject_vs_median_pct`.

Found by a test written for fault 1. It had been reachable the whole time, on
both paths.

## The fix

Narrow to an exact `paon` **before** the uniqueness check. Not a relaxation:
nothing is selected that the query did not already return, and the check still
runs afterwards on what survives. Where nothing matches exactly, every candidate
merely *contains* the number asked for, so none is the property meant — `None`
is right.

`_normalise_paon` compares case and spacing only. Deliberately no more: "5" and
"5A" are different properties, and equating them would invent identity rather
than compare it.

## Verified against the real artifact

```
5 Alexandra Road   -> 3 sales, latest 2026-01-23 £225,000   (was None)
9 Alexandra Road   -> 2 sales, latest 2022-12-05 £330,000   (was None)
27 Havenwood Rise  -> 1 sale                                (was None)
"Alexandra Road"   -> None        9999 Nowhere Street -> None
```

The 2026 sale matches the live answer retained on 2026-08-31. The **2008 and
2004 sales are history the eleven-year artifact could not have held** — the
rebuild paying off.

## Tests

One test from #69 asserted the old refusal for "27 Havenwood Rise"; updated,
with its docstring recording that the assertion described the defect rather than
the intent. Two tests replace it for what is *genuinely* ambiguous: no exact
match among partial ones, and an exact number on two streets with no street to
discriminate.

Changes both paths identically — narrowing happens after the fetch, so live and
snapshot behave the same, which keeps the fallback honest.

`./scripts/validate.sh` → **2220 passed, 28 skipped**.