### PR TITLE
fix(epc): certificates were unfetchable on three upstream shape variants

### DIFF
--- a/property_core/epc/codebook.py
+++ b/property_core/epc/codebook.py
@@ -1,6 +1,9 @@
 """Cached codebook for the coded integers the certificate returns.
 
-The upstream returns `built_form: 4`, not "Mid-Terrace". Resolution goes through
+The upstream returns `built_form: 4`, not "Mid-Terrace". Keys are STRINGS: the
+tables carry `ND` ("unknown") and `NR` ("Not Recorded") beside the numeric keys,
+and certificates do return them. Coercing keys with int() silently dropped both
+from every table, so they could never resolve. Resolution goes through
 /api/codes/info, which — verified by probe — returns a whole table when given
 (code, schemaVersion) without a key. So the cache unit is a table, not a key.
 
@@ -30,6 +33,10 @@ SUPPORTED_CODES = ("built_form", "property_type", "tenure")
 
 _BREAKER_THRESHOLD = 3
 
+# warm() resolves a throwaway key purely to force the table load. Any key does;
+# it is in the string key space so the signature stays honest.
+_WARM_KEY = "0"
+
 
 class EPCCodebook:
     """Table-per-(code, schemaVersion) cache with a failure breaker."""
@@ -47,7 +54,7 @@ class EPCCodebook:
         # One budget for the whole warm, not per table: three sequential
         # per-request timeouts would exceed the 30s MCP tool timeout on their own.
         self._warm_budget = warm_budget
-        self._tables: dict[tuple[str, str | None], dict[int, str]] = {}
+        self._tables: dict[tuple[str, str | None], dict[str, str]] = {}
         # Single-flight: concurrent callers awaiting the same (code,
         # schemaVersion) share one in-flight fetch instead of each issuing a
         # request. Without this, four concurrent cold certificates produced
@@ -66,7 +73,7 @@ class EPCCodebook:
             h["Authorization"] = f"Bearer {self._token}"
         return h
 
-    async def _fetch_table(self, code: str, schema_version: Optional[str]) -> dict[int, str]:
+    async def _fetch_table(self, code: str, schema_version: Optional[str]) -> dict[str, str]:
         params = {"code": code}
         if schema_version:
             params["schemaVersion"] = schema_version  # verbatim — proven 11/11
@@ -76,19 +83,19 @@ class EPCCodebook:
             raise RuntimeError(f"codebook HTTP {resp.status_code}")
         body = resp.json()
         entries = body.get("data") if isinstance(body, dict) else body
-        table: dict[int, str] = {}
+        table: dict[str, str] = {}
         for entry in entries or []:
             key = entry.get("key")
             values = entry.get("values") or []
             if key is None or not values:
                 continue
-            try:
-                table[int(key)] = values[0].get("value")
-            except (TypeError, ValueError):
+            key = str(key).strip()
+            if not key:
                 continue
+            table[key] = values[0].get("value")
         return table
 
-    async def label(self, code: str, key: Optional[int], schema_version: Optional[str]) -> Optional[str]:
+    async def label(self, code: str, key: Optional[str], schema_version: Optional[str]) -> Optional[str]:
         """Resolve one code to its label, or None. Never raises.
 
         Async because the certificate path is async: a synchronous request here
@@ -181,7 +188,7 @@ class EPCCodebook:
 
         try:
             await asyncio.wait_for(
-                asyncio.gather(*(self.label(c, 0, schema_version) for c in pending)),
+                asyncio.gather(*(self.label(c, _WARM_KEY, schema_version) for c in pending)),
                 timeout=self._warm_budget,
             )
         except asyncio.TimeoutError:
@@ -191,7 +198,7 @@ class EPCCodebook:
             ]
         return []
 
-    def label_sync(self, code: str, key: Optional[int], schema_version: Optional[str]) -> Optional[str]:
+    def label_sync(self, code: str, key: Optional[str], schema_version: Optional[str]) -> Optional[str]:
         """Cache-only lookup for synchronous callers. Never issues a request."""
         if key is None or code not in SUPPORTED_CODES:
             return None

--- a/property_core/epc/compat.py
+++ b/property_core/epc/compat.py
@@ -33,6 +33,17 @@ _NO_DEMONSTRATED_SOURCE = (
 )
 
 
+def _quantity(value) -> Optional[float]:
+    """Legacy scalar for a measured amount. No unit conversion is attempted.
+
+    Every observed unit is "tonnes per year", which is what the legacy field
+    already carried, so the scalar transfers unchanged. A future differing unit
+    would need converting rather than passing through — hence the unit is kept
+    on the source model instead of being discarded here.
+    """
+    return None if value is None else float(value.value)
+
+
 def _money(value, field: str, warnings: list[str], inferred: list[str]) -> Optional[int]:
     """Legacy scalar, when the currency is the expected one or was never stated.
 
@@ -99,7 +110,7 @@ def to_epcdata(
             "placeholder would be indistinguishable from real data"
         )
 
-    def label(code: str, key: Optional[int]) -> Optional[str]:
+    def label(code: str, key: Optional[str]) -> Optional[str]:
         if key is None:
             return None
         resolved = codebook.label_sync(code, key, doc.schema_type) if codebook else None
@@ -135,8 +146,10 @@ def to_epcdata(
         hot_water_cost_potential=_money(doc.hot_water_cost_potential, "hot_water_cost_potential", warnings, inferred_currency),
         lighting_cost_current=_money(doc.lighting_cost_current, "lighting_cost_current", warnings, inferred_currency),
         lighting_cost_potential=_money(doc.lighting_cost_potential, "lighting_cost_potential", warnings, inferred_currency),
-        co2_emissions_current=doc.co2_emissions_current,
-        co2_emissions_potential=doc.co2_emissions_potential,
+        # Legacy field is `float | None`; the unit, when upstream stated one,
+        # stays on the source model rather than being folded into the number.
+        co2_emissions_current=_quantity(doc.co2_emissions_current),
+        co2_emissions_potential=_quantity(doc.co2_emissions_potential),
         inspection_date=doc.inspection_date,
         certificate_hash=doc.certificate_number,
         lmk_key=doc.certificate_number,

--- a/property_core/epc/source_models.py
+++ b/property_core/epc/source_models.py
@@ -27,7 +27,11 @@ from property_core.epc.errors import EPCUpstreamShapeError
 _SEARCH_MARKERS = {"certificateNumber", "addressLine1", "currentEnergyEfficiencyBand", "schemaType"}
 _CERT_MARKERS = {"address_line_1", "current_energy_efficiency_band", "schema_type", "assessment_type"}
 
-# Coded integers resolvable via /api/codes in v1.14.0. Six further coded fields
+# Coded fields resolvable via /api/codes in v1.14.0. The key space is STRING,
+# not integer: alongside the numeric keys the tables carry `ND` ("unknown") and
+# `NR` ("Not Recorded"), and certificates do return them — measured 2026-09-05,
+# 8 of 133 live certificates (6.0%) carried one. Typing these int made every
+# such certificate unfetchable. Six further coded fields
 # (conservatory_type, language_code, measurement_type, multiple_glazing_type,
 # region_code, report_type) have no table upstream at all — see
 # UNRESOLVED_CODE_TABLES.
@@ -36,6 +40,8 @@ UNRESOLVED_CODE_TABLES = (
     "conservatory_type", "language_code", "measurement_type",
     "multiple_glazing_type", "region_code", "report_type",
 )
+
+_QUANTITY_FIELDS = ("co2_emissions_current", "co2_emissions_potential")
 
 _MONEY_FIELDS = (
     "heating_cost_current", "heating_cost_potential",
@@ -124,6 +130,50 @@ class EPCMoney(BaseModel):
         if not currency:
             raise EPCUpstreamShapeError(f"{field}: missing currency")
         return cls(value=value, currency=currency)
+
+
+class EPCQuantity(BaseModel):
+    """A measured amount with an optionally-stated unit.
+
+    Same dual shape as EPCMoney, and for the same reason — which one appears is a
+    property of the SCHEMA, not of the field. Measured 2026-09-05:
+
+        RdSAP 17.x-21.x, SAP 16.x-19.x  ->  a bare number
+        SAP-Schema-13.0                 ->  {"value", "quantity"}
+
+    A bare number states no unit, so `unit` stays None and `unit_stated` is
+    False. The unit is never fabricated: "tonnes per year" is not written in
+    where upstream said nothing, because a stated unit and an assumed one are
+    not the same claim. `"quantity": ""` was observed and is a stated nothing.
+    """
+
+    value: Decimal
+    unit: Optional[str] = None
+
+    @property
+    def unit_stated(self) -> bool:
+        """DERIVED, never stored — see EPCMoney.currency_stated for the reasoning."""
+        return self.unit is not None
+
+    @classmethod
+    def from_source(cls, raw: Any, field: str) -> "EPCQuantity":
+        # bool BEFORE the number check: isinstance(True, int) is True in Python.
+        if isinstance(raw, bool):
+            raise EPCUpstreamShapeError(
+                f"{field}: expected a number or {{value, quantity}}, got bool {raw!r}"
+            )
+        if isinstance(raw, (int, float)):
+            return cls(value=_finite(raw, field), unit=None)
+        if not isinstance(raw, dict) or "value" not in raw:
+            raise EPCUpstreamShapeError(
+                f"{field}: expected a number or {{value, quantity}}, "
+                f"got {type(raw).__name__} {raw!r:.60}"
+            )
+        if isinstance(raw["value"], bool):
+            raise EPCUpstreamShapeError(f"{field}: value is not numeric: {raw['value']!r}")
+        # Unlike currency, an absent or empty unit is NOT an error: it is the
+        # bare-number case wearing an object, and the amount is still usable.
+        return cls(value=_finite(raw["value"], field), unit=_str_or_none(raw.get("quantity")))
 
 
 class EPCPagination(BaseModel):
@@ -312,13 +362,14 @@ class EPCCertificateDoc(BaseModel):
     registration_date: Optional[str] = None
     completion_date: Optional[str] = None
 
-    co2_emissions_current: Optional[float] = None
-    co2_emissions_potential: Optional[float] = None
+    co2_emissions_current: Optional[EPCQuantity] = None
+    co2_emissions_potential: Optional[EPCQuantity] = None
 
-    # Raw codes always preserved; labels resolved separately by the codebook.
-    built_form_code: Optional[int] = None
-    property_type_code: Optional[int] = None
-    tenure_code: Optional[int] = None
+    # Raw codes always preserved verbatim in the upstream key space (string —
+    # `4` and `ND` are both keys); labels resolved separately by the codebook.
+    built_form_code: Optional[str] = None
+    property_type_code: Optional[str] = None
+    tenure_code: Optional[str] = None
 
     # Schema-variant field sampled by tests.
     photovoltaic_supply: Optional[Any] = None
@@ -360,6 +411,8 @@ class EPCCertificateDoc(BaseModel):
             )
 
         money = {f: EPCMoney.from_source(raw[f], f) for f in _MONEY_FIELDS if raw.get(f) is not None}
+        quantities = {f: EPCQuantity.from_source(raw[f], f)
+                      for f in _QUANTITY_FIELDS if raw.get(f) is not None}
 
         known = {
             "certificate_number": certificate_number,
@@ -379,12 +432,13 @@ class EPCCertificateDoc(BaseModel):
             "inspection_date": _str_or_none(raw.get("inspection_date")),
             "registration_date": _str_or_none(raw.get("registration_date")),
             "completion_date": _str_or_none(raw.get("completion_date")),
-            "co2_emissions_current": raw.get("co2_emissions_current"),
-            "co2_emissions_potential": raw.get("co2_emissions_potential"),
-            "built_form_code": raw.get("built_form"),
-            "property_type_code": raw.get("property_type"),
-            "tenure_code": raw.get("tenure"),
+            # _str_or_none, not str(): keeps an absent code distinct from the
+            # stated-unknown code `ND`, which is a real key with a real label.
+            "built_form_code": _str_or_none(raw.get("built_form")),
+            "property_type_code": _str_or_none(raw.get("property_type")),
+            "tenure_code": _str_or_none(raw.get("tenure")),
             "photovoltaic_supply": raw.get("photovoltaic_supply"),
+            **quantities,
             **money,
         }
 

--- a/tests/test_epc_call_budgets.py
+++ b/tests/test_epc_call_budgets.py
@@ -123,7 +123,7 @@ class TestCodebookBudget:
         t = CountingTransport()
         book = EPCCodebook(transport=t)
         for _ in range(10):
-            _run(book.label("built_form", 4, "RdSAP-Schema-20.0.0"))
+            _run(book.label("built_form", "4", "RdSAP-Schema-20.0.0"))
         assert t.counts["codebook"] == 1, "one table fetch per (code, schemaVersion)"
 
     def test_schema_version_is_sent_verbatim(self):
@@ -135,7 +135,7 @@ class TestCodebookBudget:
             return httpx.Response(200, json={"data": []})
 
         book = EPCCodebook(transport=httpx.MockTransport(handler))
-        _run(book.label("built_form", 4, "RdSAP-Schema-20.0.0"))
+        _run(book.label("built_form", "4", "RdSAP-Schema-20.0.0"))
         assert seen[0].get("schemaVersion") == "RdSAP-Schema-20.0.0"
 
     def test_codebook_outage_is_circuit_broken_not_retried_per_certificate(self):

--- a/tests/test_epc_co2_quantity_shape.py
+++ b/tests/test_epc_co2_quantity_shape.py
@@ -1,0 +1,116 @@
+"""CO2 emissions carry the same dual shape the cost fields already model.
+
+`co2_emissions_current` / `_potential` were typed `Optional[float]`. Observed at
+the live boundary on 2026-09-05, SAP-Schema-13.0 certificates return an object
+instead:
+
+    RdSAP 17.x-21.x, SAP 16.x-19.x   3.4
+    SAP-Schema-13.0                  {"value": 1.8, "quantity": "tonnes per year"}
+
+Six of 133 sampled certificates (4.5%) took the object form, and every one of
+them failed validation outright — the whole certificate was unfetchable, the
+same user-visible failure as the non-numeric code keys in
+test_epc_non_numeric_codes.py, found by the same audit.
+
+This is the shape EPCMoney already documents for the six cost fields ("which one
+appears is a property of the SCHEMA, not of the field"). CO2 is modelled the
+same way, and for the same reason: the unit is reported when upstream states it
+and is never fabricated when it does not. One sampled certificate returned
+`"quantity": ""` — a stated-nothing, which is not a unit.
+
+The legacy `EPCData.co2_emissions_current` stays `float | None`; the projection
+takes the scalar. A caller wanting the unit reads the source model.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from property_core.epc.compat import to_epcdata
+from property_core.epc.errors import EPCUpstreamShapeError
+from property_core.epc.source_models import EPCCertificateDoc, EPCQuantity
+
+from tests.test_epc_source_models import CERT_DOC
+
+TONNES = "tonnes per year"
+
+
+def _doc(**overrides) -> EPCCertificateDoc:
+    return EPCCertificateDoc.from_source(
+        {**CERT_DOC, **overrides}, certificate_number="1111-2222-3333-4444-5555")
+
+
+class TestBothShapesParse:
+    def test_the_object_shape_does_not_fail_validation(self):
+        doc = _doc(co2_emissions_current={"value": 1.8, "quantity": TONNES})
+        assert doc.co2_emissions_current.value == Decimal("1.8")
+        assert doc.co2_emissions_current.unit == TONNES
+
+    def test_the_bare_number_shape_still_parses(self):
+        doc = _doc(co2_emissions_current=3.4)
+        assert doc.co2_emissions_current.value == Decimal("3.4")
+        assert doc.co2_emissions_current.unit is None
+
+    def test_an_integer_is_a_valid_bare_number(self):
+        assert _doc(co2_emissions_current=3).co2_emissions_current.value == Decimal("3")
+
+    def test_an_absent_field_stays_none(self):
+        raw = {k: v for k, v in CERT_DOC.items() if not k.startswith("co2_")}
+        doc = EPCCertificateDoc.from_source(raw, certificate_number="1")
+        assert doc.co2_emissions_current is None and doc.co2_emissions_potential is None
+
+    def test_both_co2_fields_are_modelled(self):
+        doc = _doc(co2_emissions_current={"value": 1.8, "quantity": TONNES},
+                   co2_emissions_potential={"value": 1.6, "quantity": TONNES})
+        assert doc.co2_emissions_potential.value == Decimal("1.6")
+
+
+class TestTheUnitIsNeverFabricated:
+    def test_a_bare_number_states_no_unit(self):
+        assert _doc(co2_emissions_current=3.4).co2_emissions_current.unit_stated is False
+
+    def test_an_empty_quantity_string_is_not_a_unit(self):
+        """One sampled certificate returned `"quantity": ""`."""
+        q = _doc(co2_emissions_current={"value": 4.5, "quantity": ""}).co2_emissions_current
+        assert q.unit is None and q.unit_stated is False
+        assert q.value == Decimal("4.5")
+
+    def test_unit_stated_cannot_contradict_the_unit(self):
+        assert EPCQuantity(value=Decimal("1")).unit_stated is False
+        assert EPCQuantity(value=Decimal("1"), unit=TONNES).unit_stated is True
+
+
+class TestMalformedShapesStayTyped:
+    """A bad payload must raise the EPC taxonomy, never a bare ValidationError."""
+
+    @pytest.mark.parametrize("bad", [
+        {"value": "abc", "quantity": TONNES},
+        {"quantity": TONNES},
+        {"value": float("nan"), "quantity": TONNES},
+        {"value": True, "quantity": TONNES},
+        True,
+        "3.4 tonnes",
+        [1.8],
+    ])
+    def test_malformed_co2_raises_the_epc_shape_error(self, bad):
+        with pytest.raises(EPCUpstreamShapeError):
+            _doc(co2_emissions_current=bad)
+
+
+class TestLegacyProjection:
+    def test_the_legacy_field_stays_a_bare_float(self):
+        d = to_epcdata(_doc(co2_emissions_current={"value": 1.8, "quantity": TONNES}),
+                       codebook=None)
+        assert d.co2_emissions_current == pytest.approx(1.8)
+        assert isinstance(d.co2_emissions_current, float)
+
+    def test_the_bare_number_projection_is_unchanged(self):
+        d = to_epcdata(_doc(co2_emissions_current=3.4), codebook=None)
+        assert d.co2_emissions_current == pytest.approx(3.4)
+
+    def test_an_absent_co2_projects_to_none(self):
+        raw = {k: v for k, v in CERT_DOC.items() if not k.startswith("co2_")}
+        d = to_epcdata(EPCCertificateDoc.from_source(raw, certificate_number="1"), codebook=None)
+        assert d.co2_emissions_current is None

--- a/tests/test_epc_codebook_failures.py
+++ b/tests/test_epc_codebook_failures.py
@@ -44,7 +44,7 @@ class TestOneAttemptIsOneFailure:
 
         async def main():
             return await asyncio.gather(
-                *(book.label("built_form", 4, SCHEMA) for _ in range(4))
+                *(book.label("built_form", "4", SCHEMA) for _ in range(4))
             )
 
         results = _run(main())
@@ -66,7 +66,7 @@ class TestOneAttemptIsOneFailure:
             # Three separate attempts, each awaited to completion so they do
             # not share an in-flight task.
             for code in ("built_form", "property_type", "tenure"):
-                await book.label(code, 1, SCHEMA)
+                await book.label(code, "1", SCHEMA)
 
         _run(main())
         assert len(requests) == 3
@@ -84,9 +84,9 @@ class TestOneAttemptIsOneFailure:
 
         async def main():
             for code in ("built_form", "property_type", "tenure"):
-                await book.label(code, 1, SCHEMA)
+                await book.label(code, "1", SCHEMA)
             before = len(requests)
-            await book.label("built_form", 1, "SAP-Schema-13.0")
+            await book.label("built_form", "1", "SAP-Schema-13.0")
             return before, len(requests)
 
         before, after = _run(main())
@@ -104,10 +104,10 @@ class TestOneAttemptIsOneFailure:
         book = _book(handler)
 
         async def main():
-            await book.label("built_form", 4, SCHEMA)
+            await book.label("built_form", "4", SCHEMA)
             assert book._failures == 1
             state["fail"] = False
-            return await book.label("property_type", 4, SCHEMA)
+            return await book.label("property_type", "4", SCHEMA)
 
         _run(main())
         assert book._failures == 0, "a success must clear the failure count"
@@ -126,14 +126,14 @@ class TestCancellationSafety:
         book = _book(handler)
 
         async def main():
-            impatient = asyncio.create_task(book.label("built_form", 4, SCHEMA))
+            impatient = asyncio.create_task(book.label("built_form", "4", SCHEMA))
             await asyncio.sleep(0.05)
             impatient.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await impatient
             # The shared loader should have survived and populated the cache.
             await asyncio.sleep(0.35)
-            return await book.label("built_form", 4, SCHEMA)
+            return await book.label("built_form", "4", SCHEMA)
 
         assert _run(main()) == "Mid-Terrace"
         assert len(requests) == 1, f"the fetch was re-issued: {len(requests)} requests"
@@ -147,7 +147,7 @@ class TestCancellationSafety:
         book = _book(handler)
 
         async def main():
-            impatient = asyncio.create_task(book.label("built_form", 4, SCHEMA))
+            impatient = asyncio.create_task(book.label("built_form", "4", SCHEMA))
             await asyncio.sleep(0.05)
             impatient.cancel()
             with pytest.raises(asyncio.CancelledError):
@@ -174,7 +174,7 @@ class TestCancellationSafety:
             loop.set_exception_handler(
                 lambda _loop, ctx: seen.append(ctx.get("message", "")))
             try:
-                waiter = asyncio.create_task(book.label("built_form", 4, SCHEMA))
+                waiter = asyncio.create_task(book.label("built_form", "4", SCHEMA))
                 await asyncio.sleep(0.05)
                 waiter.cancel()
                 with pytest.raises(asyncio.CancelledError):
@@ -203,7 +203,7 @@ class TestSharedLoaderStillCaches:
 
         async def main():
             await asyncio.gather(*(
-                book.label(code, 1, SCHEMA)
+                book.label(code, "1", SCHEMA)
                 for code in ("built_form", "property_type", "tenure")
                 for _ in range(4)
             ))

--- a/tests/test_epc_compat_and_selection.py
+++ b/tests/test_epc_compat_and_selection.py
@@ -31,13 +31,13 @@ class _StubCodebook:
         self.available = available
         self.calls: list[tuple] = []
 
-    def label_sync(self, code: str, key: int, schema_version: str | None):
+    def label_sync(self, code: str, key: str, schema_version: str | None):
         self.calls.append((code, key, schema_version))
         if not self.available:
             return None
-        return {("built_form", 4): "Mid-Terrace",
-                ("property_type", 2): "Flat",
-                ("tenure", 3): "rented (private)"}.get((code, key))
+        return {("built_form", "4"): "Mid-Terrace",
+                ("property_type", "2"): "Flat",
+                ("tenure", "3"): "rented (private)"}.get((code, key))
 
 
 class TestLegacyProjection:

--- a/tests/test_epc_non_numeric_codes.py
+++ b/tests/test_epc_non_numeric_codes.py
@@ -1,0 +1,181 @@
+"""The coded fields are keyed by STRING upstream, not by integer.
+
+`built_form`, `property_type` and `tenure` were modelled as `Optional[int]`.
+Observed at the live boundary on 2026-09-05 across 133 certificates drawn from
+twelve postcodes, **8 (6.0%) carry a non-numeric code** and were therefore
+unfetchable — the whole certificate failed pydantic validation:
+
+    tenure     'ND'   3 certificates   SAP-Schema-16.1, SAP-Schema-19.1.0
+    built_form 'NR'   5 certificates   RdSAP-Schema-21.0.1
+
+These are not junk and they are not absences. `/api/codes/info` lists them as
+first-class keys in the same tables as the numeric ones, in every schema
+version checked:
+
+    tenure     ND -> "unknown"       (RdSAP 20.0.0 / 21.0.1, SAP 19.1.0, 16.1)
+    built_form NR -> "Not Recorded"  (RdSAP 20.0.0 / 21.0.1, SAP 16.1)
+
+So the fix is not to discard them. Dropping 'ND' to None would conflate "the
+upstream states the tenure is unknown" with "the upstream said nothing about
+tenure" — the same conflation this package already refuses for pagination
+completeness and for stated-vs-inferred currency — and would throw away a label
+the upstream is willing to supply.
+
+The codebook made the mirror-image mistake: `_fetch_table` did `int(key)` inside
+a try/except that `continue`d, so 'ND' and 'NR' were silently dropped from every
+table. Even had the model accepted them, they could never have resolved.
+
+Both sides now use the upstream key space: string.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import httpx
+import pytest
+
+from property_core.epc.codebook import EPCCodebook
+from property_core.epc.compat import to_epcdata
+from property_core.epc.source_models import EPCCertificateDoc
+
+from tests.test_epc_source_models import CERT_DOC
+
+SCHEMA = "RdSAP-Schema-20.0.0"
+
+# Shape returned by /api/codes/info, including the non-numeric keys.
+TENURE_TABLE = {"data": [
+    {"key": "1", "values": [{"value": "owner-occupied", "schemaVersion": SCHEMA}]},
+    {"key": "2", "values": [{"value": "rented (social)", "schemaVersion": SCHEMA}]},
+    {"key": "3", "values": [{"value": "rented (private)", "schemaVersion": SCHEMA}]},
+    {"key": "ND", "values": [{"value": "unknown", "schemaVersion": SCHEMA}]},
+]}
+BUILT_FORM_TABLE = {"data": [
+    {"key": "4", "values": [{"value": "Mid-Terrace", "schemaVersion": SCHEMA}]},
+    {"key": "NR", "values": [{"value": "Not Recorded", "schemaVersion": SCHEMA}]},
+]}
+
+
+def _doc(**overrides) -> EPCCertificateDoc:
+    return EPCCertificateDoc.from_source(
+        {**CERT_DOC, **overrides}, certificate_number="1111-2222-3333-4444-5555")
+
+
+class TestTheCertificateParsesAtAll:
+    """The reported bug: one non-numeric code made the whole certificate unfetchable."""
+
+    def test_tenure_nd_does_not_fail_validation(self):
+        assert _doc(tenure="ND").tenure_code == "ND"
+
+    def test_built_form_nr_does_not_fail_validation(self):
+        assert _doc(built_form="NR").built_form_code == "NR"
+
+    def test_every_coded_field_tolerates_a_non_numeric_key(self):
+        doc = _doc(built_form="NR", property_type="ND", tenure="ND")
+        assert (doc.built_form_code, doc.property_type_code, doc.tenure_code) == (
+            "NR", "ND", "ND")
+
+
+class TestNumericCodesStillJoinTheCodebook:
+    """Certificates send `4`; the code table sends `"4"`. They must still meet."""
+
+    def test_an_integer_code_is_carried_in_the_upstream_key_space(self):
+        doc = _doc()
+        assert (doc.built_form_code, doc.property_type_code, doc.tenure_code) == (
+            "4", "2", "3")
+
+    def test_a_code_of_zero_is_preserved_and_not_read_as_absent(self):
+        assert _doc(built_form=0).built_form_code == "0"
+
+
+class TestUnknownIsNotAbsent:
+    """'the upstream says unknown' and 'the upstream said nothing' stay distinct."""
+
+    def test_an_absent_code_is_none(self):
+        raw = {k: v for k, v in CERT_DOC.items() if k != "tenure"}
+        assert EPCCertificateDoc.from_source(raw, certificate_number="1").tenure_code is None
+
+    def test_a_stated_unknown_is_not_none(self):
+        assert _doc(tenure="ND").tenure_code is not None
+
+    def test_an_empty_string_is_absence_not_a_code(self):
+        assert _doc(tenure="").tenure_code is None
+
+
+class TestTheCodebookKeepsNonNumericKeys:
+    def _book(self, body):
+        async def handler(request):
+            return httpx.Response(200, json=body)
+        return EPCCodebook(transport=httpx.MockTransport(handler))
+
+    def test_nd_resolves_to_its_label_rather_than_being_skipped(self):
+        book = self._book(TENURE_TABLE)
+        assert asyncio.run(book.label("tenure", "ND", SCHEMA)) == "unknown"
+
+    def test_nr_resolves_to_its_label(self):
+        book = self._book(BUILT_FORM_TABLE)
+        assert asyncio.run(book.label("built_form", "NR", SCHEMA)) == "Not Recorded"
+
+    def test_numeric_keys_are_unaffected(self):
+        book = self._book(TENURE_TABLE)
+        assert asyncio.run(book.label("tenure", "3", SCHEMA)) == "rented (private)"
+
+    def test_a_key_absent_from_the_table_is_still_none(self):
+        book = self._book(TENURE_TABLE)
+        assert asyncio.run(book.label("tenure", "ZZ", SCHEMA)) is None
+
+    def test_a_table_entry_with_no_key_is_still_skipped(self):
+        book = self._book({"data": [{"key": None, "values": [{"value": "x"}]}]})
+        assert asyncio.run(book.label("tenure", "1", SCHEMA)) is None
+
+
+class TestEndToEndLabelling:
+    class _Book:
+        def label_sync(self, code, key, schema_version):
+            return {("tenure", "ND"): "unknown",
+                    ("built_form", "NR"): "Not Recorded",
+                    ("built_form", "4"): "Mid-Terrace",
+                    ("property_type", "2"): "Flat",
+                    ("tenure", "3"): "rented (private)"}.get((code, key))
+
+    def test_unknown_tenure_reaches_the_legacy_field_as_a_label(self):
+        d = to_epcdata(_doc(tenure="ND"), codebook=self._Book())
+        assert d.tenure == "unknown"
+
+    def test_not_recorded_built_form_reaches_the_legacy_field_as_a_label(self):
+        d = to_epcdata(_doc(built_form="NR"), codebook=self._Book())
+        assert d.built_form == "Not Recorded"
+
+    def test_the_ordinary_case_is_unchanged(self):
+        d = to_epcdata(_doc(), codebook=self._Book())
+        assert (d.built_form, d.property_type, d.tenure) == (
+            "Mid-Terrace", "Flat", "rented (private)")
+
+    def test_a_resolved_label_emits_no_unresolved_warning(self):
+        _, warnings = to_epcdata(_doc(tenure="ND"), codebook=self._Book(), return_warnings=True)
+        assert not any("tenure code" in w for w in warnings)
+
+
+@pytest.mark.skipif(os.getenv("RUN_LIVE_TESTS") != "1", reason="Set RUN_LIVE_TESTS=1")
+@pytest.mark.skipif(not os.getenv("EPC_API_TOKEN"), reason="EPC credentials not set")
+class TestAgainstTheLiveCertificatesThatFailed:
+    """The two certificates observed failing on 2026-09-05."""
+
+    @pytest.mark.parametrize("number,field,code", [
+        ("0070-3068-7679-2402-8091", "tenure_code", "ND"),
+        ("9075-3062-2205-6806-4204", "built_form_code", "NR"),
+    ])
+    def test_the_certificate_is_retrievable(self, number, field, code):
+        from property_core.epc_client import EPCClient
+
+        async def go():
+            return await EPCClient().get_certificate_doc(number)
+
+        try:
+            doc = asyncio.run(go())
+        except httpx.HTTPError as exc:
+            pytest.skip(f"EPC API unavailable: {exc}")
+        if doc is None:
+            pytest.skip(f"certificate {number} no longer published")
+        assert getattr(doc, field) == code

--- a/tests/test_epc_source_models.py
+++ b/tests/test_epc_source_models.py
@@ -121,7 +121,8 @@ class TestCertificateAdapter:
 
     def test_raw_codes_preserved_alongside_labels(self):
         doc = EPCCertificateDoc.from_source(CERT_DOC, certificate_number="1")
-        assert doc.built_form_code == 4 and doc.property_type_code == 2 and doc.tenure_code == 3
+        # The upstream key space is string — `4` and `ND` are both keys.
+        assert doc.built_form_code == "4" and doc.property_type_code == "2" and doc.tenure_code == "3"
 
     def test_schema_variant_fields_absent_are_none_not_errors(self):
         """Older schemas legitimately omit fields (72 vs 83 observed)."""


### PR DESCRIPTION
## What the smoke test found, and what was actually there

A claude.ai smoke test reported `EPCCertificateDoc.tenure_code` failing on `'ND'`, and suggested grepping for other int-typed code fields with the same exposure. Doing that found **three** variants, not one — all with the same user-visible effect: the certificate raises `ValidationError` and nothing is returned, on both `epc_certificate` and `property_epc`-with-address.

Measured at the live boundary on 2026-09-05, 133 certificates across twelve postcodes: **14 (10.5%) were unfetchable.**

| Field | Value | Certs | Schemas |
|---|---|---|---|
| `tenure` | `'ND'` | 3 | SAP 16.1, SAP 19.1.0 |
| `built_form` | `'NR'` | 5 | RdSAP 21.0.1 |
| `co2_emissions_current` / `_potential` | `{"value": 1.8, "quantity": "tonnes per year"}` | 6 | SAP 13.0 |

## Why not normalise `'ND'` to None

The report proposed that, reasoning that `'ND'` is an absence rather than a code. The upstream code tables say otherwise — `ND` and `NR` are first-class keys beside the numeric ones, in every schema version checked:

```
tenure     ND -> "unknown"        RdSAP 20.0.0 / 21.0.1, SAP 19.1.0, SAP 16.1
built_form NR -> "Not Recorded"   RdSAP 20.0.0 / 21.0.1, SAP 16.1
```

So the key space is string, and typing it `int` was the error. Dropping to `None` would conflate *"upstream states the tenure is unknown"* with *"upstream said nothing about tenure"* — the same conflation this package already refuses for pagination completeness and for stated-vs-inferred currency — and would throw away a label upstream is willing to supply.

The codebook made the mirror-image mistake: `_fetch_table` coerced keys with `int()` inside a `try/except` that `continue`d, so `ND` and `NR` were silently dropped from every table. Even had the model accepted them, they could never have resolved. Both sides now use the upstream key space.

## CO2 is the shape `EPCMoney` already documents

Bare number in most schemas, `{value, quantity}` in SAP 13.0 — "a property of the SCHEMA, not of the field", exactly as the cost fields. Modelled as `EPCQuantity` with the same discipline: the unit is reported when upstream states it and never fabricated when it does not. One certificate returned `"quantity": ""`, which is a stated nothing.

## Contract

Unchanged. `EPCData` still carries labels as `str` and `co2_emissions_*` as `float`; `*_code` is internal to the epc package (one test referenced it).

## Verification

Against the live API, same 133-certificate sample:

```
before:  127/133 fetched, 6 failed   (+8 more failed on the code fields)
after:   133/133 fetched, 0 failed
```

The two certificates from the report and the survey, end to end:

```
0070-3068-7679-2402-8091  tenure='ND'    -> tenure     = "unknown"
9075-3062-2205-6806-4204  built_form='NR'-> built_form = "Not Recorded"
6234-2126-7300-0853-9222  numeric codes  -> unchanged
```

`./scripts/validate.sh`: **2257 passed, 30 skipped**. Two new test files, plus live-gated tests pinned to the two certificates observed failing.

## Found but not fixed here

`SAP-Schema-13.0` has **no `tenure` table upstream** — `/api/codes/info` returns 404, permanently. That 404 currently counts toward the codebook's outage breaker, and once tripped every label for every schema returns `None` for the rest of the process. In the 133-certificate sweep this left 35 tenure labels unresolved. Pre-existing (confirmed against `main`), a different failure mode from this PR — degraded labels, not an unfetchable certificate — and it needs its own decision: a 404 is a permanent per-table answer, not an outage, so it arguably should be cached as "no such table" rather than counted as a failure.